### PR TITLE
fix: migrate Paper to Fill v3 + Velocity proxy follow-ups

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,9 +1,9 @@
 name: Publish Docker Images
 
+# Releases are cut from v* tags only. Do not add a branches trigger here —
+# that would publish :latest images on every push to the default branch.
 on:
   push:
-    branches:
-      - main
     tags:
       - "v*"
   workflow_dispatch:

--- a/apps/MineOS.Infrastructure/Services/ProfileService.cs
+++ b/apps/MineOS.Infrastructure/Services/ProfileService.cs
@@ -19,8 +19,8 @@ public sealed class ProfileService : IProfileService
     private const string BuildToolsUrl =
         "https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar";
     private const string RestartFlagFile = ".mineos-restart-required";
-    private const string PaperProjectUrl = "https://api.papermc.io/v2/projects/paper";
     // PaperMC's legacy api.papermc.io/v2 API was sunset in 2026; Fill v3 is the replacement.
+    private const string PaperProjectUrl = "https://fill.papermc.io/v3/projects/paper";
     private const string VelocityProjectUrl = "https://fill.papermc.io/v3/projects/velocity";
     private const string MojangVersionManifestUrl = "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json";
     private const int PaperVersionLimit = 20;
@@ -1046,29 +1046,39 @@ public sealed class ProfileService : IProfileService
             var json = await _httpClient.GetStringAsync(PaperProjectUrl, cancellationToken);
             using var doc = JsonDocument.Parse(json);
 
+            // Fill v3 shape: "versions" is an object mapping a version group to an
+            // array of version strings, e.g. { "1.21": ["1.21.11", "1.21.11-rc3", ...] }.
             if (!doc.RootElement.TryGetProperty("versions", out var versionsElement) ||
-                versionsElement.ValueKind != JsonValueKind.Array)
+                versionsElement.ValueKind != JsonValueKind.Object)
             {
                 return Array.Empty<ProfileDto>();
             }
 
             var versions = new List<(string Raw, Version Parsed)>();
-            foreach (var element in versionsElement.EnumerateArray())
+            foreach (var group in versionsElement.EnumerateObject())
             {
-                var versionText = element.GetString();
-                if (string.IsNullOrWhiteSpace(versionText))
+                if (group.Value.ValueKind != JsonValueKind.Array)
                 {
                     continue;
                 }
 
-                if (!IsStablePaperVersion(versionText))
+                foreach (var element in group.Value.EnumerateArray())
                 {
-                    continue;
-                }
+                    var versionText = element.GetString();
+                    if (string.IsNullOrWhiteSpace(versionText))
+                    {
+                        continue;
+                    }
 
-                if (Version.TryParse(versionText, out var parsed))
-                {
-                    versions.Add((versionText, parsed));
+                    if (!IsStablePaperVersion(versionText))
+                    {
+                        continue;
+                    }
+
+                    if (Version.TryParse(versionText, out var parsed))
+                    {
+                        versions.Add((versionText, parsed));
+                    }
                 }
             }
 
@@ -1089,16 +1099,13 @@ public sealed class ProfileService : IProfileService
                         continue;
                     }
 
-                    var url =
-                        $"https://api.papermc.io/v2/projects/paper/versions/{version}/builds/{build.Build}/downloads/{build.FileName}";
-
                     results.Add(new ProfileDto(
                         $"paper-{version}",
                         "paper",
                         "release",
                         version,
                         build.Time,
-                        url,
+                        build.Url,
                         build.FileName,
                         false,
                         null));
