### PR TITLE
Add client mod management and .mrpack support

### DIFF
--- a/apps/MineOS.Api/Endpoints/ClientPackageEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/ClientPackageEndpoints.cs
@@ -1,5 +1,7 @@
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using MineOS.Api.Middleware;
+using MineOS.Application.Dtos;
 using MineOS.Application.Interfaces;
 
 namespace MineOS.Api.Endpoints;
@@ -19,12 +21,13 @@ public static class ClientPackageEndpoints
 
         servers.MapPost("/{name}/client-packages", async (
             string name,
+            [FromBody] CreateClientPackageRequest? request,
             IClientPackageService clientPackageService,
             CancellationToken cancellationToken) =>
         {
             try
             {
-                var filename = await clientPackageService.CreateClientPackageAsync(name, cancellationToken);
+                var filename = await clientPackageService.CreateClientPackageAsync(name, request, cancellationToken);
                 return Results.Ok(new
                 {
                     filename,
@@ -71,7 +74,10 @@ public static class ClientPackageEndpoints
             try
             {
                 var path = await clientPackageService.GetClientPackagePathAsync(name, filename, cancellationToken);
-                return Results.File(path, "application/zip", filename);
+                var contentType = filename.EndsWith(".mrpack", StringComparison.OrdinalIgnoreCase)
+                    ? "application/x-modrinth-modpack+zip"
+                    : "application/zip";
+                return Results.File(path, contentType, filename);
             }
             catch (FileNotFoundException ex)
             {

--- a/apps/MineOS.Api/Endpoints/CurseForgeEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/CurseForgeEndpoints.cs
@@ -18,6 +18,7 @@ public static class CurseForgeEndpoints
             [FromQuery] string? sort,
             [FromQuery] string? order,
             [FromQuery] long? minDownloads,
+            [FromQuery] string? gameVersion,
             ICurseForgeService curseForgeService,
             CancellationToken cancellationToken) =>
         {
@@ -36,6 +37,7 @@ public static class CurseForgeEndpoints
                     sort,
                     order,
                     minDownloads,
+                    gameVersion,
                     cancellationToken);
                 return Results.Ok(results);
             }

--- a/apps/MineOS.Api/Endpoints/ModEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/ModEndpoints.cs
@@ -125,6 +125,107 @@ public static class ModEndpoints
             }
         });
 
+        // Client-only mods (stored in client-mods/mods/, included in client packages only)
+        servers.MapGet("/{name}/client-mods", async (
+            string name,
+            IModService modService,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var mods = await modService.ListClientModsAsync(name, cancellationToken);
+                return Results.Ok(mods);
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+        });
+
+        servers.MapPost("/{name}/client-mods/upload", async (
+            string name,
+            HttpRequest request,
+            IModService modService,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                if (!request.HasFormContentType)
+                {
+                    return Results.BadRequest(new { error = "Form content type required" });
+                }
+
+                var form = await request.ReadFormAsync(cancellationToken);
+                var file = form.Files.FirstOrDefault();
+                if (file == null)
+                {
+                    return Results.BadRequest(new { error = "Mod file is required" });
+                }
+
+                await using var stream = file.OpenReadStream();
+                await modService.SaveClientModAsync(name, file.FileName, stream, cancellationToken);
+                return Results.Ok(new { message = $"Uploaded client mod '{file.FileName}'" });
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        });
+
+        servers.MapDelete("/{name}/client-mods/{filename}", async (
+            string name,
+            string filename,
+            IModService modService,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                await modService.DeleteClientModAsync(name, filename, cancellationToken);
+                return Results.Ok(new { message = $"Deleted client mod '{filename}'" });
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+            catch (FileNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        });
+
+        servers.MapGet("/{name}/client-mods/{filename}/download", async (
+            string name,
+            string filename,
+            IModService modService,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var path = await modService.GetClientModPathAsync(name, filename, cancellationToken);
+                return Results.File(path, "application/java-archive", filename);
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+            catch (FileNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.BadRequest(new { error = ex.Message });
+            }
+        });
+
         servers.MapPost("/{name}/mods/install-from-curseforge", async (
             string name,
             [FromBody] InstallModRequest request,
@@ -295,6 +396,7 @@ public static class ModEndpoints
             [FromQuery] int? pageSize,
             [FromQuery] string? loader,
             [FromQuery] string? gameVersion,
+            [FromQuery] string? sortBy,
             IModrinthService modrinthService,
             IServerService serverService,
             IProfileService profileService,
@@ -320,6 +422,7 @@ public static class ModEndpoints
                 pageSize ?? 20,
                 effectiveLoader,
                 effectiveVersion,
+                sortBy,
                 cancellationToken);
 
             return Results.Ok(result);
@@ -402,6 +505,7 @@ public static class ModEndpoints
             [FromQuery] int? pageSize,
             [FromQuery] string? loader,
             [FromQuery] string? gameVersion,
+            [FromQuery] string? sortBy,
             IModrinthService modrinthService,
             IServerService serverService,
             IProfileService profileService,
@@ -427,6 +531,7 @@ public static class ModEndpoints
                 pageSize ?? 20,
                 effectiveLoader,
                 effectiveVersion,
+                sortBy,
                 cancellationToken);
 
             return Results.Ok(result);

--- a/apps/MineOS.Api/Endpoints/PluginEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/PluginEndpoints.cs
@@ -167,6 +167,7 @@ public static class PluginEndpoints
             [FromQuery] int? pageSize,
             [FromQuery] string? loader,
             [FromQuery] string? gameVersion,
+            [FromQuery] string? sortBy,
             IModrinthService modrinthService,
             IServerService serverService,
             IProfileService profileService,
@@ -192,6 +193,7 @@ public static class PluginEndpoints
                 pageSize ?? 20,
                 effectiveLoader,
                 effectiveVersion,
+                sortBy,
                 cancellationToken);
 
             return Results.Ok(result);

--- a/apps/MineOS.Api/Endpoints/ResourcePackEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/ResourcePackEndpoints.cs
@@ -19,6 +19,7 @@ public static class ResourcePackEndpoints
             [FromQuery] int? pageSize,
             [FromQuery] string? gameVersion,
             [FromQuery] string? projectType,
+            [FromQuery] string? sortBy,
             IModrinthService modrinthService,
             IServerService serverService,
             IProfileService profileService,
@@ -42,6 +43,7 @@ public static class ResourcePackEndpoints
                 index ?? 0,
                 pageSize ?? 20,
                 effectiveVersion,
+                sortBy,
                 cancellationToken);
 
             return Results.Ok(result);

--- a/apps/MineOS.Api/Program.cs
+++ b/apps/MineOS.Api/Program.cs
@@ -135,10 +135,6 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 builder.Services.AddAuthorization();
 
 var defaultConnectionString = builder.Configuration.GetConnectionString("Default");
-builder.Services.AddDbContext<AppDbContext>(options =>
-{
-    options.UseSqlite(defaultConnectionString);
-});
 builder.Services.AddDbContextFactory<AppDbContext>(options =>
 {
     options.UseSqlite(defaultConnectionString);

--- a/apps/MineOS.Api/appsettings.Development.json
+++ b/apps/MineOS.Api/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "Default": "Data Source=C:\\Users\\Dave\\projects\\mineos-sveltkit\\data\\mineos.db"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",
@@ -36,6 +39,14 @@
     "ApiKey": "$2a$10$zOdAGXfIO4YAVXlAj3ivJO9MFWAX/slI1gA530AFsw99jtsYlFUxK",
     "BaseUrl": "https://api.curseforge.com",
     "GameId": 432
+  },
+  "Host": {
+    "BaseDirectory": "C:\\Users\\Dave\\projects\\mineos-sveltkit\\minecraft",
+    "ServersPathSegment": "servers",
+    "ProfilesPathSegment": "profiles",
+    "BackupsPathSegment": "backups",
+    "ArchivesPathSegment": "archives",
+    "ImportsPathSegment": "imports"
   },
   "Cors": {
     "AllowedOrigins": [

--- a/apps/MineOS.Application/Dtos/HostDtos.cs
+++ b/apps/MineOS.Application/Dtos/HostDtos.cs
@@ -47,7 +47,13 @@ public record AdminShellStatusDto(
 
 public record ArchiveEntryDto(DateTimeOffset Time, long Size, string Filename);
 
-public record ClientPackageEntryDto(DateTimeOffset Time, long Size, string Filename);
+public record ClientPackageEntryDto(DateTimeOffset Time, long Size, string Filename, string? Format);
+
+public record CreateClientPackageRequest(
+    string? Format,
+    string? MinecraftVersion,
+    string? ModLoader,
+    string? ModLoaderVersion);
 
 public record IncrementEntryDto(DateTimeOffset Time, string Step, long? Size, long? CumulativeSize);
 

--- a/apps/MineOS.Application/Interfaces/IClientPackageService.cs
+++ b/apps/MineOS.Application/Interfaces/IClientPackageService.cs
@@ -5,7 +5,7 @@ namespace MineOS.Application.Interfaces;
 public interface IClientPackageService
 {
     Task<IEnumerable<ClientPackageEntryDto>> ListClientPackagesAsync(string serverName, CancellationToken cancellationToken);
-    Task<string> CreateClientPackageAsync(string serverName, CancellationToken cancellationToken);
+    Task<string> CreateClientPackageAsync(string serverName, CreateClientPackageRequest? request, CancellationToken cancellationToken);
     Task DeleteClientPackageAsync(string serverName, string filename, CancellationToken cancellationToken);
     Task<string> GetClientPackagePathAsync(string serverName, string filename, CancellationToken cancellationToken);
 }

--- a/apps/MineOS.Application/Interfaces/ICurseForgeService.cs
+++ b/apps/MineOS.Application/Interfaces/ICurseForgeService.cs
@@ -12,6 +12,7 @@ public interface ICurseForgeService
         string? sort,
         string? order,
         long? minDownloads,
+        string? gameVersion,
         CancellationToken cancellationToken);
 
     Task<CurseForgeModDto> GetModAsync(int modId, CancellationToken cancellationToken);

--- a/apps/MineOS.Application/Interfaces/IModService.cs
+++ b/apps/MineOS.Application/Interfaces/IModService.cs
@@ -45,4 +45,10 @@ public interface IModService
 
     Task<IReadOnlyList<InstalledModpackDto>> ListInstalledModpacksAsync(string serverName, CancellationToken cancellationToken);
     Task UninstallModpackAsync(string serverName, int modpackDbId, CancellationToken cancellationToken);
+
+    // Client-only mods (stored in client-mods/mods/, included in client packages only)
+    Task<IReadOnlyList<InstalledModWithModpackDto>> ListClientModsAsync(string serverName, CancellationToken cancellationToken);
+    Task SaveClientModAsync(string serverName, string fileName, Stream content, CancellationToken cancellationToken);
+    Task DeleteClientModAsync(string serverName, string fileName, CancellationToken cancellationToken);
+    Task<string> GetClientModPathAsync(string serverName, string fileName, CancellationToken cancellationToken);
 }

--- a/apps/MineOS.Application/Interfaces/IModrinthService.cs
+++ b/apps/MineOS.Application/Interfaces/IModrinthService.cs
@@ -10,6 +10,7 @@ public interface IModrinthService
         int pageSize,
         string? loader,
         string? gameVersion,
+        string? sortBy,
         CancellationToken cancellationToken);
 
     Task<ModrinthSearchResultDto> SearchModpacksAsync(
@@ -18,6 +19,7 @@ public interface IModrinthService
         int pageSize,
         string? loader,
         string? gameVersion,
+        string? sortBy,
         CancellationToken cancellationToken);
 
     Task<ModrinthSearchResultDto> SearchPluginsAsync(
@@ -26,6 +28,7 @@ public interface IModrinthService
         int pageSize,
         string? loader,
         string? gameVersion,
+        string? sortBy,
         CancellationToken cancellationToken);
 
     Task<ModrinthSearchResultDto> SearchResourcePacksAsync(
@@ -33,6 +36,7 @@ public interface IModrinthService
         int index,
         int pageSize,
         string? gameVersion,
+        string? sortBy,
         CancellationToken cancellationToken);
 
     Task<ModrinthProjectDto?> GetProjectAsync(string projectId, CancellationToken cancellationToken);

--- a/apps/MineOS.Infrastructure/Services/ClientPackageService.cs
+++ b/apps/MineOS.Infrastructure/Services/ClientPackageService.cs
@@ -23,13 +23,13 @@ public sealed class ClientPackageService : IClientPackageService
         "kubejs"
     };
 
+    private static readonly string[] PackageExtensions = { ".zip", ".mrpack" };
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         WriteIndented = true
     };
-
-    private const string PackageExtension = ".zip";
 
     private readonly ILogger<ClientPackageService> _logger;
     private readonly HostOptions _hostOptions;
