### PR TITLE
feat: add Velocity proxy support (#63)

### DIFF
--- a/apps/MineOS.Api/Endpoints/ServerEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/ServerEndpoints.cs
@@ -290,6 +290,44 @@ public static class ServerEndpoints
             }
         });
 
+        // Velocity (proxy) configuration
+        servers.MapGet("/{name}/velocity-config", async (
+            string name,
+            IServerService serverService,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var config = await serverService.GetVelocityConfigAsync(name, cancellationToken);
+                return Results.Ok(config);
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+        });
+
+        servers.MapPut("/{name}/velocity-config", async (
+            string name,
+            [FromBody] VelocityConfigDto config,
+            IServerService serverService,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                await serverService.UpdateVelocityConfigAsync(name, config, cancellationToken);
+                return Results.Ok(new { message = "Velocity config updated" });
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Conflict(new { error = ex.Message });
+            }
+        });
+
         // Server config
         servers.MapGet("/{name}/server-config", async (
             string name,

--- a/apps/MineOS.Application/Dtos/VelocityConfigDto.cs
+++ b/apps/MineOS.Application/Dtos/VelocityConfigDto.cs
@@ -1,0 +1,18 @@
+namespace MineOS.Application.Dtos;
+
+public record VelocityConfigDto(
+    bool Exists,
+    string Bind,
+    string Motd,
+    int ShowMaxPlayers,
+    bool OnlineMode,
+    bool ForceKeyAuthentication,
+    bool PreventClientProxyConnections,
+    string PlayerInfoForwardingMode,
+    string ForwardingSecretFile,
+    bool AnnounceForge,
+    bool KickExistingPlayers,
+    string PingPassthrough,
+    bool EnablePlayerAddressLogging,
+    Dictionary<string, string> Servers,
+    List<string> Try);

--- a/apps/MineOS.Application/Dtos/VelocityConfigDto.cs
+++ b/apps/MineOS.Application/Dtos/VelocityConfigDto.cs
@@ -15,4 +15,5 @@ public record VelocityConfigDto(
     string PingPassthrough,
     bool EnablePlayerAddressLogging,
     Dictionary<string, string> Servers,
-    List<string> Try);
+    List<string> Try,
+    Dictionary<string, List<string>> ForcedHosts);

--- a/apps/MineOS.Application/Interfaces/IServerService.cs
+++ b/apps/MineOS.Application/Interfaces/IServerService.cs
@@ -26,6 +26,13 @@ public interface IServerService
     Task<VelocityConfigDto> GetVelocityConfigAsync(string name, CancellationToken cancellationToken);
     Task UpdateVelocityConfigAsync(string name, VelocityConfigDto config, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Returns the (host, port) the server listens on, branching on server type
+    /// (server.properties for java/bedrock, velocity.toml for proxy).
+    /// Returns null if neither config exists or the value is malformed.
+    /// </summary>
+    Task<(string Host, int Port)?> GetServerListenEndpointAsync(string name, CancellationToken cancellationToken);
+
     Task AcceptEulaAsync(string name, CancellationToken cancellationToken);
     Task RunFtbInstallerAsync(string name, CancellationToken cancellationToken);
 

--- a/apps/MineOS.Application/Interfaces/IServerService.cs
+++ b/apps/MineOS.Application/Interfaces/IServerService.cs
@@ -23,6 +23,8 @@ public interface IServerService
     Task UpdateServerPropertiesAsync(string name, Dictionary<string, string> properties, CancellationToken cancellationToken);
     Task<ServerConfigDto> GetServerConfigAsync(string name, CancellationToken cancellationToken);
     Task UpdateServerConfigAsync(string name, ServerConfigDto config, CancellationToken cancellationToken);
+    Task<VelocityConfigDto> GetVelocityConfigAsync(string name, CancellationToken cancellationToken);
+    Task UpdateVelocityConfigAsync(string name, VelocityConfigDto config, CancellationToken cancellationToken);
 
     Task AcceptEulaAsync(string name, CancellationToken cancellationToken);
     Task RunFtbInstallerAsync(string name, CancellationToken cancellationToken);

--- a/apps/MineOS.Infrastructure/MineOS.Infrastructure.csproj
+++ b/apps/MineOS.Infrastructure/MineOS.Infrastructure.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
+    <PackageReference Include="Tomlyn" Version="0.19.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/MineOS.Infrastructure/Services/HostService.cs
+++ b/apps/MineOS.Infrastructure/Services/HostService.cs
@@ -14,17 +14,20 @@ public sealed class HostService : IHostService
     private readonly ILogger<HostService> _logger;
     private readonly IProcessManager _processManager;
     private readonly IMonitoringService _monitoringService;
+    private readonly IServerService _serverService;
 
     public HostService(
         IOptions<HostOptions> options,
         ILogger<HostService> logger,
         IProcessManager processManager,
-        IMonitoringService monitoringService)
+        IMonitoringService monitoringService,
+        IServerService serverService)
     {
         _options = options.Value;
         _logger = logger;
         _processManager = processManager;
         _monitoringService = monitoringService;
+        _serverService = serverService;
     }
 
     public Task<HostMetricsDto> GetMetricsAsync(CancellationToken cancellationToken)
@@ -81,9 +84,9 @@ public sealed class HostService : IHostService
             var name = Path.GetFileName(dir);
             var props = TryReadProperties(Path.Combine(dir, "server.properties"));
 
-            var port = props.TryGetValue("server-port", out var portValue) && int.TryParse(portValue, out var portInt)
-                ? portInt
-                : (int?)null;
+            // server.properties for java/bedrock; velocity.toml bind for proxies.
+            var endpoint = await _serverService.GetServerListenEndpointAsync(name, cancellationToken);
+            var port = endpoint?.Port;
             var maxPlayers = props.TryGetValue("max-players", out var maxValue) && int.TryParse(maxValue, out var maxInt)
                 ? maxInt
                 : (int?)null;

--- a/apps/MineOS.Infrastructure/Services/MonitoringService.cs
+++ b/apps/MineOS.Infrastructure/Services/MonitoringService.cs
@@ -15,15 +15,18 @@ public sealed partial class MonitoringService : IMonitoringService
     private readonly ILogger<MonitoringService> _logger;
     private readonly IProcessManager _processManager;
     private readonly HostOptions _hostOptions;
+    private readonly IServerService _serverService;
 
     public MonitoringService(
         ILogger<MonitoringService> logger,
         IProcessManager processManager,
-        IOptions<HostOptions> hostOptions)
+        IOptions<HostOptions> hostOptions,
+        IServerService serverService)
     {
         _logger = logger;
         _processManager = processManager;
         _hostOptions = hostOptions.Value;
+        _serverService = serverService;
     }
 
     private string GetServerPath(string serverName) =>