@@ -1120,44 +1127,29 @@ public sealed class ProfileService : IProfileService
 
     private async Task<PaperBuildInfo?> GetLatestPaperBuildAsync(string version, CancellationToken cancellationToken)
     {
-        var versionUrl = $"{PaperProjectUrl}/versions/{version}";
-        var json = await _httpClient.GetStringAsync(versionUrl, cancellationToken);
-        using var doc = JsonDocument.Parse(json);
-
-        if (!doc.RootElement.TryGetProperty("builds", out var buildsElement) ||
-            buildsElement.ValueKind != JsonValueKind.Array)
-        {
-            return null;
-        }
-
-        var builds = buildsElement
-            .EnumerateArray()
-            .Select(element => element.GetInt32())
-            .ToList();
-
-        if (builds.Count == 0)
-        {
-            return null;
-        }
-
-        var latestBuild = builds[^1];
-        var buildUrl = $"{versionUrl}/builds/{latestBuild}";
+        // Fill v3 exposes the newest build directly, downloads keyed by kind
+        // ("server:default") with an absolute download URL.
+        var buildUrl = $"{PaperProjectUrl}/versions/{version}/builds/latest";
         var buildJson = await _httpClient.GetStringAsync(buildUrl, cancellationToken);
         using var buildDoc = JsonDocument.Parse(buildJson);
+
+        if (!buildDoc.RootElement.TryGetProperty("downloads", out var downloadsElement) ||
+            !downloadsElement.TryGetProperty("server:default", out var serverDownload) ||
+            !serverDownload.TryGetProperty("url", out var urlElement) ||
+            urlElement.GetString() is not string url)
+        {
+            return null;
+        }
 
         var time = buildDoc.RootElement.TryGetProperty("time", out var timeElement)
             ? timeElement.GetString() ?? DateTimeOffset.UtcNow.ToString("O")
             : DateTimeOffset.UtcNow.ToString("O");
 
-        string fileName = $"paper-{version}-{latestBuild}.jar";
-        if (buildDoc.RootElement.TryGetProperty("downloads", out var downloadsElement) &&
-            downloadsElement.TryGetProperty("application", out var appElement) &&
-            appElement.TryGetProperty("name", out var nameElement))
-        {
-            fileName = nameElement.GetString() ?? fileName;
-        }
+        var fileName = serverDownload.TryGetProperty("name", out var nameElement)
+            ? nameElement.GetString() ?? $"paper-{version}.jar"
+            : $"paper-{version}.jar";
 
-        return new PaperBuildInfo(latestBuild, time, fileName);
+        return new PaperBuildInfo(time, fileName, url);
     }
 
     private static bool IsStablePaperVersion(string version)
@@ -1449,7 +1441,7 @@ public sealed class ProfileService : IProfileService
                 "release",
                 "1.20.4",
                 now,
-                "https://api.papermc.io/v2/projects/paper/versions/1.20.4/builds/496/downloads/paper-1.20.4-496.jar",
+                "https://fill-data.papermc.io/v1/objects/cabed3ae77cf55deba7c7d8722bc9cfd5e991201c211665f9265616d9fe5c77b/paper-1.20.4-499.jar",
                 "paper-1.20.4.jar",
                 false,
                 null
@@ -1527,7 +1519,7 @@ public sealed class ProfileService : IProfileService
     }
 
     private record MojangVersionInfo(string Id, string Url, string ReleaseTime, DateTimeOffset? ReleaseTimeParsed);
-    private record PaperBuildInfo(int Build, string Time, string FileName);
+    private record PaperBuildInfo(string Time, string FileName, string Url);
 
     private async Task MarkRestartRequiredAsync(string serverPath, CancellationToken cancellationToken)
     {

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -1061,7 +1061,10 @@ public class ServerService : IServerService
         else
         {
             model = new TomlTable();
-            model["config-version"] = "1.0";
+            // Match current Velocity 3.x. Writing an old version (e.g. "1.0") makes
+            // Velocity run its config migration on first boot, which logs a
+            // deprecation warning and escapes the MiniMessage MOTD.
+            model["config-version"] = "2.7";
         }
 
         model["bind"] = config.Bind;
@@ -1710,17 +1713,40 @@ public class ServerService : IServerService
             }
 
             var propertiesPath = Path.Combine(dir, "server.properties");
-            if (!File.Exists(propertiesPath))
+            if (File.Exists(propertiesPath))
             {
+                var content = await File.ReadAllTextAsync(propertiesPath, cancellationToken);
+                var props = IniParser.ParseSimple(content);
+                if (props.TryGetValue("server-port", out var portValue) &&
+                    int.TryParse(portValue, out var port))
+                {
+                    usedPorts.Add(port);
+                }
                 continue;
             }
 