@@ -57,22 +57,26 @@ public sealed class ClientPackageService : IClientPackageService
         }
 
         var packages = new List<ClientPackageEntryDto>();
-        var files = Directory.GetFiles(packagePath, $"*{PackageExtension}");
-
-        foreach (var file in files)
+        foreach (var ext in PackageExtensions)
         {
-            var fileInfo = new FileInfo(file);
-            packages.Add(new ClientPackageEntryDto(
-                fileInfo.LastWriteTimeUtc,
-                fileInfo.Length,
-                fileInfo.Name
-            ));
+            var files = Directory.GetFiles(packagePath, $"*{ext}");
+            foreach (var file in files)
+            {
+                var fileInfo = new FileInfo(file);
+                var format = DetectFormat(fileInfo.Name);
+                packages.Add(new ClientPackageEntryDto(
+                    fileInfo.LastWriteTimeUtc,
+                    fileInfo.Length,
+                    fileInfo.Name,
+                    format
+                ));
+            }
         }
 
         return await Task.FromResult(packages.OrderByDescending(p => p.Time));
     }
 
-    public Task<string> CreateClientPackageAsync(string serverName, CancellationToken cancellationToken)
+    public Task<string> CreateClientPackageAsync(string serverName, CreateClientPackageRequest? request, CancellationToken cancellationToken)
     {
         var serverPath = GetServerPath(serverName);
         if (!Directory.Exists(serverPath))
@@ -80,7 +84,8 @@ public sealed class ClientPackageService : IClientPackageService
             throw new DirectoryNotFoundException($"Server '{serverName}' not found");
         }
 
-        var metadata = ResolveCurseForgeMetadata(serverPath);
+        var metadata = ResolveMetadata(serverPath, serverName, request);
+        var isMrpack = string.Equals(request?.Format, "mrpack", StringComparison.OrdinalIgnoreCase);
 
         var packagePath = GetClientPackagePath(serverName);
         Directory.CreateDirectory(packagePath);
@@ -88,7 +93,9 @@ public sealed class ClientPackageService : IClientPackageService
 
         var timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd_HH-mm-ss");
         var suffix = Guid.NewGuid().ToString("N")[..8];
-        var packageFilename = $"{serverName}_curseforge_{timestamp}_{suffix}{PackageExtension}";
+        var packageFilename = isMrpack
+            ? $"{serverName}_mrpack_{timestamp}_{suffix}.mrpack"
+            : $"{serverName}_curseforge_{timestamp}_{suffix}.zip";
         var packageFullPath = Path.Combine(packagePath, packageFilename);
 
         var sourceFolders = ClientOverrideFolders
@@ -99,7 +106,12 @@ public sealed class ClientPackageService : IClientPackageService
         var clientModsPath = Path.Combine(serverPath, "client-mods", "mods");
         if (Directory.Exists(clientModsPath))
         {
-            sourceFolders.Add(new PackageSource(clientModsPath, Path.Combine("overrides", "mods")));
+            // For .mrpack, client-only mods go into client-overrides/ so they're
+            // only applied on client installs, not server installs.
+            var clientModsRoot = isMrpack
+                ? Path.Combine("client-overrides", "mods")
+                : Path.Combine("overrides", "mods");
+            sourceFolders.Add(new PackageSource(clientModsPath, clientModsRoot));
         }
 
         if (sourceFolders.Count == 0)
@@ -107,13 +119,16 @@ public sealed class ClientPackageService : IClientPackageService
             throw new InvalidOperationException("No client assets found to package.");
         }
 
-        var manifest = BuildCurseForgeManifest(serverName, metadata);
         var addedFiles = 0;
         var addedEntries = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         try
         {
             using var archive = ZipFile.Open(packageFullPath, ZipArchiveMode.Create);
-            AddManifestToArchive(archive, manifest);
+
+            if (isMrpack)
+                AddMrpackIndexToArchive(archive, metadata);
+            else
+                AddCurseForgeManifestToArchive(archive, metadata);
 
             foreach (var folder in sourceFolders)
             {
@@ -148,7 +163,7 @@ public sealed class ClientPackageService : IClientPackageService
         var packagePath = GetClientPackagePath(serverName);
         var fullPath = Path.Combine(packagePath, filename);
 
-        if (Path.GetFileName(filename) != filename || !filename.EndsWith(PackageExtension, StringComparison.OrdinalIgnoreCase))
+        if (Path.GetFileName(filename) != filename || !HasValidPackageExtension(filename))
         {
             throw new ArgumentException("Invalid client package filename");
         }
@@ -169,7 +184,7 @@ public sealed class ClientPackageService : IClientPackageService
         var packagePath = GetClientPackagePath(serverName);
         var fullPath = Path.Combine(packagePath, filename);
 
-        if (Path.GetFileName(filename) != filename || !filename.EndsWith(PackageExtension, StringComparison.OrdinalIgnoreCase))
+        if (Path.GetFileName(filename) != filename || !HasValidPackageExtension(filename))
         {
             throw new ArgumentException("Invalid client package filename");
         }
@@ -182,25 +197,58 @@ public sealed class ClientPackageService : IClientPackageService
         return Task.FromResult(fullPath);
     }
 
-    private CurseForgeMetadata ResolveCurseForgeMetadata(string serverPath)
+    // --- Metadata resolution (never throws) ---
+
+    private PackageMetadata ResolveMetadata(string serverPath, string serverName, CreateClientPackageRequest? request)
     {
-        var modpackMetadata = TryReadModpackManifest(serverPath);
-        if (modpackMetadata != null)
+        string? detectedMcVersion = null;
+        string? detectedLoaderType = null;
+        string? detectedLoaderVersion = null;
+        string? detectedPackName = null;
+        string? detectedPackVersion = null;
+
+        // Try modpack manifest first (CurseForge-installed packs)
+        var modpackMeta = TryReadModpackManifest(serverPath);
+        if (modpackMeta != null)
         {
-            return modpackMetadata;
+            detectedMcVersion = modpackMeta.MinecraftVersion;
+            (detectedLoaderType, detectedLoaderVersion) = SplitLoaderId(modpackMeta.ModLoaderId);
+            detectedPackName = modpackMeta.PackName;
+            detectedPackVersion = modpackMeta.PackVersion;
         }
 
-        if (TryResolveFromServerConfig(serverPath, out var metadata))
+        // Fallback: parse jar filename from server.config
+        if (string.IsNullOrWhiteSpace(detectedMcVersion) &&
+            TryResolveFromServerConfig(serverPath, out var configMeta))
         {
-            return metadata;
+            detectedMcVersion = configMeta.MinecraftVersion;
+            (detectedLoaderType, detectedLoaderVersion) = SplitLoaderId(configMeta.ModLoaderId);
         }
 
-        throw new InvalidOperationException(
-            "Unable to determine Minecraft version and mod loader for this server. " +
-            "Install a CurseForge modpack or ensure the server jar filename includes the loader and game version.");
+        // Merge: request overrides > auto-detected > defaults
+        return new PackageMetadata(
+            MinecraftVersion: request?.MinecraftVersion ?? detectedMcVersion ?? "Unknown",
+            ModLoaderType: request?.ModLoader ?? detectedLoaderType ?? "forge",
+            ModLoaderVersion: request?.ModLoaderVersion ?? detectedLoaderVersion ?? "0.0.0",
+            PackName: detectedPackName ?? $"{serverName} Client Pack",
+            PackVersion: detectedPackVersion ?? DateTime.UtcNow.ToString("yyyy.MM.dd.HHmm")
+        );
     }
 
-    private CurseForgeMetadata? TryReadModpackManifest(string serverPath)
+    private static (string Type, string Version) SplitLoaderId(string loaderId)
+    {
+        // "forge-47.2.0" → ("forge", "47.2.0")
+        var idx = loaderId.IndexOf('-');
+        if (idx > 0 && idx < loaderId.Length - 1)
+            return (loaderId[..idx], loaderId[(idx + 1)..]);
+        return (loaderId, "0.0.0");
+    }
+
+    // --- Auto-detection helpers (unchanged logic, just returns nullable) ---
+
+    private record DetectedMetadata(string MinecraftVersion, string ModLoaderId, string? PackName, string? PackVersion);
+
+    private DetectedMetadata? TryReadModpackManifest(string serverPath)
     {
         var modpackPath = Path.Combine(serverPath, "modpacks");
         if (!Directory.Exists(modpackPath))
@@ -272,7 +320,7 @@ public sealed class ClientPackageService : IClientPackageService
                     ? versionProp.GetString()
                     : null;
 
-                return new CurseForgeMetadata(minecraftVersion, modLoaderId, name, version);
+                return new DetectedMetadata(minecraftVersion, modLoaderId, name, version);
             }
             catch (Exception ex)
             {
@@ -283,9 +331,9 @@ public sealed class ClientPackageService : IClientPackageService
         return null;
     }
 
-    private bool TryResolveFromServerConfig(string serverPath, out CurseForgeMetadata metadata)
+    private bool TryResolveFromServerConfig(string serverPath, out DetectedMetadata metadata)
     {
-        metadata = new CurseForgeMetadata(string.Empty, string.Empty, null, null);
+        metadata = new DetectedMetadata(string.Empty, string.Empty, null, null);
         var configPath = Path.Combine(serverPath, "server.config");
         if (!File.Exists(configPath))
         {
@@ -307,7 +355,7 @@ public sealed class ClientPackageService : IClientPackageService
         var jarName = Path.GetFileName(jarFile);
         if (TryParseJarMetadata(jarName, out var minecraftVersion, out var modLoaderId))
         {
-            metadata = new CurseForgeMetadata(minecraftVersion, modLoaderId, null, null);
+            metadata = new DetectedMetadata(minecraftVersion, modLoaderId, null, null);
             return true;
         }
 
@@ -351,24 +399,16 @@ public sealed class ClientPackageService : IClientPackageService
         return false;
     }
 
-    private CurseForgeManifest BuildCurseForgeManifest(string serverName, CurseForgeMetadata metadata)
+    // --- CurseForge manifest ---
+
+    private static void AddCurseForgeManifestToArchive(ZipArchive archive, PackageMetadata metadata)
     {
-        var versionTag = metadata.PackVersion;
-        if (string.IsNullOrWhiteSpace(versionTag))
-        {
-            versionTag = DateTime.UtcNow.ToString("yyyy.MM.dd.HHmm");
-        }
-
-        var displayName = string.IsNullOrWhiteSpace(metadata.PackName)
-            ? $"{serverName} Client Pack"
-            : metadata.PackName!;
-
-        return new CurseForgeManifest
+        var manifest = new CurseForgeManifest
         {
             ManifestType = "minecraftModpack",
             ManifestVersion = 1,
-            Name = displayName,
-            Version = versionTag!,
+            Name = metadata.PackName,
+            Version = metadata.PackVersion,
             Author = "MineOS",
             Files = new List<CurseForgeFileEntry>(),
             Overrides = "overrides",
@@ -377,18 +417,51 @@ public sealed class ClientPackageService : IClientPackageService
                 Version = metadata.MinecraftVersion,
                 ModLoaders = new List<CurseForgeModLoader>
                 {
-                    new(metadata.ModLoaderId, true)
+                    new($"{metadata.ModLoaderType}-{metadata.ModLoaderVersion}", true)
                 }
             }
         };
-    }
 
-    private static void AddManifestToArchive(ZipArchive archive, CurseForgeManifest manifest)
-    {
         var entry = archive.CreateEntry("manifest.json", CompressionLevel.Optimal);
         using var stream = entry.Open();
         JsonSerializer.Serialize(stream, manifest, JsonOptions);
     }
+
+    // --- Modrinth .mrpack manifest ---
+
+    private static void AddMrpackIndexToArchive(ZipArchive archive, PackageMetadata metadata)
+    {
+        var loaderKey = metadata.ModLoaderType.ToLowerInvariant() switch
+        {
+            "neoforge" => "neoforge",
+            "fabric" or "fabric-loader" => "fabric-loader",
+            "quilt" or "quilt-loader" => "quilt-loader",
+            _ => "forge"
+        };
+
+        var dependencies = new Dictionary<string, string>
+        {
+            ["minecraft"] = metadata.MinecraftVersion,
+            [loaderKey] = metadata.ModLoaderVersion
+        };
+
+        var index = new
+        {
+            formatVersion = 1,
+            game = "minecraft",
+            versionId = metadata.PackVersion,
+            name = metadata.PackName,
+            summary = $"Client pack for {metadata.PackName}",
+            files = Array.Empty<object>(),
+            dependencies
+        };
+
+        var entry = archive.CreateEntry("modrinth.index.json", CompressionLevel.Optimal);
+        using var stream = entry.Open();
+        JsonSerializer.Serialize(stream, index, JsonOptions);
+    }
+
+    // --- Shared helpers ---
 
     private static int AddDirectoryToArchive(
         ZipArchive archive,
@@ -417,13 +490,44 @@ public sealed class ClientPackageService : IClientPackageService
         return added;
     }
 
+    private static bool HasValidPackageExtension(string filename) =>
+        PackageExtensions.Any(ext => filename.EndsWith(ext, StringComparison.OrdinalIgnoreCase));
+
+    private static string? DetectFormat(string filename)
+    {
+        if (filename.EndsWith(".mrpack", StringComparison.OrdinalIgnoreCase))
+            return "mrpack";
+        if (filename.Contains("_curseforge_", StringComparison.OrdinalIgnoreCase) ||
+            filename.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+            return "curseforge";
+        return null;
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // Ignore cleanup failures.
+        }
+    }
+
+    // --- Internal types ---
+
     private sealed record PackageSource(string SourcePath, string EntryRoot);
 
-    private sealed record CurseForgeMetadata(
+    private sealed record PackageMetadata(
         string MinecraftVersion,
-        string ModLoaderId,
-        string? PackName,
-        string? PackVersion);
+        string ModLoaderType,
+        string ModLoaderVersion,
+        string PackName,
+        string PackVersion);
 
     private sealed class CurseForgeManifest
     {
@@ -446,19 +550,4 @@ public sealed class ClientPackageService : IClientPackageService
     }
 
     private sealed record CurseForgeModLoader(string Id, bool Primary);
-
-    private static void TryDeleteFile(string path)
-    {
-        try
-        {
-            if (File.Exists(path))
-            {
-                File.Delete(path);
-            }
-        }
-        catch
-        {
-            // Ignore cleanup failures.
-        }
-    }
 }