@@ -60,22 +63,15 @@ public sealed partial class MonitoringService : IMonitoringService
     {
         try
         {
-            // Get server port from server.properties
-            var properties = await ReadPropertiesAsync(serverName, cancellationToken);
-            if (!properties.TryGetValue("server-port", out var portStr) || !int.TryParse(portStr, out var port))
+            // ServerService picks the right config (server.properties for java/bedrock,
+            // velocity.toml for proxy) so the SLP ping reaches the actual listener.
+            var endpoint = await _serverService.GetServerListenEndpointAsync(serverName, cancellationToken);
+            if (endpoint is null)
             {
-                port = 25565; // Default Minecraft port
+                return null;
             }
 
-            var host = "127.0.0.1";
-            if (properties.TryGetValue("server-ip", out var ip) &&
-                !string.IsNullOrWhiteSpace(ip) &&
-                !ip.Equals("0.0.0.0", StringComparison.OrdinalIgnoreCase))
-            {
-                host = ip;
-            }
-
-            return await MinecraftPingClient.PingAsync(host, port, cancellationToken);
+            return await MinecraftPingClient.PingAsync(endpoint.Value.Host, endpoint.Value.Port, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/apps/MineOS.Infrastructure/Services/ProfileService.cs
+++ b/apps/MineOS.Infrastructure/Services/ProfileService.cs
@@ -20,12 +20,18 @@ public sealed class ProfileService : IProfileService
         "https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar";
     private const string RestartFlagFile = ".mineos-restart-required";
     private const string PaperProjectUrl = "https://api.papermc.io/v2/projects/paper";
+    private const string VelocityProjectUrl = "https://api.papermc.io/v2/projects/velocity";
     private const string MojangVersionManifestUrl = "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json";
     private const int PaperVersionLimit = 20;
+    private const int VelocityVersionLimit = 10;
     private static readonly TimeSpan PaperCacheTtl = TimeSpan.FromMinutes(10);
     private static readonly SemaphoreSlim PaperCacheLock = new(1, 1);
     private static DateTimeOffset? _paperLastFetch;
     private static List<ProfileDto> _paperCache = new();
+    private static readonly TimeSpan VelocityCacheTtl = TimeSpan.FromMinutes(10);
+    private static readonly SemaphoreSlim VelocityCacheLock = new(1, 1);
+    private static DateTimeOffset? _velocityLastFetch;
+    private static List<ProfileDto> _velocityCache = new();
     private static readonly TimeSpan VanillaCacheTtl = TimeSpan.FromMinutes(10);
     private static readonly SemaphoreSlim VanillaCacheLock = new(1, 1);
     private static DateTimeOffset? _vanillaLastFetch;
@@ -93,6 +99,7 @@ public sealed class ProfileService : IProfileService
         var profiles = await LoadProfilesAsync(cancellationToken);
         var vanillaProfiles = await GetVanillaProfilesAsync(cancellationToken);
         var paperProfiles = await GetPaperProfilesAsync(cancellationToken);
+        var velocityProfiles = await GetVelocityProfilesAsync(cancellationToken);
         var buildToolsProfiles = await DiscoverBuildToolsProfilesAsync(cancellationToken);
         var bedrockProfiles = await GetBedrockProfilesAsync(cancellationToken);
         var combined = new Dictionary<string, ProfileDto>(StringComparer.OrdinalIgnoreCase);
@@ -108,6 +115,11 @@ public sealed class ProfileService : IProfileService
         }
 
         foreach (var profile in paperProfiles)
+        {
+            combined[profile.Id] = profile;
+        }
+
+        foreach (var profile in velocityProfiles)
         {
             combined[profile.Id] = profile;
         }
@@ -1144,6 +1156,171 @@ public sealed class ProfileService : IProfileService
     }
 
     private static bool IsStablePaperVersion(string version)
+    {
+        return !version.Contains('-', StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<IReadOnlyList<ProfileDto>> GetVelocityProfilesAsync(CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        if (_velocityLastFetch.HasValue &&
+            now - _velocityLastFetch.Value < VelocityCacheTtl &&
+            _velocityCache.Count > 0)
+        {
+            return _velocityCache;
+        }
+
+        await VelocityCacheLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_velocityLastFetch.HasValue &&
+                now - _velocityLastFetch.Value < VelocityCacheTtl &&
+                _velocityCache.Count > 0)
+            {
+                return _velocityCache;
+            }
+
+            var fetched = await FetchVelocityProfilesAsync(cancellationToken);
+            if (fetched.Count > 0)
+            {
+                _velocityCache = fetched.ToList();
+                _velocityLastFetch = DateTimeOffset.UtcNow;
+            }
+            else if (_velocityCache.Count == 0)
+            {
+                _velocityLastFetch = DateTimeOffset.UtcNow;
+            }
+
+            return _velocityCache;
+        }
+        finally
+        {
+            VelocityCacheLock.Release();
+        }
+    }
+
+    private async Task<IReadOnlyList<ProfileDto>> FetchVelocityProfilesAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var json = await _httpClient.GetStringAsync(VelocityProjectUrl, cancellationToken);
+            using var doc = JsonDocument.Parse(json);
+
+            if (!doc.RootElement.TryGetProperty("versions", out var versionsElement) ||
+                versionsElement.ValueKind != JsonValueKind.Array)
+            {
+                return Array.Empty<ProfileDto>();
+            }
+
+            var versions = new List<(string Raw, Version Parsed)>();
+            foreach (var element in versionsElement.EnumerateArray())
+            {
+                var versionText = element.GetString();
+                if (string.IsNullOrWhiteSpace(versionText))
+                {
+                    continue;
+                }
+
+                if (!IsStableVelocityVersion(versionText))
+                {
+                    continue;
+                }
+
+                if (Version.TryParse(versionText, out var parsed))
+                {
+                    versions.Add((versionText, parsed));
+                }
+            }
+
+            var recentVersions = versions
+                .OrderByDescending(v => v.Parsed)
+                .Take(VelocityVersionLimit)
+                .Select(v => v.Raw)
+                .ToList();
+
+            var results = new List<ProfileDto>();
+            foreach (var version in recentVersions)
+            {
+                try
+                {
+                    var build = await GetLatestVelocityBuildAsync(version, cancellationToken);
+                    if (build == null)
+                    {
+                        continue;
+                    }
+
+                    var url =
+                        $"{VelocityProjectUrl}/versions/{version}/builds/{build.Build}/downloads/{build.FileName}";
+
+                    results.Add(new ProfileDto(
+                        $"velocity-{version}",
+                        "velocity",
+                        "release",
+                        version,
+                        build.Time,
+                        url,
+                        build.FileName,
+                        false,
+                        null));
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to load Velocity build for {Version}", version);
+                }
+            }
+
+            return results;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch Velocity profiles");
+            return Array.Empty<ProfileDto>();
+        }
+    }
+
+    private async Task<PaperBuildInfo?> GetLatestVelocityBuildAsync(string version, CancellationToken cancellationToken)
+    {
+        var versionUrl = $"{VelocityProjectUrl}/versions/{version}";
+        var json = await _httpClient.GetStringAsync(versionUrl, cancellationToken);
+        using var doc = JsonDocument.Parse(json);
+
+        if (!doc.RootElement.TryGetProperty("builds", out var buildsElement) ||
+            buildsElement.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        var builds = buildsElement
+            .EnumerateArray()
+            .Select(element => element.GetInt32())
+            .ToList();
+
+        if (builds.Count == 0)
+        {
+            return null;
+        }
+
+        var latestBuild = builds[^1];
+        var buildUrl = $"{versionUrl}/builds/{latestBuild}";
+        var buildJson = await _httpClient.GetStringAsync(buildUrl, cancellationToken);
+        using var buildDoc = JsonDocument.Parse(buildJson);
+
+        var time = buildDoc.RootElement.TryGetProperty("time", out var timeElement)
+            ? timeElement.GetString() ?? DateTimeOffset.UtcNow.ToString("O")
+            : DateTimeOffset.UtcNow.ToString("O");
+
+        string fileName = $"velocity-{version}-{latestBuild}.jar";
+        if (buildDoc.RootElement.TryGetProperty("downloads", out var downloadsElement) &&
+            downloadsElement.TryGetProperty("application", out var appElement) &&
+            appElement.TryGetProperty("name", out var nameElement))
+        {
+            fileName = nameElement.GetString() ?? fileName;
+        }
+
+        return new PaperBuildInfo(latestBuild, time, fileName);
+    }
+
+    private static bool IsStableVelocityVersion(string version)
     {
         return !version.Contains('-', StringComparison.OrdinalIgnoreCase);
     }

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -924,6 +924,73 @@ public class ServerService : IServerService
     private string GetVelocityTomlPath(string name) =>
         Path.Combine(GetServerPath(name), "velocity.toml");
 
+    public async Task<(string Host, int Port)?> GetServerListenEndpointAsync(string name, CancellationToken cancellationToken)
+    {
+        var serverPath = GetServerPath(name);
+        if (!Directory.Exists(serverPath))
+        {
+            return null;
+        }
+
+        if (DetectServerType(name) == "proxy")
+        {
+            var tomlPath = GetVelocityTomlPath(name);
+            if (!File.Exists(tomlPath))
+            {
+                return null;
+            }
+            try
+            {
+                var content = await File.ReadAllTextAsync(tomlPath, cancellationToken);
+                var model = Toml.ToModel(content);
+                if (!model.TryGetValue("bind", out var bindObj) || bindObj is not string bind)
+                {
+                    return null;
+                }
+                // Velocity bind format is "<host>:<port>" e.g. "0.0.0.0:25577".
+                // Velocity also supports IPv6 like "[::]:25577" but we treat that
+                // by splitting on the LAST colon.
+                var lastColon = bind.LastIndexOf(':');
+                if (lastColon <= 0 || lastColon == bind.Length - 1)
+                {
+                    return null;
+                }
+                if (!int.TryParse(bind[(lastColon + 1)..], out var port) || port < 1 || port > 65535)
+                {
+                    return null;
+                }
+                var host = bind[..lastColon].Trim('[', ']');
+                if (string.IsNullOrWhiteSpace(host) || host == "0.0.0.0" || host == "::")
+                {
+                    host = "127.0.0.1";
+                }
+                return (host, port);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to parse velocity.toml for {ServerName}", name);
+                return null;
+            }
+        }
+
+        // Java + bedrock: read server.properties
+        var properties = await GetServerPropertiesAsync(name, cancellationToken);
+        if (!properties.TryGetValue("server-port", out var portStr) ||
+            !int.TryParse(portStr, out var jPort) ||
+            jPort < 1 || jPort > 65535)
+        {
+            return null;
+        }
+        var jHost = "127.0.0.1";
+        if (properties.TryGetValue("server-ip", out var ip) &&
+            !string.IsNullOrWhiteSpace(ip) &&
+            !ip.Equals("0.0.0.0", StringComparison.OrdinalIgnoreCase))
+        {
+            jHost = ip;
+        }
+        return (jHost, jPort);
+    }
+
     public async Task<VelocityConfigDto> GetVelocityConfigAsync(string name, CancellationToken cancellationToken)
     {
         var serverPath = GetServerPath(name);
@@ -1703,10 +1770,32 @@ public class ServerService : IServerService
         if (!Directory.Exists(serverPath))
             throw new DirectoryNotFoundException($"Server '{name}' not found");
 
+        var normalized = serverType.ToLowerInvariant();
         await File.WriteAllTextAsync(
-            Path.Combine(serverPath, ServerTypeFile), serverType.ToLowerInvariant(), cancellationToken);
+            Path.Combine(serverPath, ServerTypeFile), normalized, cancellationToken);
 
-        _logger.LogInformation("Updated server type for {Server} to {Type}", name, serverType);
+        // When converting an existing server to a proxy, bootstrap velocity.toml
+        // the same way CreateServerAsync does: pre-populated with sibling Java
+        // backends and an empty [forced-hosts] table. Mirrors the wizard so a
+        // type-changed proxy is functional from the first launch.
+        if (normalized == "proxy")
+        {
+            var tomlPath = GetVelocityTomlPath(name);
+            if (!File.Exists(tomlPath))
+            {
+                var backends = await DiscoverJavaBackendsAsync(name, cancellationToken);
+                var initialConfig = VelocityConfigDefaults(exists: true) with
+                {
+                    Servers = backends,
+                    Try = backends.Count > 0
+                        ? new List<string> { backends.Keys.First() }
+                        : new List<string>()
+                };
+                await WriteVelocityTomlAsync(tomlPath, initialConfig, cancellationToken);
+            }
+        }
+
+        _logger.LogInformation("Updated server type for {Server} to {Type}", name, normalized);
     }
 
     private static readonly System.Text.RegularExpressions.Regex[] JarLoaderPatterns =

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -315,8 +315,7 @@ public class ServerService : IServerService
                     // Velocity rejects "nogui"; treat as unconventional so the
                     // launcher does not append it.
                     ["unconventional"] = "true",
-                    ["lan_broadcast"] = "false",
-                    ["proxy_port"] = defaultPort.ToString()
+                    ["lan_broadcast"] = "false"
                 },
                 ["onreboot"] = new()
                 {

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -147,7 +147,8 @@ public class ServerService : IServerService
         var config = await GetServerConfigAsync(name, cancellationToken);
 
         var status = processInfo?.JavaPid != null ? "running" : "stopped";
-        var eulaAccepted = serverType == "bedrock" || await IsEulaAcceptedAsync(serverPath, cancellationToken);
+        var eulaAccepted = serverType == "bedrock" || serverType == "proxy"
+            || await IsEulaAcceptedAsync(serverPath, cancellationToken);
         var needsRestart = File.Exists(GetRestartFlagPath(name));
 
         // Get owner info from directory
@@ -290,6 +291,43 @@ public class ServerService : IServerService
             };
 
             await File.WriteAllTextAsync(configPath, IniParser.WriteWithSections(bedrockConfig), cancellationToken);
+        }
+        else if (serverType == "proxy")
+        {
+            // Velocity (and future BungeeCord/Waterfall) proxies: no server.properties,
+            // no EULA, no world. Velocity creates velocity.toml on first launch.
+            // Velocity's actual default bind port is 25577 (set in velocity.toml).
+            var defaultPort = GetNextAvailablePort(usedPorts, 25577);
+
+            var proxyConfig = new Dictionary<string, Dictionary<string, string>>
+            {
+                ["java"] = new()
+                {
+                    ["java_binary"] = "",
+                    ["java_xmx"] = "1024",
+                    ["java_xms"] = "512"
+                },
+                ["minecraft"] = new()
+                {
+                    ["profile"] = "",
+                    // Velocity rejects "nogui"; treat as unconventional so the
+                    // launcher does not append it.
+                    ["unconventional"] = "true",
+                    ["lan_broadcast"] = "false",
+                    ["proxy_port"] = defaultPort.ToString()
+                },
+                ["onreboot"] = new()
+                {
+                    ["start"] = "false"
+                },
+                ["monitoring"] = new()
+                {
+                    ["tps_enabled"] = "false",
+                    ["tps_command"] = ""
+                }
+            };
+
+            await File.WriteAllTextAsync(configPath, IniParser.WriteWithSections(proxyConfig), cancellationToken);
         }
         else
         {
@@ -613,31 +651,44 @@ public class ServerService : IServerService
         }
         else
         {
+            var isProxy = serverType == "proxy";
+
             // Read server config to build start arguments
             var config = await GetServerConfigAsync(name, cancellationToken);
             var javaBinary = config.Java.JavaBinary;
             if (string.IsNullOrEmpty(javaBinary) || javaBinary == "java")
             {
-                // Auto-detect Java version from the server's Minecraft version
-                string? mcVersion = null;
-                try
+                if (isProxy)
                 {
-                    var props = await GetServerPropertiesAsync(name, cancellationToken);
-                    // server.properties doesn't have MC version, but the profile might
+                    // Velocity requires Java 21+. The auto-detector keys off MC version,
+                    // but proxy jars have no MC version — pin to Java 21.
+                    javaBinary = ResolveJavaBinary("1.21");
+                    _logger.LogInformation("Resolved Java 21 binary for proxy {Server}: {JavaBinary}",
+                        name, javaBinary);
                 }
-                catch { /* no properties file yet */ }
+                else
+                {
+                    // Auto-detect Java version from the server's Minecraft version
+                    string? mcVersion = null;
+                    try
+                    {
+                        var props = await GetServerPropertiesAsync(name, cancellationToken);
+                        // server.properties doesn't have MC version, but the profile might
+                    }
+                    catch { /* no properties file yet */ }
 
-                // Try to extract MC version from profile name or jar filename
-                var profile = config.Minecraft.Profile ?? "";
-                var jar = config.Java.JarFile ?? "";
-                var versionMatch = System.Text.RegularExpressions.Regex.Match(
-                    profile + " " + jar, @"(\d+\.\d+(?:\.\d+)?)");
-                if (versionMatch.Success)
-                    mcVersion = versionMatch.Groups[1].Value;
+                    // Try to extract MC version from profile name or jar filename
+                    var profile = config.Minecraft.Profile ?? "";
+                    var jar = config.Java.JarFile ?? "";
+                    var versionMatch = System.Text.RegularExpressions.Regex.Match(
+                        profile + " " + jar, @"(\d+\.\d+(?:\.\d+)?)");
+                    if (versionMatch.Success)
+                        mcVersion = versionMatch.Groups[1].Value;
 
-                javaBinary = ResolveJavaBinary(mcVersion);
-                _logger.LogInformation("Auto-resolved Java binary for {Server} (MC {Version}): {JavaBinary}",
-                    name, mcVersion ?? "unknown", javaBinary);
+                    javaBinary = ResolveJavaBinary(mcVersion);
+                    _logger.LogInformation("Auto-resolved Java binary for {Server} (MC {Version}): {JavaBinary}",
+                        name, mcVersion ?? "unknown", javaBinary);
+                }
             }
             var jarFile = config.Java.JarFile;
 
@@ -654,7 +705,10 @@ public class ServerService : IServerService
                 throw new InvalidOperationException($"Server '{name}' has no JAR file configured");
             }
 