-            var content = await File.ReadAllTextAsync(propertiesPath, cancellationToken);
-            var props = IniParser.ParseSimple(content);
-            if (props.TryGetValue("server-port", out var portValue) &&
-                int.TryParse(portValue, out var port))
+            // Proxies have no server.properties — their port lives in velocity.toml's
+            // "bind". Count it so a second proxy doesn't default to the same port.
+            var tomlPath = Path.Combine(dir, "velocity.toml");
+            if (File.Exists(tomlPath))
             {
-                usedPorts.Add(port);
+                try
+                {
+                    var toml = Toml.ToModel(await File.ReadAllTextAsync(tomlPath, cancellationToken));
+                    if (toml.TryGetValue("bind", out var bindObj) && bindObj is string bind)
+                    {
+                        var lastColon = bind.LastIndexOf(':');
+                        if (lastColon > 0 && lastColon < bind.Length - 1 &&
+                            int.TryParse(bind[(lastColon + 1)..], out var bindPort))
+                        {
+                            usedPorts.Add(bindPort);
+                        }
+                    }
+                }
+                catch
+                {
+                    // Malformed toml — skip; worst case the port is offered again.
+                }
             }
         }
 
@@ -1808,6 +1834,17 @@ public class ServerService : IServerService
         // type-changed proxy is functional from the first launch.
         if (normalized == "proxy")
         {
+            // Velocity rejects `nogui`; flip unconventional so the launcher won't
+            // append it (wizard-created proxies already set this at creation).
+            var config = await GetServerConfigAsync(name, cancellationToken);
+            if (!config.Minecraft.Unconventional)
+            {
+                await UpdateServerConfigAsync(
+                    name,
+                    config with { Minecraft = config.Minecraft with { Unconventional = true } },
+                    cancellationToken);
+            }
+
             var tomlPath = GetVelocityTomlPath(name);
             if (!File.Exists(tomlPath))
             {


### PR DESCRIPTION
## Why

PaperMC sunset `api.papermc.io/v2` — the same breakage that hit Velocity in #99 also affects **Paper on the live server**:

- The version picker serves a stale in-memory cache (frozen at 1.21.11; **26.x never appears**). The API logs `Failed to fetch Paper profiles ... 410 (Gone)` every refresh.
- Any "Will Download" version fails — the cached URLs point at the dead v2 API.
- After a container restart the Paper list would collapse to the single hardcoded 1.20.4 default (whose URL was also dead).

## What

1. **Paper → Fill v3** (`fill.papermc.io/v3`), mirroring the Velocity migration (`ae89a7e`): versions come from the v3 group map, download URLs come from `builds/latest` → `downloads["server:default"]`. Default `paper-1.20.4` profile URL updated to its fill-data equivalent.
2. **Proxy follow-ups from the #99 review:**
   - `GetUsedPortsAsync` now counts proxy `velocity.toml` bind ports, so a second proxy no longer defaults to the same port.
   - Fresh `velocity.toml` files get `config-version = "2.7"` instead of `"1.0"`, avoiding Velocity's first-boot config migration (deprecation warning + it escaped the MiniMessage MOTD).
   - Changing a server's type to `proxy` via the API now sets `unconventional=true` so the launcher doesn't append `nogui` (Velocity rejects it).
3. **CI:** `publish-images.yml` dropped its dead `branches: [main]` trigger — images publish from `v*` tags (and manual dispatch) only, and can't start publishing on branch pushes if the default branch is ever renamed.

## Verification (live Docker stack)

- All 56 tests pass.
- Paper picker lists 20 stable versions, newest **26.2**; `paper-26.2-56.jar` (61.7 MB) downloads from fill-data.
- `proxy2` created → port 25577; `proxy3` → **25578** (previously would have collided).
- Velocity **3.4.0** boots with no deprecation warning and the MOTD unescaped; old **3.1.1** also boots cleanly with `config-version 2.7`.
- `PUT /servers/{name}/server-type {"serverType":"proxy"}` on a Java server flips `unconventional=true` and seeds `velocity.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)