--- a/apps/MineOS.Infrastructure/Services/CurseForgeService.cs
+++ b/apps/MineOS.Infrastructure/Services/CurseForgeService.cs
@@ -25,6 +25,7 @@ public sealed class CurseForgeService : ICurseForgeService
         string? sort,
         string? order,
         long? minDownloads,
+        string? gameVersion,
         CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(query))
@@ -43,6 +44,11 @@ public sealed class CurseForgeService : ICurseForgeService
         if (classId.HasValue)
         {
             parameters.Add($"classId={classId.Value}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(gameVersion))
+        {
+            parameters.Add($"gameVersion={Uri.EscapeDataString(gameVersion)}");
         }
 
         var sortField = ResolveSortField(sort);

--- a/apps/MineOS.Infrastructure/Services/ModService.cs
+++ b/apps/MineOS.Infrastructure/Services/ModService.cs
@@ -215,6 +215,109 @@ public sealed class ModService : IModService
         return Task.FromResult(targetPath);
     }
 
+    public Task<IReadOnlyList<InstalledModWithModpackDto>> ListClientModsAsync(string serverName, CancellationToken cancellationToken)
+    {
+        var serverPath = GetServerPath(serverName);
+        if (!Directory.Exists(serverPath))
+        {
+            throw new DirectoryNotFoundException($"Server '{serverName}' not found");
+        }
+
+        var clientModsPath = GetClientModsPath(serverName);
+        if (!Directory.Exists(clientModsPath))
+        {
+            return Task.FromResult<IReadOnlyList<InstalledModWithModpackDto>>(Array.Empty<InstalledModWithModpackDto>());
+        }
+
+        var sourceMap = ReadClientModSourceMap(serverName);
+
+        var mods = Directory.GetFiles(clientModsPath)
+            .Select(path =>
+            {
+                var info = new FileInfo(path);
+                sourceMap.TryGetValue(info.Name, out var source);
+                return new InstalledModWithModpackDto(
+                    info.Name,
+                    info.Length,
+                    info.LastWriteTimeUtc,
+                    info.Name.EndsWith(".disabled", StringComparison.OrdinalIgnoreCase),
+                    null,
+                    source,
+                    null);
+            })
+            .OrderBy(m => m.FileName)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<InstalledModWithModpackDto>>(mods);
+    }
+
+    public async Task SaveClientModAsync(string serverName, string fileName, Stream content, CancellationToken cancellationToken)
+    {
+        var serverPath = GetServerPath(serverName);
+        if (!Directory.Exists(serverPath))
+        {
+            throw new DirectoryNotFoundException($"Server '{serverName}' not found");
+        }
+
+        var safeName = ValidateFileName(fileName);
+        var clientModsPath = EnsureClientModsPath(serverName);
+        var targetPath = Path.Combine(clientModsPath, safeName);
+        await using var target = new FileStream(targetPath, FileMode.Create, FileAccess.Write, FileShare.None);
+        await content.CopyToAsync(target, cancellationToken);
+        await OwnershipHelper.ChangeOwnershipAsync(
+            targetPath, _hostOptions.RunAsUid, _hostOptions.RunAsGid, _logger, cancellationToken);
+        _logger.LogInformation("Uploaded client mod {FileName} for server {ServerName}", safeName, serverName);
+    }
+
+    public async Task DeleteClientModAsync(string serverName, string fileName, CancellationToken cancellationToken)
+    {
+        var serverPath = GetServerPath(serverName);
+        if (!Directory.Exists(serverPath))
+        {
+            throw new DirectoryNotFoundException($"Server '{serverName}' not found");
+        }
+
+        var safeName = ValidateFileName(fileName);
+        var targetPath = Path.Combine(GetClientModsPath(serverName), safeName);
+
+        if (!File.Exists(targetPath))
+        {
+            throw new FileNotFoundException($"Client mod '{safeName}' not found");
+        }
+
+        File.Delete(targetPath);
+
+        // Remove from source map
+        var map = ReadClientModSourceMap(serverName);
+        if (map.Remove(safeName))
+        {
+            var mapPath = GetClientModSourceMapPath(serverName);
+            var json = JsonSerializer.Serialize(map, new JsonSerializerOptions { WriteIndented = true });
+            await File.WriteAllTextAsync(mapPath, json, cancellationToken);
+        }
+
+        _logger.LogInformation("Deleted client mod {FileName} for server {ServerName}", safeName, serverName);
+    }
+
+    public Task<string> GetClientModPathAsync(string serverName, string fileName, CancellationToken cancellationToken)
+    {
+        var serverPath = GetServerPath(serverName);
+        if (!Directory.Exists(serverPath))
+        {
+            throw new DirectoryNotFoundException($"Server '{serverName}' not found");
+        }
+
+        var safeName = ValidateFileName(fileName);
+        var targetPath = Path.Combine(GetClientModsPath(serverName), safeName);
+
+        if (!File.Exists(targetPath))
+        {
+            throw new FileNotFoundException($"Client mod '{safeName}' not found");
+        }
+
+        return Task.FromResult(targetPath);
+    }
+
     public async Task InstallModFromCurseForgeAsync(
         string serverName,
         int modId,
@@ -1189,7 +1292,8 @@ public sealed class ModService : IModService
                 $"Missing required Modrinth dependencies: {string.Join(", ", dependencyResolution.Errors)}. See {Path.GetFileName(missingDependencyReportPath)}.");
         }
 
-        total = installFiles.Count + excludedMods.Count + dependencyResolution.Installs.Count + 1;
+        total = installFiles.Count + excludedMods.Count + dependencyResolution.Installs.Count
+            + dependencyResolution.ClientOnlyInstalls.Count + 1;
 
         foreach (var decision in installFiles)
         {
@@ -1335,6 +1439,67 @@ public sealed class ModService : IModService
             }
         }
 
+        if (dependencyResolution.ClientOnlyInstalls.Count > 0)
+        {
+            var clientModsPath = Path.Combine(serverPath, "client-mods", "mods");
+            Directory.CreateDirectory(clientModsPath);
+            OwnershipHelper.TrySetOwnership(clientModsPath, _hostOptions.RunAsUid, _hostOptions.RunAsGid, _logger, recursive: true);
+
+            foreach (var dependency in dependencyResolution.ClientOnlyInstalls)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var file = SelectModrinthFile(dependency.Version);
+                if (file == null || string.IsNullOrWhiteSpace(file.Url))
+                {
+                    _logger.LogWarning(
+                        "Missing download URL for client-only dependency {ProjectName} ({ProjectId})",
+                        dependency.ProjectName, dependency.ProjectId);
+                    completed++;
+                    continue;
+                }
+
+                var targetPath = Path.Combine(clientModsPath, ValidateFileName(file.FileName));
+                var stepMessage = $"Saving client-only dependency {Path.GetFileName(file.FileName)}";
+                ReportProgress(progress, serverName, "modrinth-modpack-install", completed, total, stepMessage);
+
+                await DownloadFileWithRetriesAsync(
+                    file.Url,
+                    targetPath,
+                    cancellationToken,
+                    null,
+                    message => ReportProgress(progress, serverName, "modrinth-modpack-install", completed, total, message));
+
+                await OwnershipHelper.ChangeOwnershipAsync(
+                    targetPath,
+                    _hostOptions.RunAsUid,
+                    _hostOptions.RunAsGid,
+                    _logger,
+                    cancellationToken);
+
+                completed++;
+                ReportProgress(progress, serverName, "modrinth-modpack-install", completed, total,
+                    $"Saved client-only dependency {Path.GetFileName(targetPath)}");
+            }
+        }
+
+        var clientModFileNames = new List<string>();
+        foreach (var excluded in excludedMods)
+        {
+            clientModFileNames.Add(Path.GetFileName(excluded.File.Path));
+        }
+        foreach (var dep in dependencyResolution.ClientOnlyInstalls)
+        {
+            var depFile = SelectModrinthFile(dep.Version);
+            if (depFile != null)
+            {
+                clientModFileNames.Add(ValidateFileName(depFile.FileName));
+            }
+        }
+        if (clientModFileNames.Count > 0)
+        {
+            await UpdateClientModSourceMapAsync(serverName, clientModFileNames, modpackName, cancellationToken);
+        }
+
         AddOverrideModRecords(installedRecords, overrideModFiles, serverName);
 
         await _modpackRepo.UpsertModpackAsync(
@@ -1358,7 +1523,7 @@ public sealed class ModService : IModService
             serverName,
             "running",
             100,
-            $"Installed {installedRecords.Count} mod(s), excluded {excludedMods.Count} mod(s), missing {dependencyResolution.Errors.Count} dependency(ies). Report saved to {Path.GetFileName(reportPath)}.",
+            $"Installed {installedRecords.Count} mod(s), excluded {excludedMods.Count} client-only mod(s), {dependencyResolution.ClientOnlyInstalls.Count} client-only dep(s), missing {dependencyResolution.Errors.Count} dependency(ies). Report saved to {Path.GetFileName(reportPath)}.",
             DateTimeOffset.UtcNow));
     }
 
@@ -1981,6 +2146,62 @@ public sealed class ModService : IModService
     private string GetModsPath(string serverName) =>
         Path.Combine(GetServerPath(serverName), "mods");
 