-            await EnsureEulaAcceptedAsync(serverPath, cancellationToken);
+            if (!isProxy)
+            {
+                await EnsureEulaAcceptedAsync(serverPath, cancellationToken);
+            }
             await EnsureExecutableAvailableAsync(javaBinary, "-version", "Java runtime", cancellationToken);
 
             // Check if using modern Forge @argfile syntax
@@ -760,8 +814,9 @@ public class ServerService : IServerService
         var uid = _options.RunAsUid;
         var gid = _options.RunAsGid;
 
-        // Send stop command
-        await _processManager.SendCommandAsync(name, "stop", uid, gid, cancellationToken);
+        // Send stop command — Velocity uses "end", backend MC servers use "stop"
+        var stopCommand = DetectServerType(name) == "proxy" ? "end" : "stop";
+        await _processManager.SendCommandAsync(name, stopCommand, uid, gid, cancellationToken);
 
         // Wait for process to stop
         var timeout = TimeSpan.FromSeconds(timeoutSeconds > 0 ? timeoutSeconds : 300);
@@ -1375,8 +1430,8 @@ public class ServerService : IServerService
 
     private static readonly HashSet<string> AllowedServerTypes = new(StringComparer.OrdinalIgnoreCase)
     {
-        "java", "bedrock", "vanilla", "paper", "spigot", "craftbukkit", "purpur",
-        "forge", "neoforge", "fabric", "quilt", "folia"
+        "java", "bedrock", "proxy", "vanilla", "paper", "spigot", "craftbukkit", "purpur",
+        "forge", "neoforge", "fabric", "quilt", "folia", "velocity"
     };
 
     public async Task UpdateServerTypeAsync(string name, string serverType, CancellationToken cancellationToken)

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -1024,7 +1024,8 @@ public class ServerService : IServerService
             PingPassthrough = TomlGetString(model, "ping-passthrough", defaults.PingPassthrough),
             EnablePlayerAddressLogging = TomlGetBool(model, "enable-player-address-logging", defaults.EnablePlayerAddressLogging),
             Servers = ReadServersTable(model),
-            Try = ReadTryList(model)
+            Try = ReadTryList(model),
+            ForcedHosts = ReadForcedHostsTable(model)
         };
     }
 
@@ -1089,15 +1090,21 @@ public class ServerService : IServerService
         serversTable["try"] = tryArray;
         model["servers"] = serversTable;
 
-        // Velocity falls back to its bundled default config for any TOML table
-        // that is entirely missing — including a [forced-hosts] block that
-        // references example servers that don't exist (factions.example.com,
-        // minigames.example.com), which fails startup. Ensure the table is
-        // present and empty unless the user has put something there already.
-        if (!model.ContainsKey("forced-hosts"))
+        // Always emit [forced-hosts] (even when empty). Velocity falls back to
+        // its bundled default config when the table is missing entirely —
+        // that default references factions.example.com / minigames.example.com
+        // and fails startup.
+        var forcedHostsTable = new TomlTable();
+        foreach (var (hostname, serverList) in config.ForcedHosts)
         {
-            model["forced-hosts"] = new TomlTable();
+            var arr = new TomlArray();
+            foreach (var s in serverList)
+            {
+                arr.Add(s);
+            }
+            forcedHostsTable[hostname] = arr;
         }
+        model["forced-hosts"] = forcedHostsTable;
 
         var output = Toml.FromModel(model);
         await File.WriteAllTextAsync(tomlPath, output, cancellationToken);
@@ -1121,7 +1128,8 @@ public class ServerService : IServerService
             PingPassthrough: "DISABLED",
             EnablePlayerAddressLogging: true,
             Servers: new Dictionary<string, string>(),
-            Try: new List<string>());
+            Try: new List<string>(),
+            ForcedHosts: new Dictionary<string, List<string>>());
     }
 
     private static string TomlGetString(TomlTable model, string key, string fallback)
@@ -1228,6 +1236,26 @@ public class ServerService : IServerService
         {
             if (item is string s)
                 result.Add(s);
+        }
+        return result;
+    }
+
+    private static Dictionary<string, List<string>> ReadForcedHostsTable(TomlTable model)
+    {
+        var result = new Dictionary<string, List<string>>();
+        if (!model.TryGetValue("forced-hosts", out var fhObj) || fhObj is not TomlTable forcedHosts)
+            return result;
+        foreach (var (hostname, value) in forcedHosts)
+        {
+            if (value is not TomlArray arr)
+                continue;
+            var list = new List<string>();
+            foreach (var item in arr)
+            {
+                if (item is string s)
+                    list.Add(s);
+            }
+            result[hostname] = list;
         }
         return result;
     }

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -8,6 +8,8 @@ using MineOS.Application.Options;
 using MineOS.Domain.Entities;
 using MineOS.Infrastructure.Utilities;
 using ServerStatusStrings = MineOS.Infrastructure.Constants.ServerStatus;
+using Tomlyn;
+using Tomlyn.Model;
 
 namespace MineOS.Infrastructure.Services;
 
@@ -903,6 +905,193 @@ public class ServerService : IServerService
         }
 
         _logger.LogInformation("Updated server.properties for {ServerName}", name);
+    }
+
+    private string GetVelocityTomlPath(string name) =>
+        Path.Combine(GetServerPath(name), "velocity.toml");
+
+    public async Task<VelocityConfigDto> GetVelocityConfigAsync(string name, CancellationToken cancellationToken)
+    {
+        var serverPath = GetServerPath(name);
+        if (!Directory.Exists(serverPath))
+        {
+            throw new DirectoryNotFoundException($"Server '{name}' not found");
+        }
+
+        var tomlPath = GetVelocityTomlPath(name);
+        if (!File.Exists(tomlPath))
+        {
+            return VelocityConfigDefaults(exists: false);
+        }
+
+        var content = await File.ReadAllTextAsync(tomlPath, cancellationToken);
+        var model = Toml.ToModel(content);
+
+        var defaults = VelocityConfigDefaults(exists: true);
+        return defaults with
+        {
+            Bind = TomlGetString(model, "bind", defaults.Bind),
+            Motd = TomlGetString(model, "motd", defaults.Motd),
+            ShowMaxPlayers = TomlGetInt(model, "show-max-players", defaults.ShowMaxPlayers),
+            OnlineMode = TomlGetBool(model, "online-mode", defaults.OnlineMode),
+            ForceKeyAuthentication = TomlGetBool(model, "force-key-authentication", defaults.ForceKeyAuthentication),
+            PreventClientProxyConnections = TomlGetBool(model, "prevent-client-proxy-connections", defaults.PreventClientProxyConnections),
+            PlayerInfoForwardingMode = TomlGetString(model, "player-info-forwarding-mode", defaults.PlayerInfoForwardingMode),
+            ForwardingSecretFile = TomlGetString(model, "forwarding-secret-file", defaults.ForwardingSecretFile),
+            AnnounceForge = TomlGetBool(model, "announce-forge", defaults.AnnounceForge),
+            KickExistingPlayers = TomlGetBool(model, "kick-existing-players", defaults.KickExistingPlayers),
+            PingPassthrough = TomlGetString(model, "ping-passthrough", defaults.PingPassthrough),
+            EnablePlayerAddressLogging = TomlGetBool(model, "enable-player-address-logging", defaults.EnablePlayerAddressLogging),
+            Servers = ReadServersTable(model),
+            Try = ReadTryList(model)
+        };
+    }
+
+    public async Task UpdateVelocityConfigAsync(string name, VelocityConfigDto config, CancellationToken cancellationToken)
+    {
+        var serverPath = GetServerPath(name);
+        if (!Directory.Exists(serverPath))
+        {
+            throw new DirectoryNotFoundException($"Server '{name}' not found");
+        }
+
+        if (DetectServerType(name) != "proxy")
+        {
+            throw new InvalidOperationException($"Server '{name}' is not a proxy server");
+        }
+
+        var tomlPath = GetVelocityTomlPath(name);
+
+        // Round-trip: load existing model (or start fresh), apply our known fields,
+        // preserve any unknown sections like [advanced] and [query].
+        TomlTable model;
+        if (File.Exists(tomlPath))
+        {
+            var content = await File.ReadAllTextAsync(tomlPath, cancellationToken);
+            model = Toml.ToModel(content);
+        }
+        else
+        {
+            model = new TomlTable();
+            model["config-version"] = "1.0";
+        }
+
+        model["bind"] = config.Bind;
+        model["motd"] = config.Motd;
+        model["show-max-players"] = (long)config.ShowMaxPlayers;
+        model["online-mode"] = config.OnlineMode;
+        model["force-key-authentication"] = config.ForceKeyAuthentication;
+        model["prevent-client-proxy-connections"] = config.PreventClientProxyConnections;
+        model["player-info-forwarding-mode"] = config.PlayerInfoForwardingMode;
+        model["forwarding-secret-file"] = config.ForwardingSecretFile;
+        model["announce-forge"] = config.AnnounceForge;
+        model["kick-existing-players"] = config.KickExistingPlayers;
+        model["ping-passthrough"] = config.PingPassthrough;
+        model["enable-player-address-logging"] = config.EnablePlayerAddressLogging;
+
+        var serversTable = new TomlTable();
+        foreach (var (key, value) in config.Servers)
+        {
+            serversTable[key] = value;
+        }
+        var tryArray = new TomlArray();
+        foreach (var entry in config.Try)
+        {
+            tryArray.Add(entry);
+        }
+        serversTable["try"] = tryArray;
+        model["servers"] = serversTable;
+
+        // Velocity falls back to its bundled default config for any TOML table
+        // that is entirely missing — including a [forced-hosts] block that
+        // references example servers that don't exist (factions.example.com,
+        // minigames.example.com), which fails startup. Ensure the table is
+        // present and empty unless the user has put something there already.
+        if (!model.ContainsKey("forced-hosts"))
+        {
+            model["forced-hosts"] = new TomlTable();
+        }
+
+        var output = Toml.FromModel(model);
+        await File.WriteAllTextAsync(tomlPath, output, cancellationToken);
+        await OwnershipHelper.ChangeOwnershipAsync(tomlPath, _options.RunAsUid, _options.RunAsGid, _logger, cancellationToken);
+
+        await MarkRestartRequiredAsync(name);
+        _logger.LogInformation("Updated velocity.toml for {ServerName}", name);
+    }
+
+    private static VelocityConfigDto VelocityConfigDefaults(bool exists)
+    {
+        return new VelocityConfigDto(
+            Exists: exists,
+            Bind: "0.0.0.0:25577",
+            Motd: "<#09add3>A Velocity Server",
+            ShowMaxPlayers: 500,
+            OnlineMode: true,
+            ForceKeyAuthentication: true,
+            PreventClientProxyConnections: false,
+            PlayerInfoForwardingMode: "none",
+            ForwardingSecretFile: "forwarding.secret",
+            AnnounceForge: false,
+            KickExistingPlayers: false,
+            PingPassthrough: "DISABLED",
+            EnablePlayerAddressLogging: true,
+            Servers: new Dictionary<string, string>(),
+            Try: new List<string>());
+    }
+
+    private static string TomlGetString(TomlTable model, string key, string fallback)
+    {
+        return model.TryGetValue(key, out var value) && value is string s ? s : fallback;
+    }
+
+    private static int TomlGetInt(TomlTable model, string key, int fallback)
+    {
+        if (!model.TryGetValue(key, out var value))
+            return fallback;
+        return value switch
+        {
+            long l => (int)l,
+            int i => i,
+            _ => fallback
+        };
+    }
+
+    private static bool TomlGetBool(TomlTable model, string key, bool fallback)
+    {
+        return model.TryGetValue(key, out var value) && value is bool b ? b : fallback;
+    }
+
+    private static Dictionary<string, string> ReadServersTable(TomlTable model)
+    {
+        var result = new Dictionary<string, string>();
+        if (!model.TryGetValue("servers", out var serversObj) || serversObj is not TomlTable servers)
+            return result;
+
+        foreach (var (key, value) in servers)
+        {
+            // Skip the "try" entry — it's a list, not a backend mapping.
+            if (key == "try" || value is TomlArray)
+                continue;
+            if (value is string s)
+                result[key] = s;
+        }
+        return result;
+    }
+
+    private static List<string> ReadTryList(TomlTable model)
+    {
+        var result = new List<string>();
+        if (!model.TryGetValue("servers", out var serversObj) || serversObj is not TomlTable servers)
+            return result;
+        if (!servers.TryGetValue("try", out var tryObj) || tryObj is not TomlArray tryArr)
+            return result;
+        foreach (var item in tryArr)
+        {
+            if (item is string s)
+                result.Add(s);
+        }
+        return result;
     }
 
     public async Task<ServerConfigDto> GetServerConfigAsync(string name, CancellationToken cancellationToken)

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -330,6 +330,21 @@ public class ServerService : IServerService
             };
 
             await File.WriteAllTextAsync(configPath, IniParser.WriteWithSections(proxyConfig), cancellationToken);