+    private string GetClientModsPath(string serverName) =>
+        Path.Combine(GetServerPath(serverName), "client-mods", "mods");
+
+    private string EnsureClientModsPath(string serverName)
+    {
+        var path = GetClientModsPath(serverName);
+        Directory.CreateDirectory(path);
+        OwnershipHelper.TrySetOwnership(path, _hostOptions.RunAsUid, _hostOptions.RunAsGid, _logger);
+        return path;
+    }
+
+    private string GetClientModSourceMapPath(string serverName) =>
+        Path.Combine(GetServerPath(serverName), "client-mods", "source-map.json");
+
+    private Dictionary<string, string> ReadClientModSourceMap(string serverName)
+    {
+        var path = GetClientModSourceMapPath(serverName);
+        if (!File.Exists(path))
+        {
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            var map = JsonSerializer.Deserialize<Dictionary<string, string>>(json);
+            return map != null
+                ? new Dictionary<string, string>(map, StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read client mod source map for {ServerName}", serverName);
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    private async Task UpdateClientModSourceMapAsync(
+        string serverName,
+        IEnumerable<string> fileNames,
+        string modpackName,
+        CancellationToken cancellationToken)
+    {
+        var map = ReadClientModSourceMap(serverName);
+        foreach (var fileName in fileNames)
+        {
+            map[fileName] = modpackName;
+        }
+
+        var clientModsRoot = Path.Combine(GetServerPath(serverName), "client-mods");
+        Directory.CreateDirectory(clientModsRoot);
+        var path = GetClientModSourceMapPath(serverName);
+        var json = JsonSerializer.Serialize(map, new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(path, json, cancellationToken);
+    }
+
     private string EnsureModsPath(string serverName)
     {
         var path = GetModsPath(serverName);
@@ -2252,6 +2473,7 @@ public sealed class ModService : IModService
         CancellationToken cancellationToken)
     {
         var installs = new List<ModrinthDependencyInstall>();
+        var clientOnlyInstalls = new List<ModrinthDependencyInstall>();
         var errors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var installedProjectIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var installedVersionIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -2365,16 +2587,34 @@ public sealed class ModService : IModService
                 continue;
             }
 
-            if (string.Equals(dependencyProject.ServerSide, "unsupported", StringComparison.OrdinalIgnoreCase))
-            {
-                errors.Add($"{dependencyProject.Title} (client-only)");
-                continue;
-            }
+            var isClientOnly = string.Equals(dependencyProject.ServerSide, "unsupported", StringComparison.OrdinalIgnoreCase)
+                || (string.IsNullOrWhiteSpace(dependencyProject.ServerSide) && IsKnownClientOnlyCategory(dependencyProject.Categories));
 
-            if (string.IsNullOrWhiteSpace(dependencyProject.ServerSide) &&
-                IsKnownClientOnlyCategory(dependencyProject.Categories))
+            if (isClientOnly)
             {
-                errors.Add($"{dependencyProject.Title} (client-only)");
+                _logger.LogInformation(
+                    "Client-only dependency {ProjectTitle} ({ProjectId}) — will be saved to client-mods",
+                    dependencyProject.Title, dependencyProject.Id);
+                clientOnlyInstalls.Add(new ModrinthDependencyInstall(
+                    dependencyProject.Id,
+                    dependencyProject.Title,
+                    dependencyVersion));
+                installedProjectIds.Add(dependencyProject.Id);
+                installedVersionIds.Add(dependencyVersion.Id);
+                if (dependencyVersion.Dependencies != null)
+                {
+                    foreach (var child in dependencyVersion.Dependencies)
+                    {
+                        if (string.Equals(child.DependencyType, "required", StringComparison.OrdinalIgnoreCase))
+                        {
+                            var childKey = GetDependencyKey(child);
+                            if (!string.IsNullOrWhiteSpace(childKey) && queuedDependencyKeys.Add(childKey))
+                            {
+                                dependencyQueue.Enqueue(child);
+                            }
+                        }
+                    }
+                }
                 continue;
             }
 
@@ -2385,7 +2625,15 @@ public sealed class ModService : IModService
 
             if (excludedProjectIds.Contains(dependencyProject.Id))
             {
-                errors.Add($"{dependencyProject.Title} (excluded)");
+                _logger.LogInformation(
+                    "Client-only dependency {ProjectTitle} ({ProjectId}) — already excluded from modpack, will be saved to client-mods",
+                    dependencyProject.Title, dependencyProject.Id);
+                clientOnlyInstalls.Add(new ModrinthDependencyInstall(
+                    dependencyProject.Id,
+                    dependencyProject.Title,
+                    dependencyVersion));
+                installedProjectIds.Add(dependencyProject.Id);
+                installedVersionIds.Add(dependencyVersion.Id);
                 continue;
             }
 
@@ -2412,7 +2660,7 @@ public sealed class ModService : IModService
             }
         }
 
-        return new ModrinthDependencyResolution(installs, errors.OrderBy(error => error).ToList());
+        return new ModrinthDependencyResolution(installs, clientOnlyInstalls, errors.OrderBy(error => error).ToList());
     }
 
     private static string? GetDependencyKey(ModrinthDependencyDto dependency)
@@ -2699,6 +2947,7 @@ public sealed class ModService : IModService
 
     private sealed record ModrinthDependencyResolution(
         IReadOnlyList<ModrinthDependencyInstall> Installs,
+        IReadOnlyList<ModrinthDependencyInstall> ClientOnlyInstalls,
         IReadOnlyList<string> Errors);
 
     private sealed record ModrinthInstallReport(

--- a/apps/MineOS.Infrastructure/Services/ModrinthService.cs
+++ b/apps/MineOS.Infrastructure/Services/ModrinthService.cs
@@ -29,9 +29,10 @@ public sealed class ModrinthService : IModrinthService
         int pageSize,
         string? loader,
         string? gameVersion,
+        string? sortBy,
         CancellationToken cancellationToken)
     {
-        return SearchAsync("mod", query, index, pageSize, loader, gameVersion, cancellationToken);
+        return SearchAsync("mod", query, index, pageSize, loader, gameVersion, sortBy, cancellationToken);
     }
 
     public Task<ModrinthSearchResultDto> SearchModpacksAsync(
@@ -40,9 +41,10 @@ public sealed class ModrinthService : IModrinthService
         int pageSize,
         string? loader,
         string? gameVersion,
+        string? sortBy,
         CancellationToken cancellationToken)
     {
-        return SearchAsync("modpack", query, index, pageSize, loader, gameVersion, cancellationToken);
+        return SearchAsync("modpack", query, index, pageSize, loader, gameVersion, sortBy, cancellationToken);
     }
 
     public async Task<ModrinthSearchResultDto> SearchPluginsAsync(
@@ -51,9 +53,10 @@ public sealed class ModrinthService : IModrinthService
         int pageSize,
         string? loader,
         string? gameVersion,
+        string? sortBy,
         CancellationToken cancellationToken)
     {
-        return await SearchAsync("plugin", query, index, pageSize, loader, gameVersion, cancellationToken);
+        return await SearchAsync("plugin", query, index, pageSize, loader, gameVersion, sortBy, cancellationToken);
     }
 
     public async Task<ModrinthSearchResultDto> SearchResourcePacksAsync(
@@ -61,10 +64,11 @@ public sealed class ModrinthService : IModrinthService
         int index,
         int pageSize,
         string? gameVersion,
+        string? sortBy,
         CancellationToken cancellationToken)
     {
         // Resource packs don't use loaders, so pass null for loader parameter
-        return await SearchAsync("resourcepack", query, index, pageSize, null, gameVersion, cancellationToken);
+        return await SearchAsync("resourcepack", query, index, pageSize, null, gameVersion, sortBy, cancellationToken);
     }
 
     public async Task<ModrinthProjectDto?> GetProjectAsync(string projectId, CancellationToken cancellationToken)
@@ -161,6 +165,9 @@ public sealed class ModrinthService : IModrinthService
         return await _httpClient.GetStreamAsync(url, cancellationToken);
     }
 
+    private static readonly HashSet<string> ValidSortIndices = new(StringComparer.OrdinalIgnoreCase)
+        { "relevance", "downloads", "follows", "newest", "updated" };
+
     private async Task<ModrinthSearchResultDto> SearchAsync(
         string projectType,
         string query,
@@ -168,6 +175,7 @@ public sealed class ModrinthService : IModrinthService
         int pageSize,
         string? loader,
         string? gameVersion,
+        string? sortBy,
         CancellationToken cancellationToken)
     {
         var facets = new List<List<string>>
@@ -185,9 +193,13 @@ public sealed class ModrinthService : IModrinthService
             facets.Add(new List<string> { $"versions:{gameVersion}" });
         }
 
+        var sortIndex = !string.IsNullOrWhiteSpace(sortBy) && ValidSortIndices.Contains(sortBy)
+            ? sortBy.ToLowerInvariant()
+            : "relevance";
+
         var facetsJson = JsonSerializer.Serialize(facets);
         var url =
-            $"search?query={Uri.EscapeDataString(query)}&offset={index}&limit={pageSize}&facets={Uri.EscapeDataString(facetsJson)}";
+            $"search?query={Uri.EscapeDataString(query)}&offset={index}&limit={pageSize}&index={sortIndex}&facets={Uri.EscapeDataString(facetsJson)}";
 
         var response = await _httpClient.GetFromJsonAsync<ModrinthSearchResponse>(url, JsonOptions, cancellationToken);
         if (response == null)

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -40,10 +40,18 @@ export type ArchiveEntry = {
 	filename: string;
 };
 
+export type CreateClientPackageRequest = {
+	format?: 'curseforge' | 'mrpack';
+	minecraftVersion?: string;
+	modLoader?: string;
+	modLoaderVersion?: string;
+};
+
 export type ClientPackageEntry = {
 	time: string;
 	size: number;
 	filename: string;
+	format: string | null;
 };
 
 export type ApiResult<T> = {

--- a/apps/web/src/lib/components/CurseForgeSearch.svelte
+++ b/apps/web/src/lib/components/CurseForgeSearch.svelte
@@ -22,6 +22,7 @@
 		'downloads-desc'
 	);
 	let minDownloads = $state('0');
+	let selectedGameVersion = $state('auto');
 	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
 	let pageIndex = 0;
 	let pageSize = 20;
@@ -98,6 +99,11 @@
 
 			if (sort) params.set('sort', sort);
 			if (order) params.set('order', order);