+
+            // Pre-populate velocity.toml with sibling Java backends so the proxy
+            // does something out of the box. The user can edit /reorder them via
+            // the Velocity tab.
+            var backends = await DiscoverJavaBackendsAsync(request.Name, cancellationToken);
+            var initialConfig = VelocityConfigDefaults(exists: true) with
+            {
+                Bind = $"0.0.0.0:{defaultPort}",
+                Servers = backends,
+                Try = backends.Count > 0
+                    ? new List<string> { backends.Keys.First() }
+                    : new List<string>()
+            };
+            var tomlPath = Path.Combine(serverPath, "velocity.toml");
+            await WriteVelocityTomlAsync(tomlPath, initialConfig, cancellationToken);
         }
         else
         {
@@ -961,7 +976,13 @@ public class ServerService : IServerService
         }
 
         var tomlPath = GetVelocityTomlPath(name);
+        await WriteVelocityTomlAsync(tomlPath, config, cancellationToken);
+        await MarkRestartRequiredAsync(name);
+        _logger.LogInformation("Updated velocity.toml for {ServerName}", name);
+    }
 
+    private async Task WriteVelocityTomlAsync(string tomlPath, VelocityConfigDto config, CancellationToken cancellationToken)
+    {
         // Round-trip: load existing model (or start fresh), apply our known fields,
         // preserve any unknown sections like [advanced] and [query].
         TomlTable model;
@@ -1015,9 +1036,6 @@ public class ServerService : IServerService
         var output = Toml.FromModel(model);
         await File.WriteAllTextAsync(tomlPath, output, cancellationToken);
         await OwnershipHelper.ChangeOwnershipAsync(tomlPath, _options.RunAsUid, _options.RunAsGid, _logger, cancellationToken);
-
-        await MarkRestartRequiredAsync(name);
-        _logger.LogInformation("Updated velocity.toml for {ServerName}", name);
     }
 
     private static VelocityConfigDto VelocityConfigDefaults(bool exists)
@@ -1076,6 +1094,60 @@ public class ServerService : IServerService
             if (value is string s)
                 result[key] = s;
         }
+        return result;
+    }
+
+    private async Task<Dictionary<string, string>> DiscoverJavaBackendsAsync(
+        string excludeName, CancellationToken cancellationToken)
+    {
+        var result = new Dictionary<string, string>();
+        var serversPath = Path.Combine(_options.BaseDirectory, _options.ServersPathSegment);
+        if (!Directory.Exists(serversPath))
+        {
+            return result;
+        }
+
+        foreach (var dir in Directory.EnumerateDirectories(serversPath).OrderBy(d => Path.GetFileName(d), StringComparer.OrdinalIgnoreCase))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var serverName = Path.GetFileName(dir);
+            if (string.IsNullOrWhiteSpace(serverName) ||
+                serverName.Equals(excludeName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            // Skip non-Java backends. Bedrock (UDP, different protocol) and proxies
+            // (a proxy fronting another proxy is not a sensible default).
+            var typeFile = Path.Combine(dir, ServerTypeFile);
+            if (File.Exists(typeFile))
+            {
+                var marker = (await File.ReadAllTextAsync(typeFile, cancellationToken)).Trim();
+                if (marker.Equals("bedrock", StringComparison.OrdinalIgnoreCase) ||
+                    marker.Equals("proxy", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+            }
+
+            var propertiesPath = Path.Combine(dir, "server.properties");
+            if (!File.Exists(propertiesPath))
+            {
+                continue;
+            }
+
+            var content = await File.ReadAllTextAsync(propertiesPath, cancellationToken);
+            var props = IniParser.ParseSimple(content);
+            if (!props.TryGetValue("server-port", out var portValue) ||
+                !int.TryParse(portValue, out var port) ||
+                port < 1 || port > 65535)
+            {
+                continue;
+            }
+
+            result[serverName] = $"127.0.0.1:{port}";
+        }
+
         return result;
     }
 

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -217,6 +217,21 @@ export async function updateServerConfig(
 	return apiPut(fetcher, `/api/servers/${name}/server-config`, config);
 }
 
+export async function getVelocityConfig(
+	fetcher: Fetcher,
+	name: string
+): Promise<ApiResult<import('./types').VelocityConfig>> {
+	return apiFetch(fetcher, `/api/servers/${name}/velocity-config`);
+}
+
+export async function updateVelocityConfig(
+	fetcher: Fetcher,
+	name: string,
+	config: import('./types').VelocityConfig
+): Promise<ApiResult<void>> {
+	return apiPut(fetcher, `/api/servers/${name}/velocity-config`, config);
+}
+
 export async function acceptEula(fetcher: Fetcher, name: string): Promise<ApiResult<void>> {
 	return apiPost(fetcher, `/api/servers/${name}/eula`);
 }

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -88,6 +88,24 @@ export type ServerConfig = {
 	monitoring: MonitoringConfig;
 };
 
+export type VelocityConfig = {
+	exists: boolean;
+	bind: string;
+	motd: string;
+	showMaxPlayers: number;
+	onlineMode: boolean;
+	forceKeyAuthentication: boolean;
+	preventClientProxyConnections: boolean;
+	playerInfoForwardingMode: 'none' | 'legacy' | 'bungeeguard' | 'modern';
+	forwardingSecretFile: string;
+	announceForge: boolean;
+	kickExistingPlayers: boolean;
+	pingPassthrough: 'DISABLED' | 'MODS' | 'DESCRIPTION' | 'ALL';
+	enablePlayerAddressLogging: boolean;
+	servers: Record<string, string>;
+	try: string[];
+};
+
 export type JavaConfig = {
 	javaBinary: string;
 	javaXmx: number;

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -104,6 +104,7 @@ export type VelocityConfig = {
 	enablePlayerAddressLogging: boolean;
 	servers: Record<string, string>;
 	try: string[];
+	forcedHosts: Record<string, string[]>;
 };
 
 export type JavaConfig = {

--- a/apps/web/src/lib/components/ChangeServerType.svelte
+++ b/apps/web/src/lib/components/ChangeServerType.svelte
@@ -19,7 +19,7 @@
 		onComplete: () => void;
 	} = $props();
 
-	type ServerType = 'vanilla' | 'paper' | 'spigot' | 'forge' | 'neoforge' | 'fabric' | 'quilt';
+	type ServerType = 'vanilla' | 'paper' | 'spigot' | 'forge' | 'neoforge' | 'fabric' | 'quilt' | 'velocity';
 
 	const serverTypes: { id: ServerType; name: string; category: string }[] = [
 		{ id: 'vanilla', name: 'Vanilla', category: 'vanilla' },
@@ -29,12 +29,15 @@
 		{ id: 'neoforge', name: 'NeoForge', category: 'mods' },
 		{ id: 'fabric', name: 'Fabric', category: 'mods' },
 		{ id: 'quilt', name: 'Quilt', category: 'mods' },
+		{ id: 'velocity', name: 'Velocity', category: 'proxy' },
 	];
 
 	// Detect current server category from jar name
 	function detectCategory(jar: string | null, type: string): string {
 		if (type === 'bedrock') return 'bedrock';
+		if (type === 'proxy') return 'proxy';
 		const j = (jar ?? '').toLowerCase();
+		if (j.includes('velocity') || j.includes('bungeecord') || j.includes('waterfall')) return 'proxy';
 		if (j.includes('forge') || j.includes('neoforge')) return 'mods';
 		if (j.includes('fabric') || j.includes('quilt')) return 'mods';
 		if (j.includes('paper') || j.includes('spigot') || j.includes('purpur') || j.includes('bukkit')) return 'plugins';
@@ -42,6 +45,15 @@
 	}
 
 	const currentCategory = detectCategory(currentJar, currentServerType);
+	// Lock the proxy silo: from a proxy, only proxy types are offered; from a
+	// backend, only backend types. (Bedrock is already locked the same way —
+	// it's not in the list at all.) Switching between Java backends and proxies
+	// in place leaves stale config files (server.properties vs velocity.toml,
+	// EULA vs forwarding.secret) and is better handled by creating a new server.
+	const visibleTypes = serverTypes.filter((t) => {
+		const isProxyOption = t.category === 'proxy';
+		return currentCategory === 'proxy' ? isProxyOption : !isProxyOption;
+	});
 
 	// State
 	let step = $state<'type' | 'version' | 'confirm' | 'installing'>('type');
@@ -65,6 +77,7 @@
 				case 'spigot': return p.group === 'spigot' || (p.group === 'vanilla' && p.type === 'release');
 					case 'forge': return p.group === 'forge';
 				case 'fabric': return p.group === 'fabric';
+				case 'velocity': return p.group === 'velocity';
 				case 'bedrock': return p.group === 'bedrock-server' || p.group === 'bedrock-server-preview';
 				default: return false;
 			}
@@ -131,6 +144,16 @@
 		}
 		if (currentServerType === 'bedrock' && type !== 'bedrock') {
 			error = 'Cannot switch a Bedrock server to Java. Create a new Java server instead.';
+			return;
+		}
+		// Proxy silo lock — defensive; the popup also filters visibleTypes.
+		const targetIsProxy = serverTypes.find((t) => t.id === type)?.category === 'proxy';
+		if (targetIsProxy && currentCategory !== 'proxy') {
+			error = 'Cannot convert a backend server to a proxy in place. Create a new Proxy server instead.';
+			return;
+		}
+		if (!targetIsProxy && currentCategory === 'proxy') {
+			error = 'Cannot convert a proxy back to a backend server in place. Create a new server of the desired type instead.';
 			return;
 		}
 		selectedType = type;
@@ -257,13 +280,17 @@
 
 	async function markInstallComplete() {
 		installCompleted = true;
-		// Update the .mineos-server-type file so detection works immediately
+		// Update the .mineos-server-type file so detection works immediately.
+		// Velocity is recorded as the generic "proxy" marker so all proxy-specific
+		// branches (skip EULA, ping via velocity.toml, send "end" not "stop", etc.)
+		// match — same as a proxy created via the wizard.
 		if (selectedType) {
+			const markerType = selectedType === 'velocity' ? 'proxy' : selectedType;
 			try {
 				await fetch(`/api/servers/${encodeURIComponent(serverName)}/server-type`, {
 					method: 'PUT',
 					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ serverType: selectedType })
+					body: JSON.stringify({ serverType: markerType })
 				});
 			} catch { /* best effort */ }
 		}
@@ -291,7 +318,7 @@
 					<div class="error-box">{error}</div>
 				{/if}
 				<div class="type-list">
-					{#each serverTypes as type}
+					{#each visibleTypes as type}
 						<button
 							class="type-row"
 							class:current={detectCategory(currentJar, currentServerType) === type.category && !selectedType}

--- a/apps/web/src/lib/components/ServerQuickActions.svelte
+++ b/apps/web/src/lib/components/ServerQuickActions.svelte
@@ -17,17 +17,33 @@
 	let status = $derived((server?.status ?? '').toLowerCase());
 	let isRunning = $derived(status === 'up' || status === 'running');
 
-	// Load server port from server.properties
+	// Load server port — proxies bind via velocity.toml, everyone else via server.properties.
 	onMount(async () => {
 		if (!server) return;
 		try {
-			const result = await api.getServerProperties(fetch, server.name);
-			if (result.data) {
-				const port = result.data['server-port'];
-				if (port) {
-					const parsed = parseInt(port, 10);
-					if (!isNaN(parsed)) {
-						serverPort = parsed;
+			if (server.serverType === 'proxy') {
+				const result = await api.getVelocityConfig(fetch, server.name);
+				const bind = result.data?.bind;
+				if (bind) {
+					// Velocity bind format: "<host>:<port>" or "[::]:port" for IPv6.
+					// Split on the LAST ":" so IPv6 hosts don't break parsing.
+					const lastColon = bind.lastIndexOf(':');
+					if (lastColon > 0 && lastColon < bind.length - 1) {
+						const parsed = parseInt(bind.slice(lastColon + 1), 10);
+						if (!isNaN(parsed)) {
+							serverPort = parsed;
+						}
+					}
+				}
+			} else {
+				const result = await api.getServerProperties(fetch, server.name);
+				if (result.data) {
+					const port = result.data['server-port'];
+					if (port) {
+						const parsed = parseInt(port, 10);
+						if (!isNaN(parsed)) {
+							serverPort = parsed;
+						}
 					}
 				}
 			}
@@ -49,7 +65,7 @@
 		if (!server) return;
 
 		// If starting and EULA not accepted, prompt instead of erroring
-		if (action === 'start' && !server.eulaAccepted && server.serverType !== 'bedrock') {
+		if (action === 'start' && !server.eulaAccepted && server.serverType !== 'bedrock' && server.serverType !== 'proxy') {
 			const accepted = await modal.confirm(
 				'This server requires you to accept the Minecraft EULA before starting.\n\n' +
 				'By accepting, you agree to the Minecraft End User License Agreement:\n' +
@@ -152,13 +168,15 @@
 				<button class="btn btn-success" onclick={() => handleAction('start')} disabled={actionLoading}>
 					Start
 				</button>
-				<button
-					class="btn btn-secondary"
-					onclick={handleAcceptEula}
-					disabled={actionLoading || server.eulaAccepted}
-				>
-					{server.eulaAccepted ? 'EULA accepted' : 'Accept EULA'}
-				</button>
+				{#if server.serverType !== 'bedrock' && server.serverType !== 'proxy'}
+					<button
+						class="btn btn-secondary"
+						onclick={handleAcceptEula}
+						disabled={actionLoading || server.eulaAccepted}
+					>
+						{server.eulaAccepted ? 'EULA accepted' : 'Accept EULA'}
+					</button>
+				{/if}
 			{/if}
 		</div>
 	</div>

--- a/apps/web/src/routes/(app)/servers/[name]/+layout.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/+layout.svelte
@@ -15,6 +15,7 @@
 	});
 
 	const isBedrock = $derived(server?.serverType === 'bedrock');
+	const isProxy = $derived(server?.serverType === 'proxy');
 	const profile = $derived(server?.config?.minecraft?.profile?.toLowerCase() ?? '');
 	const jarFile = $derived(server?.config?.java?.jarFile?.toLowerCase() ?? '');
 	const javaTweaks = $derived(server?.config?.java?.javaTweaks?.toLowerCase() ?? '');
@@ -48,7 +49,12 @@
 		const s = server?.name;
 		return [
 			{ href: `/servers/${s}`, label: 'Dashboard', exact: true },
-			{ href: `/servers/${s}/config`, label: 'Properties' },
+			{
+				href: `/servers/${s}/config`,
+				label: 'Properties',
+				disabled: isProxy,
+				tooltip: 'Proxies do not use server.properties — edit velocity.toml in the Files tab'
+			},
 			{
 				href: `/servers/${s}/advanced`,
 				label: 'Config',
@@ -59,28 +65,39 @@
 			{ href: `/servers/${s}/archives`, label: 'Archives' },
 			{ href: `/servers/${s}/files`, label: 'Files' },
 			{ href: `/servers/${s}/performance`, label: 'Performance' },
-			{ href: `/servers/${s}/worlds`, label: 'Worlds' },
+			{
+				href: `/servers/${s}/worlds`,
+				label: 'Worlds',
+				disabled: isProxy,
+				tooltip: 'Proxies do not host worlds'
+			},
 			{
 				href: `/servers/${s}/players`,
 				label: 'Players',
-				disabled: isBedrock,
-				tooltip: 'Player management is not available for Bedrock servers'
+				disabled: isBedrock || isProxy,
+				tooltip: isBedrock
+					? 'Player management is not available for Bedrock servers'
+					: 'Player management is not available for proxies'
 			},
 			{
 				href: `/servers/${s}/mods`,
 				label: 'Mods',
-				disabled: isBedrock || !isModded,
+				disabled: isBedrock || isProxy || !isModded,
 				tooltip: isBedrock
 					? 'Bedrock servers do not support Java mods'
-					: 'Mods require a modded server (Forge, Fabric, NeoForge, or Quilt)'
+					: isProxy
+						? 'Proxies do not load mods'
+						: 'Mods require a modded server (Forge, Fabric, NeoForge, or Quilt)'
 			},
 			{
 				href: `/servers/${s}/plugins`,
 				label: 'Plugins',
-				disabled: isBedrock || !isPluginServer,
+				disabled: isBedrock || isProxy || !isPluginServer,
 				tooltip: isBedrock
 					? 'Bedrock servers do not support Java plugins'
-					: 'Plugins require a plugin server (Paper, Spigot, Purpur, or Bukkit)'
+					: isProxy
+						? 'Proxy plugins use a separate ecosystem — drop jars into the plugins/ folder via Files'
+						: 'Plugins require a plugin server (Paper, Spigot, Purpur, or Bukkit)'
 			},
 			{ href: `/servers/${s}/cron`, label: 'Cron Jobs' }
 		];

--- a/apps/web/src/routes/(app)/servers/[name]/+layout.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/+layout.svelte
@@ -65,7 +65,7 @@
 			isProxy
 				? {
 						href: `/servers/${s}/proxy-config`,
-						label: 'Velocity'
+						label: 'Properties'
 					}
 				: {
 						href: `/servers/${s}/config`,

--- a/apps/web/src/routes/(app)/servers/[name]/+layout.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/+layout.svelte
@@ -37,6 +37,19 @@
 				serverHint.includes('folia'))
 	);
 
+	// For proxies, the SLP ping returns a protocol-range string ("Velocity 1.7.2-1.18.1")
+	// that's confusing in the page header. Derive the actual proxy build (e.g. "Velocity 3.1.1")
+	// from the jar filename so the chip says what's running.
+	const proxyVersionFromJar = $derived.by(() => {
+		if (!isProxy) return null;
+		const raw = server?.config?.java?.jarFile ?? '';
+		const m = raw.match(/^(velocity|bungeecord|waterfall)-(\d+\.\d+(?:\.\d+)?)/i);
+		if (!m) return null;
+		const name = m[1].charAt(0).toUpperCase() + m[1].slice(1).toLowerCase();
+		return `${name} ${m[2]}`;
+	});
+	const displayVersion = $derived(proxyVersionFromJar ?? playerInfo.version);
+
 	type Tab = {
 		href: string;
 		label: string;
@@ -95,12 +108,10 @@
 			{
 				href: `/servers/${s}/plugins`,
 				label: 'Plugins',
-				disabled: isBedrock || isProxy || !isPluginServer,
+				disabled: isBedrock || (!isProxy && !isPluginServer),
 				tooltip: isBedrock
 					? 'Bedrock servers do not support Java plugins'
-					: isProxy
-						? 'Proxy plugins use a separate ecosystem — drop jars into the plugins/ folder via Files'
-						: 'Plugins require a plugin server (Paper, Spigot, Purpur, or Bukkit)'
+					: 'Plugins require a plugin server (Paper, Spigot, Purpur, or Bukkit) or a proxy (Velocity)'
 			},
 			{ href: `/servers/${s}/cron`, label: 'Cron Jobs' }
 		];
@@ -197,10 +208,10 @@
 					<span class="chip-sep">/</span>
 					<span class="chip-value muted">{playerInfo.max ?? '--'}</span>
 				</div>
-				{#if playerInfo.version}
+				{#if displayVersion}
 					<div class="meta-chip">
 						<span class="chip-label">Version</span>
-						<span class="chip-value">{playerInfo.version}</span>
+						<span class="chip-value">{displayVersion}</span>
 					</div>
 				{/if}
 				{#if server?.javaPid}

--- a/apps/web/src/routes/(app)/servers/[name]/+layout.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/+layout.svelte
@@ -49,12 +49,15 @@
 		const s = server?.name;
 		return [
 			{ href: `/servers/${s}`, label: 'Dashboard', exact: true },
-			{
-				href: `/servers/${s}/config`,
-				label: 'Properties',
-				disabled: isProxy,
-				tooltip: 'Proxies do not use server.properties — edit velocity.toml in the Files tab'
-			},
+			isProxy
+				? {
+						href: `/servers/${s}/proxy-config`,
+						label: 'Velocity'
+					}
+				: {
+						href: `/servers/${s}/config`,
+						label: 'Properties'
+					},
 			{
 				href: `/servers/${s}/advanced`,
 				label: 'Config',

--- a/apps/web/src/routes/(app)/servers/[name]/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/+page.svelte
@@ -21,6 +21,13 @@
 	// Detect server type from jar, profile, jar args, and server directory
 	function detectServerTypeFromConfig(server: any): string {
 		if (server.serverType === 'bedrock') return 'Bedrock';
+		if (server.serverType === 'proxy') {
+			const jar = (server.config?.java?.jarFile ?? '').toLowerCase();
+			if (jar.includes('velocity')) return 'Velocity';
+			if (jar.includes('bungeecord')) return 'BungeeCord';
+			if (jar.includes('waterfall')) return 'Waterfall';
+			return 'Proxy';
+		}
 		const jar = (server.config?.java?.jarFile ?? '').toLowerCase();
 		const profile = (server.config?.minecraft?.profile ?? '').toLowerCase();
 		const jarArgs = (server.config?.java?.jarArgs ?? '').toLowerCase();

--- a/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.server.ts
+++ b/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.server.ts
@@ -1,0 +1,35 @@
+import type { PageServerLoad, Actions } from './$types';
+import { getVelocityConfig, updateVelocityConfig } from '$lib/api/client';
+import { fail } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ params, fetch }) => {
+	const config = await getVelocityConfig(fetch, params.name);
+	return {
+		config,
+		serverName: params.name
+	};
+};
+
+export const actions = {
+	default: async ({ request, params, fetch }) => {
+		const data = await request.formData();
+		const configJson = data.get('config')?.toString();
+
+		if (!configJson) {
+			return fail(400, { error: 'Config data is required' });
+		}
+
+		try {
+			const config = JSON.parse(configJson);
+			const result = await updateVelocityConfig(fetch, params.name, config);
+
+			if (result.error) {
+				return fail(500, { error: result.error });
+			}
+
+			return { success: true };
+		} catch {
+			return fail(500, { error: 'Failed to update Velocity config' });
+		}
+	}
+} satisfies Actions;

--- a/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.svelte
@@ -1,0 +1,564 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
+	import type { PageData, ActionData } from './$types';
+	import type { VelocityConfig } from '$lib/api/types';
+
+	let { data, form }: { data: PageData; form: ActionData } = $props();
+
+	function emptyConfig(): VelocityConfig {
+		return {
+			exists: false,
+			bind: '0.0.0.0:25577',
+			motd: '<#09add3>A Velocity Server',
+			showMaxPlayers: 500,
+			onlineMode: true,
+			forceKeyAuthentication: true,
+			preventClientProxyConnections: false,
+			playerInfoForwardingMode: 'none',
+			forwardingSecretFile: 'forwarding.secret',
+			announceForge: false,
+			kickExistingPlayers: false,
+			pingPassthrough: 'DISABLED',
+			enablePlayerAddressLogging: true,
+			servers: {},
+			try: []
+		};
+	}
+
+	let config = $state<VelocityConfig>({ ...(data.config.data ?? emptyConfig()) });
+	let initial = $state<VelocityConfig>(JSON.parse(JSON.stringify(config)));
+	let lastServerName = $state(data.serverName);
+
+	let serverEntries = $state<{ name: string; address: string }[]>(
+		Object.entries(config.servers).map(([name, address]) => ({ name, address }))
+	);
+	let tryList = $state<string[]>([...config.try]);
+	let saving = $state(false);
+
+	$effect(() => {
+		if (data.serverName !== lastServerName) {
+			lastServerName = data.serverName;
+			const fresh = data.config.data ?? emptyConfig();
+			config = { ...fresh };
+			initial = JSON.parse(JSON.stringify(fresh));
+			serverEntries = Object.entries(fresh.servers).map(([name, address]) => ({
+				name,
+				address
+			}));
+			tryList = [...fresh.try];
+		}
+	});
+
+	const dirty = $derived.by(() => {
+		const current: VelocityConfig = {
+			...config,
+			servers: Object.fromEntries(
+				serverEntries
+					.filter((e) => e.name.trim().length > 0)
+					.map((e) => [e.name.trim(), e.address.trim()])
+			),
+			try: tryList.filter((n) => n.trim().length > 0)
+		};
+		return JSON.stringify(current) !== JSON.stringify(initial);
+	});
+
+	function buildSubmitConfig(): VelocityConfig {
+		return {
+			...config,
+			servers: Object.fromEntries(
+				serverEntries
+					.filter((e) => e.name.trim().length > 0)
+					.map((e) => [e.name.trim(), e.address.trim()])
+			),
+			try: tryList.filter((n) => n.trim().length > 0)
+		};
+	}
+
+	function addServer() {
+		serverEntries = [...serverEntries, { name: '', address: '' }];
+	}
+
+	function removeServer(idx: number) {
+		const removedName = serverEntries[idx]?.name.trim();
+		serverEntries = serverEntries.filter((_, i) => i !== idx);
+		if (removedName) {
+			tryList = tryList.filter((n) => n !== removedName);
+		}
+	}
+
+	function addTry() {
+		tryList = [...tryList, ''];
+	}
+
+	function removeTry(idx: number) {
+		tryList = tryList.filter((_, i) => i !== idx);
+	}
+
+	function resetForm() {
+		config = JSON.parse(JSON.stringify(initial));
+		serverEntries = Object.entries(initial.servers).map(([name, address]) => ({
+			name,
+			address
+		}));
+		tryList = [...initial.try];
+	}
+</script>
+
+<svelte:head>
+	<title>Velocity Config | {data.serverName} | MineOS</title>
+</svelte:head>
+
+<div class="page">
+	<header class="header">
+		<div>
+			<h1>Velocity Configuration</h1>
+			<p class="subtitle">
+				Edit <code>velocity.toml</code>. Changes require a restart to take effect.
+			</p>
+		</div>
+		<div class="header-actions">
+			<button class="btn btn-secondary" type="button" onclick={resetForm} disabled={!dirty}>
+				Reset
+			</button>
+		</div>
+	</header>
+
+	{#if !config.exists}
+		<div class="hint">
+			<strong>velocity.toml has not been generated yet.</strong> Showing Velocity defaults — saving
+			here will create the file. Alternatively, start the server once and it will generate the
+			file with its own defaults.
+		</div>
+	{/if}
+
+	{#if form?.error}
+		<div class="error">{form.error}</div>
+	{:else if form?.success}
+		<div class="success">Saved. Restart the proxy for changes to apply.</div>
+	{/if}
+
+	<form
+		method="POST"
+		use:enhance={() => {
+			saving = true;
+			return async ({ update }) => {
+				await update();
+				await invalidateAll();
+				saving = false;
+				initial = JSON.parse(JSON.stringify(buildSubmitConfig()));
+			};
+		}}
+	>
+		<input type="hidden" name="config" value={JSON.stringify(buildSubmitConfig())} />
+
+		<section class="card">
+			<h2>Network</h2>
+			<div class="grid">
+				<label class="field">
+					<span class="label">Bind address</span>
+					<input type="text" bind:value={config.bind} placeholder="0.0.0.0:25577" />
+					<span class="help">IP and port the proxy listens on. Default port is 25577.</span>
+				</label>
+				<label class="field">
+					<span class="label">MOTD</span>
+					<input type="text" bind:value={config.motd} />
+					<span class="help">Server list message. Supports MiniMessage format.</span>
+				</label>
+				<label class="field">
+					<span class="label">Show max players</span>
+					<input type="number" bind:value={config.showMaxPlayers} min="0" max="100000" />
+					<span class="help">Cosmetic player cap shown in server list.</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.onlineMode} />
+					<span class="label">Online mode</span>
+					<span class="help">Authenticate players with Mojang.</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.forceKeyAuthentication} />
+					<span class="label">Force key authentication</span>
+					<span class="help">Require signed messages from clients.</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.preventClientProxyConnections} />
+					<span class="label">Prevent client-side proxies</span>
+					<span class="help">Weak VPN/proxy filter; can have false positives.</span>
+				</label>
+			</div>
+		</section>
+
+		<section class="card">
+			<h2>Forwarding</h2>
+			<div class="grid">
+				<label class="field">
+					<span class="label">Player info forwarding mode</span>
+					<select bind:value={config.playerInfoForwardingMode}>
+						<option value="none">none</option>
+						<option value="legacy">legacy (BungeeCord-compatible)</option>
+						<option value="bungeeguard">bungeeguard</option>
+						<option value="modern">modern (recommended for Paper backends)</option>
+					</select>
+					<span class="help"
+						>Use <code>modern</code> if your backends are Paper 1.13+ and you control them.</span
+					>
+				</label>
+				<label class="field">
+					<span class="label">Forwarding secret file</span>
+					<input type="text" bind:value={config.forwardingSecretFile} />
+					<span class="help"
+						>Filename in the server directory holding the modern/bungeeguard secret.</span
+					>
+				</label>
+				<label class="field">
+					<span class="label">Ping passthrough</span>
+					<select bind:value={config.pingPassthrough}>
+						<option value="DISABLED">DISABLED</option>
+						<option value="MODS">MODS</option>
+						<option value="DESCRIPTION">DESCRIPTION</option>
+						<option value="ALL">ALL</option>
+					</select>
+					<span class="help">What server-list info gets forwarded from the backend.</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.announceForge} />
+					<span class="label">Announce Forge</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.kickExistingPlayers} />
+					<span class="label">Kick existing players on reconnect</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.enablePlayerAddressLogging} />
+					<span class="label">Log player addresses</span>
+				</label>
+			</div>
+		</section>
+
+		<section class="card">
+			<div class="card-header">
+				<h2>Backend servers</h2>
+				<button class="btn btn-secondary" type="button" onclick={addServer}>+ Add</button>
+			</div>
+			<p class="card-description">
+				Map a name to a backend Minecraft server's <code>host:port</code>.
+			</p>
+			{#if serverEntries.length === 0}
+				<p class="empty">No backends configured. Velocity won't have anywhere to route players.</p>
+			{:else}
+				<div class="server-rows">
+					{#each serverEntries as entry, i}
+						<div class="server-row">
+							<input type="text" placeholder="Name (e.g. lobby)" bind:value={entry.name} />
+							<input
+								type="text"
+								placeholder="host:port (e.g. 127.0.0.1:30066)"
+								bind:value={entry.address}
+							/>
+							<button
+								class="btn btn-icon"
+								type="button"
+								title="Remove"
+								onclick={() => removeServer(i)}>×</button
+							>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</section>
+
+		<section class="card">
+			<div class="card-header">
+				<h2>Try order</h2>
+				<button class="btn btn-secondary" type="button" onclick={addTry}>+ Add</button>
+			</div>
+			<p class="card-description">
+				Server names to try in order when a player joins or gets kicked from a backend. Names must
+				match entries above.
+			</p>
+			{#if tryList.length === 0}
+				<p class="empty">No try list configured.</p>
+			{:else}
+				<div class="try-rows">
+					{#each tryList as name, i}
+						<div class="try-row">
+							<input type="text" placeholder="Backend name" bind:value={tryList[i]} />
+							<button
+								class="btn btn-icon"
+								type="button"
+								title="Remove"
+								onclick={() => removeTry(i)}>×</button
+							>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</section>
+
+		<div class="actions">
+			<button class="btn btn-primary" type="submit" disabled={!dirty || saving}>
+				{saving ? 'Saving…' : 'Save'}
+			</button>
+		</div>
+	</form>
+</div>
+
+<style>
+	.page {
+		padding: 1.5rem 2rem;
+		max-width: 980px;
+		margin: 0 auto;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 1rem;
+	}
+
+	.header h1 {
+		margin: 0 0 4px;
+		font-size: 1.6rem;
+		font-weight: 700;
+	}
+
+	.subtitle {
+		margin: 0;
+		color: var(--mc-text-muted, #9aa2c5);
+		font-size: 0.9rem;
+	}
+
+	.subtitle code,
+	.help code,
+	.card-description code {
+		background: rgba(255, 255, 255, 0.08);
+		padding: 0.05rem 0.3rem;
+		border-radius: 0.2rem;
+		font-size: 0.85em;
+	}
+
+	.hint {
+		padding: 0.6rem 0.9rem;
+		font-size: 0.85rem;
+		color: var(--mc-text-secondary, #c4cff5);
+		background: rgba(6, 182, 212, 0.08);
+		border: 1px solid rgba(6, 182, 212, 0.25);
+		border-radius: 0.5rem;
+	}
+
+	.error {
+		padding: 0.6rem 0.9rem;
+		font-size: 0.9rem;
+		color: #fecaca;
+		background: rgba(239, 68, 68, 0.12);
+		border: 1px solid rgba(239, 68, 68, 0.3);
+		border-radius: 0.5rem;
+	}
+
+	.success {
+		padding: 0.6rem 0.9rem;
+		font-size: 0.9rem;
+		color: #bbf7d0;
+		background: rgba(34, 197, 94, 0.12);
+		border: 1px solid rgba(34, 197, 94, 0.3);
+		border-radius: 0.5rem;
+	}
+
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.card {
+		background: var(--mc-panel, rgba(22, 27, 46, 0.95));
+		border: 1px solid var(--border-color, #2a2f47);
+		border-radius: 0.75rem;
+		padding: 1.25rem;
+	}
+
+	.card h2 {
+		margin: 0 0 0.75rem;
+		font-size: 1.05rem;
+		font-weight: 600;
+	}
+
+	.card-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 0.5rem;
+	}
+
+	.card-header h2 {
+		margin: 0;
+	}
+
+	.card-description {
+		margin: 0 0 0.75rem;
+		font-size: 0.85rem;
+		color: var(--mc-text-muted, #9aa2c5);
+	}
+
+	.empty {
+		margin: 0.5rem 0 0;
+		font-size: 0.85rem;
+		color: var(--mc-text-muted, #9aa2c5);
+		font-style: italic;
+	}
+
+	.grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.75rem 1rem;
+	}
+
+	@media (max-width: 720px) {
+		.grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.field .label {
+		font-size: 0.85rem;
+		font-weight: 500;
+		color: var(--mc-text-secondary, #c4cff5);
+	}
+
+	.field input[type='text'],
+	.field input[type='number'],
+	.field select {
+		padding: 0.4rem 0.6rem;
+		background: var(--input-bg, #1f2937);
+		border: 1px solid var(--border-color, #374151);
+		border-radius: 0.375rem;
+		color: inherit;
+		font-size: 0.9rem;
+		font-family: inherit;
+	}
+
+	.field.checkbox {
+		flex-direction: row;
+		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	.field.checkbox input[type='checkbox'] {
+		width: 1rem;
+		height: 1rem;
+		flex-shrink: 0;
+	}
+
+	.field.checkbox .label {
+		flex: 1 1 auto;
+	}
+
+	.field.checkbox .help {
+		flex-basis: 100%;
+		margin-left: 1.5rem;
+	}
+
+	.help {
+		font-size: 0.75rem;
+		color: var(--mc-text-muted, #9aa2c5);
+	}
+
+	.server-rows,
+	.try-rows {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.server-row {
+		display: grid;
+		grid-template-columns: 1fr 2fr auto;
+		gap: 0.5rem;
+	}
+
+	.try-row {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		gap: 0.5rem;
+	}
+
+	.server-row input,
+	.try-row input {
+		padding: 0.35rem 0.55rem;
+		background: var(--input-bg, #1f2937);
+		border: 1px solid var(--border-color, #374151);
+		border-radius: 0.35rem;
+		color: inherit;
+		font-size: 0.85rem;
+		font-family: inherit;
+	}
+
+	.btn {
+		padding: 0.4rem 0.9rem;
+		border-radius: 0.4rem;
+		border: 1px solid transparent;
+		font-size: 0.85rem;
+		font-weight: 500;
+		cursor: pointer;
+		font-family: inherit;
+	}
+
+	.btn-primary {
+		background: #06b6d4;
+		color: #0b1220;
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		filter: brightness(1.08);
+	}
+
+	.btn-primary:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.btn-secondary {
+		background: var(--mc-panel-light, #2a2f47);
+		color: var(--mc-text-secondary, #c4cff5);
+	}
+
+	.btn-secondary:hover:not(:disabled) {
+		background: var(--mc-panel-lighter, #3a3f5a);
+	}
+
+	.btn-secondary:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.btn-icon {
+		background: transparent;
+		color: var(--mc-text-muted, #9aa2c5);
+		border: 1px solid var(--border-color, #374151);
+		padding: 0.2rem 0.55rem;
+		font-size: 1rem;
+		line-height: 1;
+	}
+
+	.btn-icon:hover {
+		color: #fecaca;
+		border-color: rgba(239, 68, 68, 0.4);
+	}
+
+	.actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.6rem;
+	}
+</style>

--- a/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.svelte
@@ -22,7 +22,8 @@
 			pingPassthrough: 'DISABLED',
 			enablePlayerAddressLogging: true,
 			servers: {},
-			try: []
+			try: [],
+			forcedHosts: {}
 		};
 	}
 
@@ -34,6 +35,12 @@
 		Object.entries(config.servers).map(([name, address]) => ({ name, address }))
 	);
 	let tryList = $state<string[]>([...config.try]);
+	let forcedHostEntries = $state<{ hostname: string; servers: string }[]>(
+		Object.entries(config.forcedHosts).map(([hostname, servers]) => ({
+			hostname,
+			servers: servers.join(', ')
+		}))
+	);
 	let saving = $state(false);
 
 	$effect(() => {
@@ -47,8 +54,26 @@
 				address
 			}));
 			tryList = [...fresh.try];
+			forcedHostEntries = Object.entries(fresh.forcedHosts).map(([hostname, servers]) => ({
+				hostname,
+				servers: servers.join(', ')
+			}));
 		}
 	});
+
+	function buildForcedHostsObject(): Record<string, string[]> {
+		const result: Record<string, string[]> = {};
+		for (const e of forcedHostEntries) {
+			const host = e.hostname.trim();
+			if (!host) continue;
+			const servers = e.servers
+				.split(',')
+				.map((s) => s.trim())
+				.filter((s) => s.length > 0);
+			result[host] = servers;
+		}
+		return result;
+	}
 
 	const dirty = $derived.by(() => {
 		const current: VelocityConfig = {
@@ -58,7 +83,8 @@
 					.filter((e) => e.name.trim().length > 0)
 					.map((e) => [e.name.trim(), e.address.trim()])
 			),
-			try: tryList.filter((n) => n.trim().length > 0)
+			try: tryList.filter((n) => n.trim().length > 0),
+			forcedHosts: buildForcedHostsObject()
 		};
 		return JSON.stringify(current) !== JSON.stringify(initial);
 	});
@@ -71,7 +97,8 @@
 					.filter((e) => e.name.trim().length > 0)
 					.map((e) => [e.name.trim(), e.address.trim()])
 			),
-			try: tryList.filter((n) => n.trim().length > 0)
+			try: tryList.filter((n) => n.trim().length > 0),
+			forcedHosts: buildForcedHostsObject()
 		};
 	}
 
@@ -95,6 +122,14 @@
 		tryList = tryList.filter((_, i) => i !== idx);
 	}
 
+	function addForcedHost() {
+		forcedHostEntries = [...forcedHostEntries, { hostname: '', servers: '' }];
+	}
+
+	function removeForcedHost(idx: number) {
+		forcedHostEntries = forcedHostEntries.filter((_, i) => i !== idx);
+	}
+
 	function resetForm() {
 		config = JSON.parse(JSON.stringify(initial));
 		serverEntries = Object.entries(initial.servers).map(([name, address]) => ({
@@ -102,6 +137,10 @@
 			address
 		}));
 		tryList = [...initial.try];
+		forcedHostEntries = Object.entries(initial.forcedHosts).map(([hostname, servers]) => ({
+			hostname,
+			servers: servers.join(', ')
+		}));
 	}
 </script>
 
@@ -298,6 +337,43 @@
 			{/if}
 		</section>
 
+		<section class="card">
+			<div class="card-header">
+				<h2>Forced hosts</h2>
+				<button class="btn btn-secondary" type="button" onclick={addForcedHost}>+ Add</button>
+			</div>
+			<p class="card-description">
+				Route players to specific backends based on the hostname they connect with.
+				Servers is a comma-separated list of backend names from above (tried in order).
+			</p>
+			{#if forcedHostEntries.length === 0}
+				<p class="empty">No forced hosts configured.</p>
+			{:else}
+				<div class="server-rows">
+					{#each forcedHostEntries as entry, i}
+						<div class="server-row">
+							<input
+								type="text"
+								placeholder="hostname (e.g. lobby.example.com)"
+								bind:value={entry.hostname}
+							/>
+							<input
+								type="text"
+								placeholder="servers (e.g. lobby, fallback)"
+								bind:value={entry.servers}
+							/>
+							<button
+								class="btn btn-icon"
+								type="button"
+								title="Remove"
+								onclick={() => removeForcedHost(i)}>×</button
+							>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</section>
+
 		<div class="actions">
 			<button class="btn btn-primary" type="submit" disabled={!dirty || saving}>
 				{saving ? 'Saving…' : 'Save'}
@@ -309,8 +385,6 @@
 <style>
 	.page {
 		padding: 1.5rem 2rem;
-		max-width: 980px;
-		margin: 0 auto;
 		display: flex;
 		flex-direction: column;
 		gap: 1rem;

--- a/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.svelte
@@ -207,7 +207,10 @@
 					<span class="label">Forwarding secret file</span>
 					<input type="text" bind:value={config.forwardingSecretFile} />
 					<span class="help"
-						>Filename in the server directory holding the modern/bungeeguard secret.</span
+						>Filename in the server directory holding the modern/bungeeguard secret. Only
+						used when forwarding mode is <code>modern</code> or <code>bungeeguard</code>.
+						Older Velocity 3.x versions write the secret inline into <code>velocity.toml</code>
+						(as <code>forwarding-secret</code>) instead of creating this file.</span
 					>
 				</label>
 				<label class="field">

--- a/apps/web/src/routes/(app)/servers/new/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/new/+page.svelte
@@ -57,6 +57,7 @@
 			implementation = 'template';
 			step = 'version';
 		} else {
+			// 'plugins', 'mods', 'proxy' all need an implementation selection
 			step = 'implementation';
 		}
 	}
@@ -85,7 +86,7 @@
 
 	function goBackFromVersion() {
 		versionConfirm = null;
-		if (category === 'plugins' || category === 'mods') {
+		if (category === 'plugins' || category === 'mods' || category === 'proxy') {
 			step = 'implementation';
 			implementation = null;
 			selectedImpl = null;
@@ -125,7 +126,10 @@
 		// Create the server first
 		simpleStepText = 'Creating server...';
 		simpleProgress = 5;
-		const serverType = implementation === 'bedrock' ? 'bedrock' : 'java';
+		const serverType =
+			implementation === 'bedrock' ? 'bedrock'
+			: implementation === 'velocity' ? 'proxy'
+			: 'java';
 		const createResult = await api.createServer(fetch, {
 			name,
 			ownerUid: 1000,
@@ -381,7 +385,7 @@
 
 		{#if step === 'category'}
 			<CategorySelect onselect={selectCategory} />
-		{:else if step === 'implementation' && (category === 'plugins' || category === 'mods')}
+		{:else if step === 'implementation' && (category === 'plugins' || category === 'mods' || category === 'proxy')}
 			<ImplementationSelect
 				{category}
 				onselect={(id) => selectedImpl = id}

--- a/apps/web/src/routes/(app)/servers/new/steps/CategorySelect.svelte
+++ b/apps/web/src/routes/(app)/servers/new/steps/CategorySelect.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import SelectionCard from '$lib/components/SelectionCard.svelte';
 
-	export type ServerCategory = 'vanilla' | 'plugins' | 'mods' | 'bedrock' | 'template';
+	export type ServerCategory = 'vanilla' | 'plugins' | 'mods' | 'proxy' | 'bedrock' | 'template';
 
 	interface Props {
 		onselect: (category: ServerCategory) => void;
@@ -36,6 +36,15 @@
 			iconImage: '/images/mods.png',
 			color: '#a855f7',
 			features: ['New blocks', 'Dimensions', 'Total conversions']
+		},
+		{
+			id: 'proxy' as const,
+			name: 'Proxy',
+			description: 'Velocity proxy for routing players across multiple backend servers',
+			icon: '🌐',
+			iconImage: '',
+			color: '#06b6d4',
+			features: ['Multi-server', 'Network', 'No world']
 		},
 		{
 			id: 'bedrock' as const,

--- a/apps/web/src/routes/(app)/servers/new/steps/ImplementationSelect.svelte
+++ b/apps/web/src/routes/(app)/servers/new/steps/ImplementationSelect.svelte
@@ -4,10 +4,11 @@
 
 	export type PluginImpl = 'paper' | 'spigot';
 	export type ModLoader = 'forge' | 'neoforge' | 'fabric' | 'quilt';
-	export type Implementation = PluginImpl | ModLoader;
+	export type ProxyImpl = 'velocity';
+	export type Implementation = PluginImpl | ModLoader | ProxyImpl;
 
 	interface Props {
-		category: 'plugins' | 'mods';
+		category: 'plugins' | 'mods' | 'proxy';
 		onselect: (impl: Implementation) => void;
 		onback: () => void;
 	}
@@ -35,6 +36,19 @@
 			iconImage: '/images/loaders/spigot.png',
 			color: '#fbbf24'
 		},
+	];
+
+	const proxyOptions = [
+		{
+			id: 'velocity' as const,
+			name: 'Velocity',
+			description:
+				'Modern, high-performance Minecraft proxy from PaperMC. Java 21+ required.',
+			icon: '🌐',
+			iconImage: '',
+			color: '#06b6d4',
+			badge: 'Recommended'
+		}
 	];
 
 	const modOptions = [
@@ -74,9 +88,15 @@
 		}
 	];
 
-	const options = $derived(category === 'plugins' ? pluginOptions : modOptions);
+	const options = $derived(
+		category === 'plugins' ? pluginOptions
+		: category === 'mods' ? modOptions
+		: proxyOptions
+	);
 	const heading = $derived(
-		category === 'plugins' ? 'Choose a plugin server' : 'Choose a modloader'
+		category === 'plugins' ? 'Choose a plugin server'
+		: category === 'mods' ? 'Choose a modloader'
+		: 'Choose a proxy'
 	);
 </script>
 

--- a/apps/web/src/routes/(app)/servers/new/steps/VersionSelect.svelte
+++ b/apps/web/src/routes/(app)/servers/new/steps/VersionSelect.svelte
@@ -8,6 +8,7 @@
 	import FabricVersions from '../version-pickers/FabricVersions.svelte';
 	import QuiltVersions from '../version-pickers/QuiltVersions.svelte';
 	import BedrockVersions from '../version-pickers/BedrockVersions.svelte';
+	import VelocityVersions from '../version-pickers/VelocityVersions.svelte';
 	import TemplateSelect from '../version-pickers/TemplateSelect.svelte';
 
 	interface VersionSelection {
@@ -40,6 +41,7 @@
 		fabric: 'Fabric',
 		quilt: 'Quilt',
 		bedrock: 'Bedrock',
+		velocity: 'Velocity',
 		template: 'Template'
 	};
 </script>
@@ -82,6 +84,12 @@
 		/>
 	{:else if implementation === 'bedrock'}
 		<BedrockVersions
+			{profiles}
+			onselect={(profile) => onselect({ profileId: profile.id, minecraftVersion: profile.version })}
+			onready={onready}
+		/>
+	{:else if implementation === 'velocity'}
+		<VelocityVersions
 			{profiles}
 			onselect={(profile) => onselect({ profileId: profile.id, minecraftVersion: profile.version })}
 			onready={onready}

--- a/apps/web/src/routes/(app)/servers/new/version-pickers/VelocityVersions.svelte
+++ b/apps/web/src/routes/(app)/servers/new/version-pickers/VelocityVersions.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+	import type { Profile } from '$lib/api/types';
+	import StatusBadge from '$lib/components/StatusBadge.svelte';
+
+	interface Props {
+		profiles: Profile[];
+		onselect: (profile: Profile) => void;
+		onready?: (fn: (() => void) | null) => void;
+	}
+
+	let { profiles, onselect, onready }: Props = $props();
+	let selectedProfile = $state<Profile | null>(null);
+
+	let search = $state('');
+	let page = $state(0);
+	const perPage = 20;
+
+	const filtered = $derived.by(() => {
+		let result = profiles.filter((p) => p.group === 'velocity');
+		if (search.trim()) {
+			result = result.filter((p) =>
+				p.version.toLowerCase().includes(search.trim().toLowerCase())
+			);
+		}
+		return result;
+	});
+
+	const paged = $derived(filtered.slice(page * perPage, (page + 1) * perPage));
+	const totalPages = $derived(Math.ceil(filtered.length / perPage));
+
+	$effect(() => {
+		search;
+		page = 0;
+	});
+</script>
+
+<div class="version-picker">
+	<div class="controls">
+		<input type="text" placeholder="Search versions..." bind:value={search} class="search" />
+	</div>
+
+	<div class="version-list">
+		{#each paged as profile}
+			<button
+				class="version-row"
+				class:selected={selectedProfile?.id === profile.id}
+				onclick={() => {
+					selectedProfile = profile;
+					onready?.(() => onselect(profile));
+				}}
+				type="button"
+			>
+				<span class="version-name">{profile.version}</span>
+				<span class="version-meta">
+					{#if profile.downloaded}
+						<StatusBadge variant="success" size="sm">Ready</StatusBadge>
+					{:else}
+						<StatusBadge variant="info" size="sm">Will Download</StatusBadge>
+					{/if}
+				</span>
+			</button>
+		{/each}
+		{#if paged.length === 0}
+			<div class="empty">No Velocity versions available</div>
+		{/if}
+	</div>
+
+	{#if totalPages > 1}
+		<div class="pagination">
+			<button onclick={() => (page = Math.max(0, page - 1))} disabled={page === 0} type="button"
+				>Prev</button
+			>
+			<span>
+				Page {page + 1} of {totalPages}
+			</span>
+			<button
+				onclick={() => (page = Math.min(totalPages - 1, page + 1))}
+				disabled={page >= totalPages - 1}
+				type="button">Next</button
+			>
+		</div>
+	{/if}
+
+	<p class="hint">
+		Velocity is a Minecraft proxy for connecting players to multiple backend servers. Requires
+		Java 21+. After first launch, edit <code>velocity.toml</code> in the server directory to
+		configure backends.
+	</p>
+</div>
+
+<style>
+	.version-picker {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.controls {
+		display: flex;
+		gap: 1rem;
+		align-items: center;
+	}
+
+	.search {
+		flex: 1;
+		padding: 0.4rem 0.75rem;
+		border: 1px solid var(--border-color, #374151);
+		border-radius: 0.375rem;
+		background: var(--input-bg, #1f2937);
+		color: inherit;
+		font-size: 0.85rem;
+	}
+
+	.version-list {
+		border: 1px solid var(--border-color, #374151);
+		border-radius: 0.5rem;
+		overflow: hidden;
+		max-height: 400px;
+		overflow-y: auto;
+	}
+
+	.version-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		width: 100%;
+		padding: 0.5rem 0.75rem;
+		border: none;
+		border-bottom: 1px solid var(--border-color, #374151);
+		background: transparent;
+		color: inherit;
+		cursor: pointer;
+		font-size: 0.85rem;
+		text-align: left;
+		font-family: inherit;
+	}
+
+	.version-row:last-child {
+		border-bottom: none;
+	}
+
+	.version-row:hover {
+		background: rgba(255, 255, 255, 0.05);
+	}
+
+	.version-row.selected {
+		background: rgba(6, 182, 212, 0.15);
+		border-color: #06b6d4;
+	}
+
+	.empty {
+		padding: 2rem;
+		text-align: center;
+		color: var(--text-secondary, #9ca3af);
+	}
+
+	.pagination {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		gap: 1rem;
+		font-size: 0.85rem;
+	}
+
+	.pagination button {
+		padding: 0.3rem 0.75rem;
+		border: 1px solid var(--border-color, #374151);
+		border-radius: 0.25rem;
+		background: transparent;
+		color: inherit;
+		cursor: pointer;
+		font-size: 0.8rem;
+	}
+
+	.pagination button:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.hint {
+		margin: 0;
+		padding: 0.6rem 0.8rem;
+		font-size: 0.78rem;
+		color: var(--text-secondary, #9ca3af);
+		background: rgba(6, 182, 212, 0.06);
+		border: 1px solid rgba(6, 182, 212, 0.2);
+		border-radius: 0.4rem;
+		line-height: 1.4;
+	}
+
+	.hint code {
+		background: rgba(255, 255, 255, 0.08);
+		padding: 0.05rem 0.3rem;
+		border-radius: 0.2rem;
+		font-size: 0.85em;
+	}
+</style>


### PR DESCRIPTION
Adds Velocity as a new "Proxy" server category alongside Vanilla, Plugins,
  Mods, Bedrock, and Template. The category is structured to host BungeeCord
  and Waterfall later without rework.

  Backend (apps/MineOS.Infrastructure/):
  - ProfileService: fetch Velocity builds from the PaperMC v2 API (mirrors
    the Paper code path with its own 10-min cache and stable-version filter)
  - ServerService: new "proxy" server type — skips server.properties and
    eula.txt at creation, defaults to port 25577 with java_xmx=1024/xms=512
    and unconventional=true (so the launcher does not append \`nogui\`),
    hard-pins Java 21 at startup, sends \`end\` (not \`stop\`) on graceful
    shutdown, and treats EULA as auto-accepted in server detail responses
  - AllowedServerTypes: add "proxy" and "velocity"

  Frontend (apps/web/):
  - New-server wizard: Proxy category card; ImplementationSelect with
    Velocity option; new VelocityVersions picker filtering profiles by
    group=velocity; +page.svelte maps implementation 'velocity' to
    serverType 'proxy'
  - Server detail layout: disable Properties, Worlds, Players, Mods, and
    Plugins tabs for proxies with proxy-specific tooltips, mirroring the
    existing Bedrock pattern

  Verified end-to-end against the running API: profile listing returns the
  expected stable Velocity builds, server creation produces the right
  on-disk layout (no eula.txt, no server.properties), and copy-to-server
  populates the jar correctly.