+
+			const effectiveVersion = selectedGameVersion === 'auto' ? detectedVersion : selectedGameVersion;
+			if (effectiveVersion) {
+				params.set('gameVersion', effectiveVersion);
+			}
 
 			const minValue = Number(minDownloads);
 			if (!Number.isNaN(minValue) && minValue > 0) {
@@ -427,19 +433,37 @@
 		/>
 
 		<div class="filters">
-			<select bind:value={sortOption} onchange={scheduleSearch}>
-				<option value="downloads-desc">Most Downloads</option>
-				<option value="downloads-asc">Least Downloads</option>
-				<option value="updated-desc">Recently Updated</option>
-				<option value="name-asc">Name (A-Z)</option>
-			</select>
+			<label class="filter-group">
+				<span class="filter-label">Version</span>
+				<select bind:value={selectedGameVersion} onchange={scheduleSearch}>
+					<option value="auto">
+						{detectedVersion ? `Auto (${detectedVersion})` : 'Auto'}
+					</option>
+					{#each commonMinecraftVersions as version}
+						<option value={version}>{version}</option>
+					{/each}
+				</select>
+			</label>
 
-			<select bind:value={minDownloads} onchange={scheduleSearch}>
-				<option value="0">All downloads</option>
-				<option value="10000">10k+ downloads</option>
-				<option value="100000">100k+ downloads</option>
-				<option value="1000000">1M+ downloads</option>
-			</select>
+			<label class="filter-group">
+				<span class="filter-label">Sort</span>
+				<select bind:value={sortOption} onchange={scheduleSearch}>
+					<option value="downloads-desc">Most Downloads</option>
+					<option value="downloads-asc">Least Downloads</option>
+					<option value="updated-desc">Recently Updated</option>
+					<option value="name-asc">Name (A-Z)</option>
+				</select>
+			</label>
+
+			<label class="filter-group">
+				<span class="filter-label">Min</span>
+				<select bind:value={minDownloads} onchange={scheduleSearch}>
+					<option value="0">All</option>
+					<option value="10000">10k+</option>
+					<option value="100000">100k+</option>
+					<option value="1000000">1M+</option>
+				</select>
+			</label>
 		</div>
 	</div>
 
@@ -588,10 +612,6 @@
 
 <style>
 	.search-container {
-		background: #1a1e2f;
-		border-radius: 16px;
-		padding: 20px;
-		box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
 		display: flex;
 		flex-direction: column;
 		gap: 16px;
@@ -644,6 +664,21 @@
 		display: flex;
 		gap: 12px;
 		flex-wrap: wrap;
+	}
+
+	.filter-group {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.filter-label {
+		font-size: 11px;
+		color: #6b7190;
+		white-space: nowrap;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		font-weight: 600;
 	}
 
 	.filters select {

--- a/apps/web/src/lib/components/ModrinthModSearch.svelte
+++ b/apps/web/src/lib/components/ModrinthModSearch.svelte
@@ -7,14 +7,16 @@
 		ModrinthProject,
 		ModrinthVersion
 	} from '$lib/api/types';
+	import type { Snippet } from 'svelte';
 
 	interface Props {
 		serverName: string;
 		serverVersion?: string | null;
 		onInstallComplete?: () => void;
+		typeTabs?: Snippet;
 	}
 
-	let { serverName, serverVersion, onInstallComplete }: Props = $props();
+	let { serverName, serverVersion, onInstallComplete, typeTabs }: Props = $props();
 
 	let searchQuery = $state('');
 	let searchResults = $state<ModrinthProjectHit[]>([]);
@@ -30,6 +32,7 @@
 	const detectedVersion = $derived(extractMinecraftVersion(serverVersion));
 	let selectedLoader = $state('auto');
 	let selectedVersion = $state(detectedVersion || 'auto');
+	let selectedSort = $state('relevance');
 
 	let detailOpen = $state(false);
 	let detailLoading = $state(false);
@@ -105,6 +108,10 @@
 
 			if (selectedVersion !== 'auto') {
 				params.set('gameVersion', selectedVersion);
+			}
+
+			if (selectedSort !== 'relevance') {
+				params.set('sortBy', selectedSort);
 			}
 
 			const res = await fetch(
@@ -214,6 +221,7 @@
 
 <div class="search-container">
 	<div class="search-controls">
+		{#if typeTabs}{@render typeTabs()}{/if}
 		<input
 			type="text"
 			bind:value={searchQuery}
@@ -223,23 +231,40 @@
 		/>
 
 		<div class="filters">
-			<select bind:value={selectedLoader} onchange={scheduleSearch}>
-				{#each loaderOptions as option}
-					<option value={option.value}>{option.label}</option>
-				{/each}
-			</select>
+			<label class="filter-group">
+				<span class="filter-label">Loader</span>
+				<select bind:value={selectedLoader} onchange={scheduleSearch}>
+					{#each loaderOptions as option}
+						<option value={option.value}>{option.label}</option>
+					{/each}
+				</select>
+			</label>
 
-			<select bind:value={selectedVersion} onchange={scheduleSearch}>
-				{#each commonMinecraftVersions as version}
-					<option value={version}>
-						{version === 'auto'
-							? detectedVersion
-								? `Auto (${detectedVersion})`
-								: 'Auto (server)'
-							: version}
-					</option>
-				{/each}
-			</select>
+			<label class="filter-group">
+				<span class="filter-label">Version</span>
+				<select bind:value={selectedVersion} onchange={scheduleSearch}>
+					{#each commonMinecraftVersions as version}
+						<option value={version}>
+							{version === 'auto'
+								? detectedVersion
+									? `Auto (${detectedVersion})`
+									: 'Auto'
+								: version}
+						</option>
+					{/each}
+				</select>
+			</label>
+
+			<label class="filter-group">
+				<span class="filter-label">Sort</span>
+				<select bind:value={selectedSort} onchange={scheduleSearch}>
+					<option value="relevance">Relevance</option>
+					<option value="downloads">Downloads</option>
+					<option value="follows">Follows</option>
+					<option value="newest">Newest</option>
+					<option value="updated">Updated</option>
+				</select>
+			</label>
 		</div>
 	</div>
 
@@ -351,10 +376,6 @@
 
 <style>
 	.search-container {
-		background: #1a1e2f;
-		border-radius: 16px;
-		padding: 20px;
-		box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
 		display: flex;
 		flex-direction: column;
 		gap: 16px;
@@ -385,6 +406,21 @@
 		display: flex;
 		gap: 12px;
 		flex-wrap: wrap;
+	}
+
+	.filter-group {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.filter-label {
+		font-size: 11px;
+		color: #6b7190;
+		white-space: nowrap;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		font-weight: 600;
 	}
 
 	.filters select {

--- a/apps/web/src/lib/components/ModrinthModpackSearch.svelte
+++ b/apps/web/src/lib/components/ModrinthModpackSearch.svelte
@@ -7,14 +7,17 @@
 		ModrinthProject,
 		ModrinthVersion
 	} from '$lib/api/types';
+	import type { Snippet } from 'svelte';
 	import ProgressBar from './ProgressBar.svelte';
 
 	interface Props {
 		serverName: string;
+		serverVersion?: string | null;
 		onInstallComplete?: () => void;
+		typeTabs?: Snippet;
 	}
 
-	let { serverName, onInstallComplete }: Props = $props();
+	let { serverName, serverVersion, onInstallComplete, typeTabs }: Props = $props();
 
 	let searchQuery = $state('');
 	let searchResults = $state<ModrinthProjectHit[]>([]);
@@ -28,6 +31,7 @@
 
 	let selectedLoader = $state('auto');
 	let selectedVersion = $state('auto');
+	let selectedSort = $state('relevance');
 
 	let detailOpen = $state(false);
 	let detailLoading = $state(false);
@@ -106,6 +110,10 @@
 
 			if (selectedVersion !== 'auto') {
 				params.set('gameVersion', selectedVersion);
+			}
+
+			if (selectedSort !== 'relevance') {
+				params.set('sortBy', selectedSort);
 			}
 
 			const res = await fetch(
@@ -273,6 +281,7 @@
 
 <div class="search-container">
 	<div class="search-controls">
+		{#if typeTabs}{@render typeTabs()}{/if}
 		<input
 			type="text"
 			bind:value={searchQuery}
@@ -282,17 +291,34 @@
 		/>
 
 		<div class="filters">
-			<select bind:value={selectedLoader} onchange={scheduleSearch}>
-				{#each loaderOptions as option}
-					<option value={option.value}>{option.label}</option>
-				{/each}
-			</select>
+			<label class="filter-group">
+				<span class="filter-label">Loader</span>
+				<select bind:value={selectedLoader} onchange={scheduleSearch}>
+					{#each loaderOptions as option}
+						<option value={option.value}>{option.label}</option>
+					{/each}
+				</select>
+			</label>
 
-			<select bind:value={selectedVersion} onchange={scheduleSearch}>
-				{#each commonMinecraftVersions as version}
-					<option value={version}>{version === 'auto' ? 'Auto (server)' : version}</option>
-				{/each}
-			</select>
+			<label class="filter-group">
+				<span class="filter-label">Version</span>
+				<select bind:value={selectedVersion} onchange={scheduleSearch}>
+					{#each commonMinecraftVersions as version}
+						<option value={version}>{version === 'auto' ? 'Auto' : version}</option>
+					{/each}
+				</select>
+			</label>
+
+			<label class="filter-group">
+				<span class="filter-label">Sort</span>
+				<select bind:value={selectedSort} onchange={scheduleSearch}>
+					<option value="relevance">Relevance</option>
+					<option value="downloads">Downloads</option>
+					<option value="follows">Follows</option>
+					<option value="newest">Newest</option>
+					<option value="updated">Updated</option>
+				</select>
+			</label>
 		</div>
 	</div>
 
@@ -410,10 +436,6 @@
 
 <style>
 	.search-container {
-		background: #1a1e2f;
-		border-radius: 16px;
-		padding: 20px;
-		box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
 		display: flex;
 		flex-direction: column;
 		gap: 16px;
@@ -444,6 +466,21 @@
 		display: flex;
 		gap: 12px;
 		flex-wrap: wrap;
+	}
+
+	.filter-group {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.filter-label {
+		font-size: 11px;
+		color: #6b7190;
+		white-space: nowrap;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		font-weight: 600;
 	}
 
 	.filters select {

--- a/apps/web/src/lib/components/ModrinthResourcePackSearch.svelte
+++ b/apps/web/src/lib/components/ModrinthResourcePackSearch.svelte
@@ -7,14 +7,16 @@
 		ModrinthProject,
 		ModrinthVersion
 	} from '$lib/api/types';
+	import type { Snippet } from 'svelte';
 
 	interface Props {
 		serverName: string;
 		serverVersion?: string | null;
 		onInstallComplete?: () => void;
+		typeTabs?: Snippet;
 	}
 
-	let { serverName, serverVersion, onInstallComplete }: Props = $props();
+	let { serverName, serverVersion, onInstallComplete, typeTabs }: Props = $props();
 
 	let searchQuery = $state('');
 	let searchResults = $state<ModrinthProjectHit[]>([]);
@@ -29,6 +31,7 @@
 	// Auto-detect and set version from server
 	const detectedVersion = $derived(extractMinecraftVersion(serverVersion));
 	let selectedVersion = $state(detectedVersion || 'auto');
+	let selectedSort = $state('relevance');
 
 	let detailOpen = $state(false);
 	let detailLoading = $state(false);
@@ -93,6 +96,10 @@
 
 			if (selectedVersion !== 'auto') {
 				params.set('gameVersion', selectedVersion);
+			}
+
+			if (selectedSort !== 'relevance') {
+				params.set('sortBy', selectedSort);
 			}
 
 			const res = await fetch(
@@ -201,6 +208,7 @@
 
 <div class="search-container">
 	<div class="search-controls">
+		{#if typeTabs}{@render typeTabs()}{/if}
 		<input
 			type="text"
 			bind:value={searchQuery}
@@ -210,17 +218,31 @@
 		/>
 
 		<div class="filters">
-			<select bind:value={selectedVersion} onchange={scheduleSearch}>
-				{#each commonMinecraftVersions as version}
-					<option value={version}>
-						{version === 'auto'
-							? detectedVersion
-								? `Auto (${detectedVersion})`
-								: 'Auto (server)'
-							: version}
-					</option>
-				{/each}
-			</select>
+			<label class="filter-group">
+				<span class="filter-label">Version</span>
+				<select bind:value={selectedVersion} onchange={scheduleSearch}>
+					{#each commonMinecraftVersions as version}
+						<option value={version}>
+							{version === 'auto'
+								? detectedVersion
+									? `Auto (${detectedVersion})`
+									: 'Auto'
+								: version}
+						</option>
+					{/each}
+				</select>
+			</label>
+
+			<label class="filter-group">
+				<span class="filter-label">Sort</span>
+				<select bind:value={selectedSort} onchange={scheduleSearch}>
+					<option value="relevance">Relevance</option>
+					<option value="downloads">Downloads</option>
+					<option value="follows">Follows</option>
+					<option value="newest">Newest</option>
+					<option value="updated">Updated</option>
+				</select>
+			</label>
 		</div>
 	</div>
 
@@ -332,10 +354,6 @@
 
 <style>
 	.search-container {
-		background: #1a1e2f;
-		border-radius: 16px;
-		padding: 20px;
-		box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
 		display: flex;
 		flex-direction: column;
 		gap: 16px;
@@ -366,6 +384,21 @@
 		display: flex;
 		gap: 12px;
 		flex-wrap: wrap;
+	}
+
+	.filter-group {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+
+	.filter-label {
+		font-size: 11px;
+		color: #6b7190;
+		white-space: nowrap;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		font-weight: 600;
 	}
 
 	.filters select {

--- a/apps/web/src/lib/components/ModrinthSearch.svelte
+++ b/apps/web/src/lib/components/ModrinthSearch.svelte
@@ -14,44 +14,36 @@
 </script>
 
 <div class="modrinth-search">
-	<div class="search-controls">
-		<div class="type-tabs" role="tablist" aria-label="Modrinth content type">
-			<button
-				type="button"
-				class:active={searchType === 'mods'}
-				role="tab"
-				aria-selected={searchType === 'mods'}
-				onclick={() => (searchType = 'mods')}
-			>
-				Mods
-			</button>
-			<button
-				type="button"
-				class:active={searchType === 'modpacks'}
-				role="tab"
-				aria-selected={searchType === 'modpacks'}
-				onclick={() => (searchType = 'modpacks')}
-			>
-				Modpacks
-			</button>
-			<button
-				type="button"
-				class:active={searchType === 'resourcepacks'}
-				role="tab"
-				aria-selected={searchType === 'resourcepacks'}
-				onclick={() => (searchType = 'resourcepacks')}
-			>
-				Resource Packs
-			</button>
-		</div>
-	</div>
-
 	{#if searchType === 'mods'}
-		<ModrinthModSearch {serverName} {serverVersion} {onInstallComplete} />
+		<ModrinthModSearch {serverName} {serverVersion} {onInstallComplete}>
+			{#snippet typeTabs()}
+				<div class="type-tabs" role="tablist" aria-label="Modrinth content type">
+					<button type="button" class:active={searchType === 'mods'} role="tab" aria-selected={searchType === 'mods'} onclick={() => (searchType = 'mods')}>Mods</button>
+					<button type="button" class:active={searchType === 'modpacks'} role="tab" aria-selected={searchType === 'modpacks'} onclick={() => (searchType = 'modpacks')}>Modpacks</button>
+					<button type="button" class:active={searchType === 'resourcepacks'} role="tab" aria-selected={searchType === 'resourcepacks'} onclick={() => (searchType = 'resourcepacks')}>Resource Packs</button>
+				</div>
+			{/snippet}
+		</ModrinthModSearch>
 	{:else if searchType === 'modpacks'}
-		<ModrinthModpackSearch {serverName} {serverVersion} {onInstallComplete} />
+		<ModrinthModpackSearch {serverName} {serverVersion} {onInstallComplete}>
+			{#snippet typeTabs()}
+				<div class="type-tabs" role="tablist" aria-label="Modrinth content type">
+					<button type="button" class:active={searchType === 'mods'} role="tab" aria-selected={searchType === 'mods'} onclick={() => (searchType = 'mods')}>Mods</button>
+					<button type="button" class:active={searchType === 'modpacks'} role="tab" aria-selected={searchType === 'modpacks'} onclick={() => (searchType = 'modpacks')}>Modpacks</button>
+					<button type="button" class:active={searchType === 'resourcepacks'} role="tab" aria-selected={searchType === 'resourcepacks'} onclick={() => (searchType = 'resourcepacks')}>Resource Packs</button>
+				</div>
+			{/snippet}
+		</ModrinthModpackSearch>
 	{:else}
-		<ModrinthResourcePackSearch {serverName} {serverVersion} {onInstallComplete} />
+		<ModrinthResourcePackSearch {serverName} {serverVersion} {onInstallComplete}>
+			{#snippet typeTabs()}
+				<div class="type-tabs" role="tablist" aria-label="Modrinth content type">
+					<button type="button" class:active={searchType === 'mods'} role="tab" aria-selected={searchType === 'mods'} onclick={() => (searchType = 'mods')}>Mods</button>
+					<button type="button" class:active={searchType === 'modpacks'} role="tab" aria-selected={searchType === 'modpacks'} onclick={() => (searchType = 'modpacks')}>Modpacks</button>
+					<button type="button" class:active={searchType === 'resourcepacks'} role="tab" aria-selected={searchType === 'resourcepacks'} onclick={() => (searchType = 'resourcepacks')}>Resource Packs</button>
+				</div>
+			{/snippet}
+		</ModrinthResourcePackSearch>
 	{/if}
 </div>
 
@@ -59,14 +51,6 @@
 	.modrinth-search {
 		display: flex;
 		flex-direction: column;
-		gap: 16px;
-	}
-
-	.search-controls {
-		display: flex;
-		align-items: center;
-		gap: 12px;
-		flex-wrap: wrap;
 	}
 
 	.type-tabs {
@@ -85,6 +69,8 @@
 		border-radius: 8px;
 		cursor: pointer;
 		transition: all 0.2s;
+		font-family: inherit;
+		font-size: 13px;
 	}
 
 	.type-tabs button.active {

--- a/apps/web/src/routes/(app)/servers/[name]/mods/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/mods/+page.svelte
@@ -24,7 +24,18 @@
 	let clientPackageLoading = $state(false);
 	let clientPackageCreating = $state(false);
 	let clientPackageActions = $state<Record<string, boolean>>({});
+	let packageFormat = $state<'curseforge' | 'mrpack'>('curseforge');
+	let packageMcVersion = $state('');
+	let packageModLoader = $state('');
+	let packageModLoaderVersion = $state('');
+	let showPackageOptions = $state(false);
 	let serverVersion = $state<string | null>(null);
+	let clientMods = $state<InstalledModWithModpack[]>([]);
+	let clientModsLoading = $state(false);
+	let clientModUploading = $state(false);
+	let clientModUploadProgress = $state(0);
+	let clientModUploadingFileName = $state('');
+	let clientModIsDragging = $state(false);
 
 	const isServerRunning = $derived(data.server?.status === 'running');
 
@@ -34,6 +45,7 @@
 
 	$effect(() => {
 		loadMods();
+		loadClientMods();
 		loadClientPackages();
 	});
 
@@ -86,11 +98,128 @@
 		}
 	}
 
+	function reloadAll() {
+		loadMods();
+		loadClientMods();
+		loadClientPackages();
+	}
+
+	async function loadClientMods() {
+		if (!data.server) return;
+		clientModsLoading = true;
+		try {
+			const res = await fetch(`/api/servers/${data.server.name}/client-mods`);
+			if (res.ok) {
+				clientMods = await res.json();
+			}
+		} catch (err) {
+			console.error('Failed to load client mods:', err);
+		} finally {
+			clientModsLoading = false;
+		}
+	}
+
+	async function uploadClientMod(file: File) {
+		if (!data.server) return;
+		const fileName = file.name.toLowerCase();
+		if (!fileName.endsWith('.jar')) {
+			await modal.error(`Only .jar files are supported for client mods. Got: ${file.name}`);
+			return;
+		}
+
+		const serverName = data.server.name;
+		clientModUploading = true;
+		clientModUploadingFileName = file.name;
+		clientModUploadProgress = 0;
+
+		try {
+			const form = new FormData();
+			form.append('file', file);
+
+			const xhr = new XMLHttpRequest();
+			const uploadPromise = new Promise((resolve, reject) => {
+				xhr.upload.addEventListener('progress', (e) => {
+					if (e.lengthComputable) {
+						clientModUploadProgress = Math.round((e.loaded / e.total) * 100);
+					}
+				});
+				xhr.addEventListener('load', () => {
+					if (xhr.status >= 200 && xhr.status < 300) {
+						resolve(xhr.response);
+					} else {
+						reject(new Error(`Upload failed: ${xhr.statusText}`));
+					}
+				});
+				xhr.addEventListener('error', () => reject(new Error('Upload failed')));
+				xhr.addEventListener('abort', () => reject(new Error('Upload cancelled')));
+				xhr.open('POST', `/api/servers/${serverName}/client-mods/upload`);
+				xhr.send(form);
+			});
+
+			await uploadPromise;
+			await loadClientMods();
+		} catch (err) {
+			await modal.error(err instanceof Error ? err.message : `Upload failed for ${file.name}`);
+		} finally {
+			clientModUploading = false;
+			clientModUploadProgress = 0;
+			clientModUploadingFileName = '';
+		}
+	}
+
+	function handleClientModUpload(event: Event) {
+		const input = event.target as HTMLInputElement;
+		const files = Array.from(input.files || []);
+		for (const file of files) {
+			uploadClientMod(file);
+		}
+		input.value = '';
+	}
+
+	function handleClientModDrop(event: DragEvent) {
+		event.preventDefault();
+		clientModIsDragging = false;
+		const files = Array.from(event.dataTransfer?.files || []);
+		for (const file of files) {
+			uploadClientMod(file);
+		}
+	}
+
+	async function deleteClientMod(fileName: string) {
+		if (!data.server) return;
+		const confirmed = await modal.confirm(`Delete client mod "${fileName}"?`, 'Delete Client Mod');
+		if (!confirmed) return;
+
+		try {
+			const res = await fetch(
+				`/api/servers/${data.server.name}/client-mods/${encodeURIComponent(fileName)}`,
+				{ method: 'DELETE' }
+			);
+			if (!res.ok) {
+				const payload = await res.json().catch(() => ({}));
+				await modal.error(payload.error || 'Failed to delete client mod');
+			} else {
+				await loadClientMods();
+			}
+		} catch (err) {
+			await modal.error(err instanceof Error ? err.message : 'Delete failed');
+		}
+	}
+
 	async function createClientPackage() {
 		if (!data.server) return;
 		clientPackageCreating = true;
 		try {
-			const res = await fetch(`/api/servers/${data.server.name}/client-packages`, { method: 'POST' });
+			const body: Record<string, string> = { format: packageFormat };
+			if (packageMcVersion.trim()) body.minecraftVersion = packageMcVersion.trim();
+			if (packageModLoader.trim()) body.modLoader = packageModLoader.trim();
+			if (packageModLoaderVersion.trim()) body.modLoaderVersion = packageModLoaderVersion.trim();
+
+			const res = await fetch(`/api/servers/${data.server.name}/client-packages`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body)
+			});
 			if (res.ok) {
 				await loadClientPackages();
 			} else {
@@ -178,7 +307,7 @@
 				const payload = await res.json().catch(() => ({}));
 				await modal.error(payload.error || 'Failed to uninstall modpack');
 			} else {
-				await loadMods();
+				reloadAll();
 			}
 		} catch (err) {
 			await modal.error(err instanceof Error ? err.message : 'Uninstall failed');
@@ -365,260 +494,407 @@
 
 <div class="page">
 	<div class="page-header">
-		<div>
-			<h2>Mods</h2>
-			<p class="subtitle">Upload, manage, and install mods for this server</p>
-		</div>
-		<div class="action-buttons">
-			{#if groupedMods.standalone.length > 0}
-				<button
-					class="delete-all-btn"
-					onclick={deleteAllMods}
-					disabled={deletingAll || isServerRunning}
-					title={isServerRunning
-						? 'Stop server to delete mods'
-						: `Delete all ${groupedMods.standalone.length} standalone mods from this server`}
-				>
-					{deletingAll ? 'Deleting...' : `Delete All Mods (${groupedMods.standalone.length})`}
-				</button>
-			{/if}
-			<label class="upload-button">
-				<input
-					type="file"
-					accept=".jar,.zip,.tar,.tar.gz,.tgz"
-					multiple
-					onchange={handleUpload}
-					disabled={uploading}
-				/>
-				{uploading ? 'Uploading...' : 'Upload Mods'}
-			</label>
-		</div>
+		<h2>Mods</h2>
+		<p class="subtitle">Upload, manage, and install mods for this server</p>
 	</div>
 
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
-	<div
-		class="upload-drop"
-		class:active={isDragging}
-		ondragover={(event) => {
-			event.preventDefault();
-			isDragging = true;
-		}}
-		ondragleave={() => {
-			isDragging = false;
-		}}
-		ondrop={handleDrop}
-	>
-		<div class="drop-content">
-			<strong>Drag & drop</strong> mod files here (.jar, .zip, .tar, .tar.gz), or use Upload Mods button
-			above.
-		</div>
-	</div>
-
-	<!-- Upload Progress -->
-	{#if uploading}
-		<div class="upload-progress-container">
-			<div class="progress-header">
-				<span class="progress-title">Uploading: {uploadingFileName}</span>
+	<!-- Server Mods -->
+	<div class="mods-section">
+		<div class="section-header">
+			<h3>Server Mods</h3>
+			<div class="section-actions">
+				{#if groupedMods.standalone.length > 0}
+					<button
+						class="delete-all-btn"
+						onclick={deleteAllMods}
+						disabled={deletingAll || isServerRunning}
+						title={isServerRunning
+							? 'Stop server to delete mods'
+							: `Delete all ${groupedMods.standalone.length} standalone mods`}
+					>
+						{deletingAll ? 'Deleting...' : `Delete All (${groupedMods.standalone.length})`}
+					</button>
+				{/if}
+				<label class="upload-button small">
+					<input
+						type="file"
+						accept=".jar,.zip,.tar,.tar.gz,.tgz"
+						multiple
+						onchange={handleUpload}
+						disabled={uploading}
+					/>
+					{uploading ? 'Uploading...' : 'Upload'}
+				</label>
 			</div>
-			<ProgressBar value={uploadProgress} color="green" size="sm" showLabel />
-			{#if uploadProgress === 100}
-				<p class="progress-message">Processing and extracting files...</p>
-			{/if}
 		</div>
-	{/if}
 
-	<!-- Installed Modpacks -->
-	{#if modpacks.length > 0}
-		<div class="mods-section">
-			<h3>Installed Modpacks</h3>
-			<div class="modpack-list">
-				{#each modpacks as modpack}
-					<div class="modpack-card">
-						<div class="modpack-header">
-							{#if modpack.logoUrl}
-								<img class="modpack-logo" src={modpack.logoUrl} alt={modpack.name} />
-							{:else}
-								<div class="modpack-logo-placeholder"></div>
-							{/if}
-							<div class="modpack-info">
-								<h4>{modpack.name}</h4>
-								<p class="modpack-meta">
-									{modpack.modCount} mods
-									{#if modpack.version}
-										<span class="separator">|</span>
-										{modpack.version}
-									{/if}
-								</p>
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div
+			class="upload-drop"
+			class:active={isDragging}
+			ondragover={(event) => {
+				event.preventDefault();
+				isDragging = true;
+			}}
+			ondragleave={() => {
+				isDragging = false;
+			}}
+			ondrop={handleDrop}
+		>
+			<div class="drop-content">
+				<strong>Drag & drop</strong> mod files here (.jar, .zip, .tar, .tar.gz)
+			</div>
+		</div>
+
+		{#if uploading}
+			<div class="upload-progress-container">
+				<div class="progress-header">
+					<span class="progress-title">Uploading: {uploadingFileName}</span>
+				</div>
+				<ProgressBar value={uploadProgress} color="green" size="sm" showLabel />
+				{#if uploadProgress === 100}
+					<p class="progress-message">Processing and extracting files...</p>
+				{/if}
+			</div>
+		{/if}
+
+		<!-- Installed Modpacks -->
+		{#if modpacks.length > 0}
+			<div class="subsection">
+				<h4>Installed Modpacks</h4>
+				<div class="modpack-list">
+					{#each modpacks as modpack}
+						<div class="modpack-card">
+							<div class="modpack-header">
+								{#if modpack.logoUrl}
+									<img class="modpack-logo" src={modpack.logoUrl} alt={modpack.name} />
+								{:else}
+									<div class="modpack-logo-placeholder"></div>
+								{/if}
+								<div class="modpack-info">
+									<h4>{modpack.name}</h4>
+									<p class="modpack-meta">
+										{modpack.modCount} mods
+										{#if modpack.version}
+											<span class="separator">|</span>
+											{modpack.version}
+										{/if}
+									</p>
+								</div>
+								<button
+									class="btn-action danger"
+									onclick={() => uninstallModpack(modpack.id, modpack.name)}
+									disabled={uninstallingModpack === modpack.id || isServerRunning}
+									title={isServerRunning ? 'Stop server to uninstall' : ''}
+								>
+									{uninstallingModpack === modpack.id ? 'Removing...' : 'Uninstall'}
+								</button>
 							</div>
-							<button
-								class="btn-action danger"
-								onclick={() => uninstallModpack(modpack.id, modpack.name)}
-								disabled={uninstallingModpack === modpack.id || isServerRunning}
-								title={isServerRunning ? 'Stop server to uninstall' : ''}
-							>
-								{uninstallingModpack === modpack.id ? 'Removing...' : 'Uninstall'}
-							</button>
+							{#if groupedMods.grouped[modpack.id]?.length}
+								<details class="modpack-mods">
+									<summary>View {groupedMods.grouped[modpack.id].length} mods</summary>
+									<ul class="mod-file-list">
+										{#each groupedMods.grouped[modpack.id] as mod}
+											<li class:disabled={mod.isDisabled}>
+												<span class="mod-name">{mod.fileName}</span>
+												<span class="mod-size">{formatBytes(mod.sizeBytes)}</span>
+											</li>
+										{/each}
+									</ul>
+								</details>
+							{/if}
 						</div>
-						{#if groupedMods.grouped[modpack.id]?.length}
-							<details class="modpack-mods">
-								<summary>View {groupedMods.grouped[modpack.id].length} mods</summary>
-								<ul class="mod-file-list">
-									{#each groupedMods.grouped[modpack.id] as mod}
-										<li class:disabled={mod.isDisabled}>
-											<span class="mod-name">{mod.fileName}</span>
-											<span class="mod-size">{formatBytes(mod.sizeBytes)}</span>
-										</li>
-									{/each}
-								</ul>
-							</details>
-						{/if}
+					{/each}
+				</div>
+			</div>
+		{/if}
+
+		<!-- All Mod Files -->
+		<details class="server-mods-details">
+			<summary>
+				<h4>All Files{#if !loading && mods.length > 0} <span class="mod-count">({mods.length})</span>{/if}</h4>
+			</summary>
+			{#if loading}
+				<p class="muted">Loading mods...</p>
+			{:else if mods.length === 0}
+				<p class="muted">No server mods installed.</p>
+			{:else}
+				<div class="mod-list">
+					<table>
+						<thead>
+							<tr>
+								<th>Name</th>
+								<th>Source</th>
+								<th>Size</th>
+								<th>Modified</th>
+								<th>Actions</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each mods as mod}
+								<tr class:modpack-mod={!!mod.modpackName}>
+									<td>
+										<span class:disabled={mod.isDisabled}>{mod.fileName}</span>
+									</td>
+									<td>
+										{#if mod.modpackName}
+											<span class="source-badge modpack">{mod.modpackName}</span>
+										{:else}
+											<span class="source-badge manual">Manual</span>
+										{/if}
+									</td>
+									<td>{formatBytes(mod.sizeBytes)}</td>
+									<td>{new Date(mod.modifiedAt).toLocaleString()}</td>
+									<td class="actions">
+										<a
+											class="btn-action"
+											href={`/api/servers/${data.server?.name}/mods/${encodeURIComponent(
+												mod.fileName
+											)}/download`}
+											download={mod.fileName}
+										>
+											Download
+										</a>
+										<button
+											class="btn-action danger"
+											onclick={() => deleteMod(mod.fileName)}
+											disabled={isServerRunning}
+											title={isServerRunning ? 'Stop server to delete' : ''}
+										>
+											Delete
+										</button>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		</details>
+
+		<!-- Install from CurseForge -->
+		<div class="subsection">
+			<h4>Install from CurseForge</h4>
+			<CurseForgeSearch serverName={data.server?.name ?? ''} {serverVersion} onInstallComplete={reloadAll} />
+		</div>
+
+		<!-- Install from Modrinth -->
+		<div class="subsection">
+			<h4>Install from Modrinth</h4>
+			<ModrinthSearch serverName={data.server?.name ?? ''} {serverVersion} onInstallComplete={reloadAll} />
+		</div>
+	</div>
+
+	<!-- Client Distribution -->
+	<div class="mods-section">
+		<div class="section-header">
+			<h3>Client Distribution</h3>
+			<p class="muted">
+				Manage client-only mods and generate downloadable packages for players to import into their launcher.
+			</p>
+		</div>
+
+		<!-- Client-Only Mods -->
+		<div class="subsection">
+			<div class="client-mods-header">
+				<h4>Client-Only Mods{#if clientMods.length > 0} <span class="mod-count">({clientMods.length})</span>{/if}</h4>
+				<label class="upload-button small">
+					<input
+						type="file"
+						accept=".jar"
+						multiple
+						onchange={handleClientModUpload}
+						disabled={clientModUploading}
+					/>
+					{clientModUploading ? 'Uploading...' : 'Upload'}
+				</label>
+			</div>
+			<p class="muted">
+				These mods are included in client packages but not loaded by the server.
+				Useful for minimaps, shaders, performance mods, and visual enhancements.
+			</p>
+
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<div
+				class="upload-drop"
+				class:active={clientModIsDragging}
+				ondragover={(event) => {
+					event.preventDefault();
+					clientModIsDragging = true;
+				}}
+				ondragleave={() => {
+					clientModIsDragging = false;
+				}}
+				ondrop={handleClientModDrop}
+			>
+				<div class="drop-content">
+					<strong>Drag & drop</strong> client mod files here (.jar)
+				</div>
+			</div>
+
+			{#if clientModUploading}
+				<div class="upload-progress-container">
+					<div class="progress-header">
+						<span class="progress-title">Uploading: {clientModUploadingFileName}</span>
 					</div>
-				{/each}
-			</div>
-		</div>
-	{/if}
+					<ProgressBar value={clientModUploadProgress} color="green" size="sm" showLabel />
+				</div>
+			{/if}
 
-	<!-- Client-Only Mods Info -->
-	<div class="mods-section info-section">
-		<h3>Client-Only Mods</h3>
-		<p class="muted">
-			You can create a <code>client-mods/mods</code> folder in your server directory to store mods that should only be packaged for clients and NOT run on the server.
-		</p>
-		<p class="muted">
-			These are useful for client-side mods like minimap, performance mods, or visual enhancements that don't need to be on the server.
-		</p>
-		<p class="muted">
-			When you generate a client package, these mods will be included automatically.
-		</p>
-	</div>
-
-	<!-- Standalone Mods -->
-	<div class="mods-section">
-		<h3>Server Mods</h3>
-		{#if loading}
-			<p class="muted">Loading mods...</p>
-		{:else if groupedMods.standalone.length === 0}
-			<p class="muted">No server mods installed.</p>
-		{:else}
-			<div class="mod-list">
-				<table>
-					<thead>
-						<tr>
-							<th>Name</th>
-							<th>Size</th>
-							<th>Modified</th>
-							<th>Actions</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each groupedMods.standalone as mod}
+			{#if clientModsLoading}
+				<p class="muted">Loading client mods...</p>
+			{:else if clientMods.length === 0}
+				<p class="muted">No client-only mods yet. They are added automatically when installing modpacks, or you can upload them manually.</p>
+			{:else}
+				<div class="mod-list">
+					<table>
+						<thead>
 							<tr>
-								<td>
-									<span class:disabled={mod.isDisabled}>{mod.fileName}</span>
-								</td>
-								<td>{formatBytes(mod.sizeBytes)}</td>
-								<td>{new Date(mod.modifiedAt).toLocaleString()}</td>
-								<td class="actions">
-									<a
-										class="btn-action"
-										href={`/api/servers/${data.server?.name}/mods/${encodeURIComponent(
-											mod.fileName
-										)}/download`}
-										download={mod.fileName}
-									>
-										Download
-									</a>
-									<button
-										class="btn-action danger"
-										onclick={() => deleteMod(mod.fileName)}
-										disabled={isServerRunning}
-										title={isServerRunning ? 'Stop server to delete' : ''}
-									>
-										Delete
-									</button>
-								</td>
+								<th>Name</th>
+								<th>Source</th>
+								<th>Size</th>
+								<th>Modified</th>
+								<th>Actions</th>
 							</tr>
-						{/each}
-					</tbody>
-				</table>
-			</div>
-		{/if}
-	</div>
+						</thead>
+						<tbody>
+							{#each clientMods as mod}
+								<tr>
+									<td>
+										<span class:disabled={mod.isDisabled}>{mod.fileName}</span>
+									</td>
+									<td>
+										{#if mod.modpackName}
+											<span class="source-badge modpack">{mod.modpackName}</span>
+										{:else}
+											<span class="source-badge manual">Manual</span>
+										{/if}
+									</td>
+									<td>{formatBytes(mod.sizeBytes)}</td>
+									<td>{new Date(mod.modifiedAt).toLocaleString()}</td>
+									<td class="actions">
+										<a
+											class="btn-action"
+											href={`/api/servers/${data.server?.name}/client-mods/${encodeURIComponent(mod.fileName)}/download`}
+											download={mod.fileName}
+										>
+											Download
+										</a>
+										<button
+											class="btn-action danger"
+											onclick={() => deleteClientMod(mod.fileName)}
+										>
+											Delete
+										</button>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		</div>
 
-	<!-- Client Packages -->
-	<div class="mods-section">
-		<div class="client-package-header">
-			<div>
-				<h3>Client Package</h3>
-				<p class="muted">
-					Generate a modpack zip containing all mods, configs, resource packs, and other client assets from this server.
-				</p>
-				<p class="muted">
-					The package is CurseForge-compatible and can be imported into any launcher that supports CurseForge format.
-				</p>
-				<p class="muted">
-					CurseForge app: Create Custom Profile → Import → select the zip.
-				</p>
+		<!-- Generate Package -->
+		<div class="subsection">
+			<h4>Generate Package</h4>
+			<p class="muted">
+				Bundles all server mods, client-only mods, configs, resource packs, and other assets into a single file.
+				Share the download link with friends.
+			</p>
+
+			<div class="format-selector">
+				<button class="format-btn" class:active={packageFormat === 'curseforge'} onclick={() => packageFormat = 'curseforge'}>
+					CurseForge (.zip)
+				</button>
+				<button class="format-btn" class:active={packageFormat === 'mrpack'} onclick={() => packageFormat = 'mrpack'}>
+					Modrinth (.mrpack)
+				</button>
 			</div>
-			<button class="btn-action" onclick={createClientPackage} disabled={clientPackageCreating}>
-				{clientPackageCreating ? 'Generating...' : 'Generate Package'}
+
+			<button class="toggle-options" onclick={() => showPackageOptions = !showPackageOptions}>
+				{showPackageOptions ? 'Hide' : 'Show'} Advanced Options
 			</button>
-		</div>
 
-		{#if clientPackageLoading}
-			<p class="muted">Loading client packages...</p>
-		{:else if clientPackages.length === 0}
-			<p class="muted">No client packages yet.</p>
-		{:else}
-			<div class="mod-list">
-				<table>
-					<thead>
-						<tr>
-							<th>Filename</th>
-							<th>Created</th>
-							<th>Size</th>
-							<th>Actions</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each clientPackages as pkg}
+			{#if showPackageOptions}
+				<div class="package-options">
+					<p class="muted" style="margin-bottom: 12px;">
+						These are auto-detected when possible. Only fill in if auto-detection fails or you need to override.
+					</p>
+					<div class="option-row">
+						<label for="pkg-mc-version">Minecraft Version</label>
+						<input id="pkg-mc-version" type="text" bind:value={packageMcVersion} placeholder="e.g. 1.20.1 (auto-detected)" />
+					</div>
+					<div class="option-row">
+						<label for="pkg-mod-loader">Mod Loader</label>
+						<select id="pkg-mod-loader" bind:value={packageModLoader}>
+							<option value="">Auto-detect</option>
+							<option value="forge">Forge</option>
+							<option value="neoforge">NeoForge</option>
+							<option value="fabric">Fabric</option>
+							<option value="quilt">Quilt</option>
+						</select>
+					</div>
+					<div class="option-row">
+						<label for="pkg-loader-version">Loader Version</label>
+						<input id="pkg-loader-version" type="text" bind:value={packageModLoaderVersion} placeholder="e.g. 47.2.0 (auto-detected)" />
+					</div>
+				</div>
+			{/if}
+
+			<button class="btn-action generate-btn" onclick={createClientPackage} disabled={clientPackageCreating}>
+				{clientPackageCreating ? 'Generating...' : `Generate ${packageFormat === 'mrpack' ? '.mrpack' : 'CurseForge'} Package`}
+			</button>
+
+			{#if clientPackageLoading}
+				<p class="muted">Loading packages...</p>
+			{:else if clientPackages.length === 0}
+				<p class="muted">No packages generated yet.</p>
+			{:else}
+				<div class="mod-list">
+					<table>
+						<thead>
 							<tr>
-								<td>{pkg.filename}</td>
-								<td>{formatDate(pkg.time)}</td>
-								<td>{formatBytes(pkg.size)}</td>
-								<td class="actions">
-									<button class="btn-action" onclick={() => downloadClientPackage(pkg.filename)}>
-										Download
-									</button>
-									<button class="btn-action" onclick={() => copyClientPackageLink(pkg.filename)}>
-										Copy Link
-									</button>
-									<button
-										class="btn-action danger"
-										onclick={() => deleteClientPackage(pkg.filename)}
-										disabled={clientPackageActions[pkg.filename]}
-									>
-										{clientPackageActions[pkg.filename] ? 'Deleting...' : 'Delete'}
-									</button>
-								</td>
+								<th>Format</th>
+								<th>Filename</th>
+								<th>Created</th>
+								<th>Size</th>
+								<th>Actions</th>
 							</tr>
-						{/each}
-					</tbody>
-				</table>
-			</div>
-		{/if}
-	</div>
-
-	<!-- CurseForge Install -->
-	<div class="curseforge-section">
-		<h3>Install from CurseForge</h3>
-		<CurseForgeSearch serverName={data.server?.name ?? ''} {serverVersion} onInstallComplete={loadMods} />
-	</div>
-
-	<!-- Modrinth Install -->
-	<div class="modrinth-section">
-		<h3>Install from Modrinth</h3>
-		<ModrinthSearch serverName={data.server?.name ?? ''} {serverVersion} onInstallComplete={loadMods} />
+						</thead>
+						<tbody>
+							{#each clientPackages as pkg}
+								<tr>
+									<td>
+										<span class="format-badge" class:mrpack={pkg.format === 'mrpack'} class:curseforge={pkg.format === 'curseforge'}>
+											{pkg.format === 'mrpack' ? 'Modrinth' : 'CurseForge'}
+										</span>
+									</td>
+									<td>{pkg.filename}</td>
+									<td>{formatDate(pkg.time)}</td>
+									<td>{formatBytes(pkg.size)}</td>
+									<td class="actions">
+										<button class="btn-action" onclick={() => downloadClientPackage(pkg.filename)}>
+											Download
+										</button>
+										<button class="btn-action" onclick={() => copyClientPackageLink(pkg.filename)}>
+											Copy Link
+										</button>
+										<button
+											class="btn-action danger"
+											onclick={() => deleteClientPackage(pkg.filename)}
+											disabled={clientPackageActions[pkg.filename]}
+										>
+											{clientPackageActions[pkg.filename] ? 'Deleting...' : 'Delete'}
+										</button>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			{/if}
+		</div>
 	</div>
 </div>
 
@@ -629,16 +905,8 @@
 		gap: 24px;
 	}
 
-	.page-header {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-		gap: 24px;
-		flex-wrap: wrap;
-	}
-
-	h2 {
-		margin: 0 0 8px;
+	.page-header h2 {
+		margin: 0 0 4px;
 		font-size: 24px;
 		font-weight: 600;
 	}
@@ -649,21 +917,37 @@
 		font-size: 14px;
 	}
 
-	.action-buttons {
-		display: flex;
-		gap: 12px;
-	}
-
-	.client-package-header {
+	.section-header {
 		display: flex;
 		justify-content: space-between;
-		align-items: center;
-		gap: 16px;
+		align-items: flex-start;
+		gap: 12px;
 		flex-wrap: wrap;
 	}
 
-	.client-package-header h3 {
-		margin: 0 0 6px;
+	.section-header h3 {
+		margin: 0;
+	}
+
+	.section-actions {
+		display: flex;
+		gap: 8px;
+		align-items: center;
+	}
+
+	.subsection {
+		background: #141827;
+		border-radius: 12px;
+		padding: 16px;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.subsection h4 {
+		margin: 0;
+		font-size: 15px;
+		font-weight: 600;
 	}
 
 	.upload-drop {
@@ -700,7 +984,7 @@
 		display: none;
 	}
 
-	.mods-section, .curseforge-section, .modrinth-section {
+	.mods-section {
 		background: #1a1e2f;
 		border-radius: 16px;
 		padding: 20px;
@@ -710,18 +994,16 @@
 		gap: 16px;
 	}
 
-	.info-section {
-		background: rgba(106, 176, 76, 0.08);
-		border: 1px solid rgba(106, 176, 76, 0.2);
+	.client-mods-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 12px;
 	}
 
-	.info-section code {
-		background: rgba(0, 0, 0, 0.3);
-		padding: 2px 6px;
-		border-radius: 4px;
-		font-family: 'Consolas', 'Monaco', monospace;
+	.upload-button.small {
+		padding: 6px 14px;
 		font-size: 13px;
-		color: #b7f5a2;
 	}
 
 
@@ -747,6 +1029,68 @@
 
 	td {
 		color: #eef0f8;
+	}
+
+	.server-mods-details summary {
+		cursor: pointer;
+		list-style: none;
+		user-select: none;
+	}
+
+	.server-mods-details summary::-webkit-details-marker {
+		display: none;
+	}
+
+	.server-mods-details summary h4 {
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		margin: 0;
+		font-size: 15px;
+		font-weight: 600;
+	}
+
+	.server-mods-details summary h4::before {
+		content: '\25B6';
+		font-size: 10px;
+		color: #8890b1;
+		transition: transform 0.2s;
+	}
+
+	.server-mods-details[open] summary h4::before {
+		transform: rotate(90deg);
+	}
+
+	.mod-count {
+		font-weight: 400;
+		color: #8890b1;
+		font-size: 14px;
+	}
+
+	.modpack-mod td {
+		opacity: 0.55;
+	}
+
+	.modpack-mod:hover td {
+		opacity: 0.85;
+	}
+
+	.source-badge {
+		font-size: 11px;
+		padding: 2px 8px;
+		border-radius: 4px;
+		font-weight: 600;
+		white-space: nowrap;
+	}
+
+	.source-badge.modpack {
+		background: rgba(138, 118, 255, 0.15);
+		color: #b0a0ff;
+	}
+
+	.source-badge.manual {
+		background: rgba(255, 255, 255, 0.06);
+		color: #8890b1;
 	}
 
 	.actions {
@@ -784,10 +1128,6 @@
 	.muted {
 		color: #8890b1;
 		margin: 0;
-	}
-
-	.curseforge-section h3 {
-		margin: 0 0 16px 0;
 	}
 
 	.modpack-list {
@@ -901,8 +1241,8 @@
 		color: #ff9f9f;
 		border: 1px solid rgba(255, 92, 92, 0.3);
 		border-radius: 8px;
-		padding: 10px 20px;
-		font-size: 14px;
+		padding: 6px 14px;
+		font-size: 13px;
 		font-weight: 600;
 		cursor: pointer;
 		transition: all 0.2s;
@@ -946,5 +1286,113 @@
 		color: #9aa2c5;
 		font-size: 13px;
 		font-style: italic;
+	}
+
+	.format-selector {
+		display: flex;
+		gap: 8px;
+	}
+
+	.format-btn {
+		background: #2b2f45;
+		color: #9aa2c5;
+		border: 1px solid #2a2f47;
+		border-radius: 8px;
+		padding: 8px 16px;
+		font-family: inherit;
+		font-size: 13px;
+		font-weight: 500;
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	.format-btn.active {
+		background: rgba(90, 107, 255, 0.2);
+		color: #a4b0ff;
+		border-color: #5a6bff;
+	}
+
+	.toggle-options {
+		background: none;
+		border: none;
+		color: #8890b1;
+		font-family: inherit;
+		font-size: 13px;
+		cursor: pointer;
+		padding: 0;
+		text-decoration: underline;
+		text-underline-offset: 3px;
+		align-self: flex-start;
+	}
+
+	.toggle-options:hover {
+		color: #d4d9f1;
+	}
+
+	.package-options {
+		background: #0d0f16;
+		border-radius: 12px;
+		padding: 16px;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.option-row {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+	}
+
+	.option-row label {
+		width: 140px;
+		flex-shrink: 0;
+		font-size: 13px;
+		color: #9aa2c5;
+	}
+
+	.option-row input,
+	.option-row select {
+		flex: 1;
+		background: #0d0f16;
+		border: 1px solid #2a2f47;
+		border-radius: 6px;
+		padding: 8px 12px;
+		color: #eef0f8;
+		font-family: inherit;
+		font-size: 13px;
+	}
+
+	.option-row select {
+		cursor: pointer;
+	}
+
+	.generate-btn {
+		align-self: flex-start;
+		padding: 10px 20px;
+		font-size: 14px;
+		font-weight: 600;
+		background: var(--mc-grass);
+		color: white;
+	}
+
+	.format-badge {
+		display: inline-block;
+		padding: 3px 8px;
+		border-radius: 4px;
+		font-size: 11px;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	.format-badge.curseforge {
+		background: rgba(241, 100, 54, 0.2);
+		color: #f1a472;
+	}
+
+	.format-badge.mrpack {
+		background: rgba(30, 200, 100, 0.2);
+		color: #7ae68d;
 	}
 </style>

--- a/apps/web/src/routes/client-packages/[server]/[filename]/+page.svelte
+++ b/apps/web/src/routes/client-packages/[server]/[filename]/+page.svelte
@@ -3,7 +3,8 @@
 
 	let { params }: { params: { server: string; filename: string } } = $props();
 
-	// Use $derived since params come from route and won't change during component lifetime
+	const isMrpack = $derived(params.filename.endsWith('.mrpack'));
+
 	const downloadPath = $derived(
 		`/api/servers/${encodeURIComponent(params.server)}/client-packages/${encodeURIComponent(params.filename)}/download?raw=1`
 	);
@@ -21,22 +22,34 @@
 		<h1>Install the Minecraft Pack</h1>
 		<p class="lead">Your download should start automatically.</p>
 
-		<div class="steps">
-			<h2>Steps (CurseForge App)</h2>
-			<ol>
-				<li>Open the CurseForge app.</li>
-				<li>Click <strong>Create Custom Profile</strong>.</li>
-				<li>Choose <strong>Import</strong> and pick the downloaded zip.</li>
-				<li>Launch the profile and join the server.</li>
-			</ol>
-		</div>
+		{#if isMrpack}
+			<div class="steps">
+				<h2>Steps (Prism / MultiMC / ATLauncher / Modrinth App)</h2>
+				<ol>
+					<li>Open your launcher (Prism Launcher, MultiMC, ATLauncher, or Modrinth App).</li>
+					<li>Click <strong>Add Instance</strong> or <strong>Import</strong>.</li>
+					<li>Select the downloaded <strong>.mrpack</strong> file.</li>
+					<li>Launch the instance and join the server.</li>
+				</ol>
+			</div>
+		{:else}
+			<div class="steps">
+				<h2>Steps (CurseForge App)</h2>
+				<ol>
+					<li>Open the CurseForge app.</li>
+					<li>Click <strong>Create Custom Profile</strong>.</li>
+					<li>Choose <strong>Import</strong> and pick the downloaded zip.</li>
+					<li>Launch the profile and join the server.</li>
+				</ol>
+			</div>
+		{/if}
 
 		<div class="actions">
 			<a class="btn-primary" href={downloadPath}>Download Again</a>
 		</div>
 
 		<p class="hint">
-			If you don’t see the download, check your browser downloads or click “Download Again.”
+			If you don't see the download, check your browser downloads or click "Download Again."
 		</p>
 	</div>
 </div>


### PR DESCRIPTION
## Summary
- **Client-only mod management**: Full CRUD for client-side mods with source tracking via JSON sidecar (`source-map.json`)
- **.mrpack client package generation**: Generate Modrinth-compatible modpacks for client distribution
- **Unified mods page UX**: Consolidated into two main cards (Server Mods / Client Distribution), collapsible file list, inline Modrinth type tabs via Svelte 5 snippets
- **Search improvements**: Modrinth sort support (relevance, downloads, follows, newest, updated), CurseForge version auto-detect, labeled filter dropdowns across both platforms
- **Source badges**: Visual origin indicators (CurseForge/Modrinth/Manual) for both server and client mods

## Test plan
- [ ] Upload client-only mods and verify source tracking
- [ ] Generate .mrpack package and verify it imports in a Modrinth-compatible launcher
- [ ] Install mods from CurseForge with version filter enabled
- [ ] Install mods from Modrinth with sort options
- [ ] Verify collapsible server mod list with 10+ mods
- [ ] Test all three Modrinth search types (Mods/Modpacks/Resource Packs)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)