### PR TITLE
fix: release hardening — security, data-loss, and correctness fixes

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: releasing-mineos
+description: Use when cutting, tagging, or publishing a mineos-sveltekit release, choosing a version number, or asked to "ship it" / "cut a release" / "make a build" / "publish images" for this repo.
+---
+
+# Releasing mineos-sveltekit
+
+## Overview
+
+Releases are **100% tag-driven**. Pushing a `v*` git tag is the entire release action — it triggers `publish-images.yml` (GHCR Docker images) and `publish-install-bundle.yml` (CLI binaries + install bundle + the GitHub Release). There are no version numbers to bump in source: the tag string flows into images and binaries via build args. Get the tag string and the tagged branch right and everything downstream is automatic; get them wrong and you silently ship a regression or clobber a release channel.
+
+## The Iron Rules
+
+1. **A release is a tag push, nothing else.** Never edit source "for the release." Never push to `master`/`main` to release. The version comes from the tag.
+2. **The tag string is load-bearing — one character decides the channel.** The workflow routes purely on "does the tag contain a hyphen":
+   - `vX.Y.Z` (no hyphen) → moves the `:latest` image tag **and** GitHub `releases/latest` (what `install.sh` installs by default). This is a **stable** release to every default user.
+   - `vX.Y.Z-beta.N` / `-rc.N` / `-alpha.N` (has hyphen) → moves `:preview`, marked prerelease. Default installs are untouched.
+   - A typo like `v1.2.0.beta.3` (dot, not hyphen) reads as **stable** and hijacks `:latest`. Type the tag exactly; re-read it before pushing.
+3. **Tag the branch the version train lives on — not reflexively `master`.** History: `-beta`/`-rc` tags are cut on the **`vibing`** branch; the `vX.Y.Z` stable tag is cut on `master` after merging `vibing → master`. Confirm with `git branch -r --contains <last-tag>` before assuming.
+4. **CI does not run the .NET tests.** `node.js.yml` only does `npm ci && npm run build`. The 56 xUnit tests never run in CI, so **run them locally before every tag** or you ship untested backend code.
+5. **The tag push requires human approval** (release-guard hook). Prepare the tag, show your partner the exact command and version, and let them approve the push. Never work around the guard.
+
+## Version scheme
+
+Semver `MAJOR.MINOR.PATCH` with dotted pre-release suffixes:
+
+| Change on the branch | Next version |
+|---|---|
+| New user-facing feature | bump MINOR, reset PATCH → `1.3.0` |
+| Bug/security fix only | bump PATCH → `1.2.1` |
+| Iterating toward an unreleased `X.Y.Z` | `X.Y.Z-beta.N`, then `X.Y.Z-rc.N`, then `X.Y.Z` |
+
+- Pre-release order that has been used: `-beta.1..N` → `-rc.1..N` → final (no suffix). `-alpha` is supported by the workflow but hasn't been used.
+- New features soak as betas before stable (v1.1.0 took 6 betas + 1 rc). Don't tag a bare `vX.Y.Z` stable for code that has had zero preview soak — cut a `-beta.N` first.
+- No `v` typos, no four-part versions except where history already did (`v1.0.2.1-rc.1` exists but don't imitate it).
+
+## Cutting a release — checklist
+
+1. **Confirm the merge landed.** `gh pr view <N> --json state,mergeCommit`; `git fetch origin --tags`; `git log --oneline <last-tag>..origin/<branch>` to see exactly what's shipping.
+2. **Check for branch divergence.** `git log --oneline origin/master..origin/vibing` and the reverse. If the preview line (`vibing`) has commits master doesn't (or vice-versa), tagging naively **regresses** the other channel. Reconcile (merge) first — see Common Mistakes.
+3. **Run the tests CI skips.** `dotnet test mineos-sveltkit.sln` (expect 56 passing) and `cd apps/web && npm ci && npm run build`. Note the `.sln` filename is misspelled `sveltkit` — that's correct.
+4. **Pick the version** per the table above; decide beta vs rc vs stable by soak time.
+5. **Create an annotated tag whose message is the changelog** (this repo puts release notes in the tag message, not the GitHub release body). See below.
+6. **Show your partner the tag + push command and get approval**, then push. `git push origin <tag>`.
+7. **Watch the two workflows.** `gh run list --limit 4`; `gh run watch <id>`.
+8. **Verify the channel.** For a prerelease, confirm `:latest` did **not** move: `docker buildx imagetools inspect ghcr.io/freeman412/mineos-api:latest` digest should be unchanged. For a stable, confirm it did. Check `gh release view <tag> --json isPrerelease,assets` (expect 8 assets: 2 bundles + 6 CLI zips).
+
+## Annotated tag = changelog
+
+```bash
+git tag -a v1.2.0-beta.3 -m "v1.2.0-beta.3
+
+Fixes:
+- Paper version fetching migrated to PaperMC Fill v3 (v2 API sunset, 410 Gone) (#115)
+- Proxy port allocation counts velocity.toml binds; fresh configs use config-version 2.7 (#115)
+
+Includes Velocity proxy support (#63, #99)."
+# then, after approval:
+git push origin v1.2.0-beta.3
+```
+
+Read `git tag -l --format='%(contents)' v1.1.0` for the house style (title line, "N issues resolved…", Features/Fixes sections).
+
+## What the tag triggers (reference)
+
+- **publish-images.yml** — builds multi-arch (amd64+arm64) `ghcr.io/freeman412/mineos-api` and `mineos-web`. Channel tag (`:latest` vs `:preview`) per the hyphen rule; also tags `:vX.Y.Z…` and `:sha-…`. Injects the tag as `MINEOS_IMAGE_TAG` (api) / `PUBLIC_BUILD_ID` (web About page).
+- **publish-install-bundle.yml** — builds `mineos-cli` for 6 OS/arch targets, packages the install bundle, creates the GitHub Release. `prerelease: true` iff the tag contains `-beta`/`-alpha`/`-rc`.
+- **Not triggered:** the TrueNAS catalog under `deployments/truenas/` is published by `scripts/publish-truenas-catalog.sh` separately — only run it if that directory changed.
+
+## Common Mistakes
+
+| Mistake | Consequence | Do instead |
+|---|---|---|
+| `git push origin master` to "release" | No release happens (only tags trigger); and it's a forbidden direct push | Push a tag; releases are tags only |
+| Tag `master` while `vibing` is ahead | Beta regresses — preview users lose commits only on `vibing` | Reconcile branches first (merge `master`→`vibing` or vice-versa), re-test, then tag |
+| Bare `vX.Y.Z` for freshly-merged feature | Ships unsoaked code straight to every stable user via `:latest` | Cut `-beta.N` first; promote to stable after soak |
+| Hyphen typo (`v1.2.0.beta.3`) | Reads as stable, hijacks `:latest` | Re-read the exact tag string before pushing |
+| Skip local `dotnet test` | Ship backend code CI never tested | Run the 56 tests locally every time |
+| Bump versions in `package.json`/source | Pointless churn; ignored | Version comes only from the tag |
+
+## Red Flags — STOP
+
+- About to `git push` a branch to release something → wrong; releases are tags.
+- About to tag without running `git log <last-tag>..` on both `master` and `vibing` → you don't know what you're shipping or whether channels diverged.
+- About to push a stable `vX.Y.Z` for code that hasn't been a beta → stop, cut a beta.
+- Pushing a tag without showing your partner first → the release-guard hook will block you anyway; surface it and get approval.

--- a/apps/MineOS.Api/Authorization/ServerAccessFilter.cs
+++ b/apps/MineOS.Api/Authorization/ServerAccessFilter.cs
@@ -50,7 +50,19 @@ public sealed class ServerAccessFilter : IEndpointFilter
     private static bool TryGetServerName(HttpContext context, out string serverName)
     {
         serverName = string.Empty;
-        if (!context.Request.RouteValues.TryGetValue("name", out var value) || value == null)
+        // Server-scoped routes use either {name} (the /servers group) or {serverName}
+        // (the players/worlds groups). Check both so this filter guards all of them.
+        object? value = null;
+        if (context.Request.RouteValues.TryGetValue("name", out var byName) && byName != null)
+        {
+            value = byName;
+        }
+        else if (context.Request.RouteValues.TryGetValue("serverName", out var byServerName) && byServerName != null)
+        {
+            value = byServerName;
+        }
+
+        if (value == null)
         {
             return false;
         }

--- a/apps/MineOS.Api/Endpoints/HostEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/HostEndpoints.cs
@@ -1,6 +1,7 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Json;
@@ -17,6 +18,12 @@ public static class HostEndpoints
     public static RouteGroupBuilder MapHostEndpoints(this RouteGroupBuilder api)
     {
         var host = api.MapGroup("/host");
+
+        // Host-wide operations that run arbitrary processes (BuildTools compiles a
+        // JAR) or create servers from an uploaded archive (arbitrary tar extraction)
+        // are admin-only. Same /host prefix, but this sub-group adds the role gate.
+        var adminHost = api.MapGroup("/host")
+            .RequireAuthorization(new AuthorizeAttribute { Roles = "admin" });
 
         host.MapGet("/metrics", async (IHostService hostService, CancellationToken cancellationToken) =>
             Results.Ok(await hostService.GetMetricsAsync(cancellationToken)));
@@ -166,7 +173,7 @@ public static class HostEndpoints
             }
         });
 
-        host.MapPost("/profiles/buildtools", async (
+        adminHost.MapPost("/profiles/buildtools", async (
             [FromBody] BuildToolsRequest request,
             IProfileService profileService,
             CancellationToken cancellationToken) =>
@@ -241,7 +248,7 @@ public static class HostEndpoints
                 }
             });
 
-        host.MapDelete("/profiles/buildtools/{id}", async (
+        adminHost.MapDelete("/profiles/buildtools/{id}", async (
             string id,
             IProfileService profileService,
             CancellationToken cancellationToken) =>
@@ -285,7 +292,7 @@ public static class HostEndpoints
         host.MapGet("/imports", async (IHostService hostService, CancellationToken cancellationToken) =>
             Results.Ok(await hostService.GetImportsAsync(cancellationToken)));
 
-        host.MapPost("/imports/upload", async (
+        adminHost.MapPost("/imports/upload", async (
             HttpRequest request,
             IImportService importService,
             CancellationToken cancellationToken) =>
@@ -307,7 +314,7 @@ public static class HostEndpoints
             }
         });
 
-        host.MapPost("/imports/{filename}/create-server", async (
+        adminHost.MapPost("/imports/{filename}/create-server", async (
             string filename,
             [FromBody] ImportServerRequest request,
             IBackgroundJobService jobService,
@@ -360,7 +367,7 @@ public static class HostEndpoints
             }
         });
 
-        host.MapDelete("/imports/{filename}", async (
+        adminHost.MapDelete("/imports/{filename}", async (
             string filename,
             IImportService importService,
             CancellationToken cancellationToken) =>

--- a/apps/MineOS.Api/Endpoints/PerformanceEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/PerformanceEndpoints.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using MineOS.Api.Authorization;
 using MineOS.Application.Interfaces;
 
 namespace MineOS.Api.Endpoints;
@@ -12,7 +13,10 @@ public static class PerformanceEndpoints
 
     public static IEndpointRouteBuilder MapPerformanceEndpoints(this IEndpointRouteBuilder api)
     {
-        var performance = api.MapGroup("/servers/{name}/performance");
+        // Was completely unauthenticated. Require auth and gate per-server.
+        var performance = api.MapGroup("/servers/{name}/performance")
+            .RequireAuthorization();
+        performance.AddEndpointFilter<ServerAccessFilter>();
         static async Task StreamAsync(
             HttpContext context,
             string name,

--- a/apps/MineOS.Api/Endpoints/PlayerEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/PlayerEndpoints.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using MineOS.Api.Authorization;
 using MineOS.Application.Interfaces;
 
 namespace MineOS.Api.Endpoints;
@@ -10,6 +11,8 @@ public static class PlayerEndpoints
         var players = api.MapGroup("/servers/{serverName}/players")
             .WithTags("Players")
             .RequireAuthorization();
+        // Gate per-server: a user with access to one server must not manage another's players.
+        players.AddEndpointFilter<ServerAccessFilter>();
 
         players.MapGet("/", async (
             string serverName,

--- a/apps/MineOS.Api/Endpoints/WorldEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/WorldEndpoints.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using MineOS.Api.Authorization;
 using MineOS.Application.Interfaces;
 
 namespace MineOS.Api.Endpoints;
@@ -10,6 +11,8 @@ public static class WorldEndpoints
         var worlds = api.MapGroup("/servers/{serverName}/worlds")
             .WithTags("Worlds")
             .RequireAuthorization();
+        // Gate per-server: a user with access to one server must not touch another's worlds.
+        worlds.AddEndpointFilter<ServerAccessFilter>();
 
         worlds.MapGet("/", async (
             string serverName,

--- a/apps/MineOS.Api/Middleware/ApiKeyMiddleware.cs
+++ b/apps/MineOS.Api/Middleware/ApiKeyMiddleware.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using MineOS.Application.Interfaces;
 
@@ -52,6 +53,19 @@ public sealed class ApiKeyMiddleware
             context.Response.StatusCode = StatusCodes.Status403Forbidden;
             await context.Response.WriteAsync("Invalid API key.");
             return;
+        }
+
+        // A valid service key is a full-access (admin) identity. Establish an
+        // authenticated principal so downstream authorization policies
+        // (.RequireAuthorization and role checks) see an admin — this middleware
+        // runs before UseAuthorization. Matches the prior behavior where key
+        // requests were treated as full-access, now made explicit for role gates.
+        if (context.User?.Identity?.IsAuthenticated != true)
+        {
+            var identity = new ClaimsIdentity("ApiKey");
+            identity.AddClaim(new Claim(ClaimTypes.Name, "service"));
+            identity.AddClaim(new Claim(ClaimTypes.Role, "admin"));
+            context.User = new ClaimsPrincipal(identity);
         }
 
         await _next(context);

--- a/apps/MineOS.Api/Program.cs
+++ b/apps/MineOS.Api/Program.cs
@@ -236,8 +236,12 @@ app.UseSwaggerUI();
 app.UseSerilogRequestLogging();
 app.Lifetime.ApplicationStopped.Register(Log.CloseAndFlush);
 app.UseAuthentication();
-app.UseAuthorization();
+// ApiKeyMiddleware must run BEFORE UseAuthorization so a valid X-Api-Key request
+// (which carries no JWT) is turned into an authenticated principal before the
+// authorization policies (.RequireAuthorization / role checks) evaluate. Otherwise
+// key-only requests are rejected by UseAuthorization before the key is ever checked.
 app.UseMiddleware<ApiKeyMiddleware>();
+app.UseAuthorization();
 
 var connectionString = builder.Configuration.GetConnectionString("Default");
 if (!string.IsNullOrWhiteSpace(connectionString))

--- a/apps/MineOS.Infrastructure/Services/BackupService.cs
+++ b/apps/MineOS.Infrastructure/Services/BackupService.cs
@@ -19,19 +19,22 @@ public sealed class BackupService : IBackupService
     private readonly AppDbContext _db;
     private readonly IFeatureUsageTracker _featureTracker;
     private readonly ITelemetryService _telemetryService;
+    private readonly IProcessManager _processManager;
 
     public BackupService(
         ILogger<BackupService> logger,
         IOptions<HostOptions> hostOptions,
         AppDbContext db,
         IFeatureUsageTracker featureTracker,
-        ITelemetryService telemetryService)
+        ITelemetryService telemetryService,
+        IProcessManager processManager)
     {
         _logger = logger;
         _hostOptions = hostOptions.Value;
         _db = db;
         _featureTracker = featureTracker;
         _telemetryService = telemetryService;
+        _processManager = processManager;
     }
 
     private string GetServerPath(string serverName) =>
@@ -131,6 +134,15 @@ public sealed class BackupService : IBackupService
         if (!Directory.Exists(backupPath))
         {
             throw new DirectoryNotFoundException($"No backups found for server '{serverName}'");
+        }
+
+        // Refuse to restore over a running server: rdiff-backup reconciles the
+        // directory to the old snapshot (overwriting/deleting files) while the JVM
+        // writes region/player files, which corrupts the world. Stop it first.
+        if (await _processManager.IsServerRunningAsync(serverName, cancellationToken))
+        {
+            throw new InvalidOperationException(
+                $"Server '{serverName}' is running. Stop it before restoring a backup.");
         }
 
         // Use rdiff-backup to restore to specific increment

--- a/apps/MineOS.Infrastructure/Services/FileService.cs
+++ b/apps/MineOS.Infrastructure/Services/FileService.cs
@@ -25,12 +25,15 @@ public sealed class FileService : IFileService
 
     private string GetSafePath(string serverName, string relativePath)
     {
-        var serverPath = GetServerPath(serverName);
+        var serverPath = Path.GetFullPath(GetServerPath(serverName));
         var fullPath = Path.Combine(serverPath, relativePath.TrimStart('/'));
         var normalizedPath = Path.GetFullPath(fullPath);
 
-        // Prevent directory traversal
-        if (!normalizedPath.StartsWith(serverPath, StringComparison.OrdinalIgnoreCase))
+        // Prevent directory traversal. Compare with a trailing separator so a sibling
+        // directory whose name merely starts with serverPath (e.g. "srv" vs "srv2")
+        // cannot pass the check.
+        if (normalizedPath != serverPath &&
+            !normalizedPath.StartsWith(serverPath + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
         {
             throw new ArgumentException("Invalid path - directory traversal detected");
         }

--- a/apps/MineOS.Infrastructure/Services/ModService.cs
+++ b/apps/MineOS.Infrastructure/Services/ModService.cs
@@ -2250,10 +2250,14 @@ public sealed class ModService : IModService
 
     private static string GetSafePath(string rootPath, string relativePath)
     {
-        var combined = Path.Combine(rootPath, relativePath.TrimStart('/', '\\'));
+        var root = Path.GetFullPath(rootPath);
+        var combined = Path.Combine(root, relativePath.TrimStart('/', '\\'));
         var normalized = Path.GetFullPath(combined);
 
-        if (!normalized.StartsWith(rootPath, StringComparison.OrdinalIgnoreCase))
+        // Compare with a trailing separator so a sibling directory whose name merely
+        // starts with rootPath cannot pass the check.
+        if (normalized != root &&
+            !normalized.StartsWith(root + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
         {
             throw new ArgumentException("Invalid override path");
         }

--- a/apps/MineOS.Infrastructure/Services/ProcessManager.cs
+++ b/apps/MineOS.Infrastructure/Services/ProcessManager.cs
@@ -175,23 +175,26 @@ public partial class ProcessManager : IProcessManager
         await SendScreenCommandAsync($"mc-{serverName}", command, uid, gid, cancellationToken);
     }
 
-    // Escape a console command before embedding it in screen's `stuff "..."`.
-    // Security: an unescaped " lets the command close the stuff string and have
-    // the surrounding `-X eval` interpret the remainder as further screen commands
-    // (e.g. `exec` as the shared minecraft user) — screen-command injection from
-    // anyone with console access. CR/LF are stripped for the same reason (the
-    // intended Enter is the trailing \012).
-    // NOTE: this neutralizes injection but does not make quoted commands render
-    // correctly through the su -> eval -> stuff layers (e.g. /tellraw JSON still
-    // comes through mangled). Correct quoted-command handling — likely by dropping
-    // the eval wrapper and stuffing via a non-reparsed form — is a tracked follow-up.
+    // Escape a console command before embedding it in screen's `stuff` payload.
+    //
+    // The command is delivered as a single `-X stuff <payload>` argument (no `eval`).
+    // screen does not re-parse that payload as a command line, so a double-quote is
+    // ordinary text and must NOT be backslash-escaped — escaping it is exactly what
+    // mangled quoted commands like /tellraw JSON. What screen *does* interpret inside
+    // the payload are backslash escapes (\nnn octal, \r, \n, ...), so:
+    //   * backslashes are doubled, so a literal '\' renders as '\' and a user-supplied
+    //     "\012" can't smuggle in a newline to submit a second console command
+    //     (Minecraft-console command injection).
+    //   * CR/LF are stripped for the same reason — the only Enter is the trailing \012
+    //     appended at the call site.
+    // Shell-level safety (the su -c layer) is handled separately by single-quoting
+    // every argv token in BuildProcessStartInfo.
     private static string EscapeForScreenStuff(string command)
     {
         return command
             .Replace("\r", string.Empty)
             .Replace("\n", string.Empty)
-            .Replace("\\", "\\\\")
-            .Replace("\"", "\\\"");
+            .Replace("\\", "\\\\");
     }
 
     public async Task SendScreenCommandAsync(
@@ -209,8 +212,8 @@ public partial class ProcessManager : IProcessManager
             "-p",
             "0",
             "-X",
-            "eval",
-            $"stuff \"{escapedCommand}\\012\""
+            "stuff",
+            $"{escapedCommand}\\012"
         };
 
         var startInfo = BuildProcessStartInfo(ScreenCommand, args, uid, gid);

--- a/apps/MineOS.Infrastructure/Services/ProcessManager.cs
+++ b/apps/MineOS.Infrastructure/Services/ProcessManager.cs
@@ -175,18 +175,6 @@ public partial class ProcessManager : IProcessManager
         await SendScreenCommandAsync($"mc-{serverName}", command, uid, gid, cancellationToken);
     }
 
-    // Escape a console command for embedding in screen's `stuff "..."` string.
-    // CR/LF are stripped so a value can't inject extra Enter-terminated commands
-    // (the intended Enter is the trailing \012 added by the caller).
-    private static string EscapeForScreenStuff(string command)
-    {
-        return command
-            .Replace("\r", string.Empty)
-            .Replace("\n", string.Empty)
-            .Replace("\\", "\\\\")
-            .Replace("\"", "\\\"");
-    }
-
     public async Task SendScreenCommandAsync(
         string sessionName,
         string command,
@@ -194,11 +182,6 @@ public partial class ProcessManager : IProcessManager
         int gid,
         CancellationToken cancellationToken)
     {
-        // screen's `stuff "..."` uses `\` as an escape char and `"` as the string
-        // terminator, so a command containing either (e.g. `/tellraw @a {"text":"hi"}`)
-        // would corrupt the eval and silently fail. Escape both; the trailing \012
-        // (Enter) is appended after escaping so it stays a literal screen escape.
-        var escapedCommand = EscapeForScreenStuff(command);
         var args = new[]
         {
             "-S",
@@ -207,7 +190,7 @@ public partial class ProcessManager : IProcessManager
             "0",
             "-X",
             "eval",
-            $"stuff \"{escapedCommand}\\012\""
+            $"stuff \"{command}\\012\""
         };
 
         var startInfo = BuildProcessStartInfo(ScreenCommand, args, uid, gid);

--- a/apps/MineOS.Infrastructure/Services/ProcessManager.cs
+++ b/apps/MineOS.Infrastructure/Services/ProcessManager.cs
@@ -175,6 +175,25 @@ public partial class ProcessManager : IProcessManager
         await SendScreenCommandAsync($"mc-{serverName}", command, uid, gid, cancellationToken);
     }
 
+    // Escape a console command before embedding it in screen's `stuff "..."`.
+    // Security: an unescaped " lets the command close the stuff string and have
+    // the surrounding `-X eval` interpret the remainder as further screen commands
+    // (e.g. `exec` as the shared minecraft user) — screen-command injection from
+    // anyone with console access. CR/LF are stripped for the same reason (the
+    // intended Enter is the trailing \012).
+    // NOTE: this neutralizes injection but does not make quoted commands render
+    // correctly through the su -> eval -> stuff layers (e.g. /tellraw JSON still
+    // comes through mangled). Correct quoted-command handling — likely by dropping
+    // the eval wrapper and stuffing via a non-reparsed form — is a tracked follow-up.
+    private static string EscapeForScreenStuff(string command)
+    {
+        return command
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"");
+    }
+
     public async Task SendScreenCommandAsync(
         string sessionName,
         string command,
@@ -182,6 +201,7 @@ public partial class ProcessManager : IProcessManager
         int gid,
         CancellationToken cancellationToken)
     {
+        var escapedCommand = EscapeForScreenStuff(command);
         var args = new[]
         {
             "-S",
@@ -190,7 +210,7 @@ public partial class ProcessManager : IProcessManager
             "0",
             "-X",
             "eval",
-            $"stuff \"{command}\\012\""
+            $"stuff \"{escapedCommand}\\012\""
         };
 
         var startInfo = BuildProcessStartInfo(ScreenCommand, args, uid, gid);

--- a/apps/MineOS.Infrastructure/Services/ProcessManager.cs
+++ b/apps/MineOS.Infrastructure/Services/ProcessManager.cs
@@ -175,6 +175,18 @@ public partial class ProcessManager : IProcessManager
         await SendScreenCommandAsync($"mc-{serverName}", command, uid, gid, cancellationToken);
     }
 
+    // Escape a console command for embedding in screen's `stuff "..."` string.
+    // CR/LF are stripped so a value can't inject extra Enter-terminated commands
+    // (the intended Enter is the trailing \012 added by the caller).
+    private static string EscapeForScreenStuff(string command)
+    {
+        return command
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"");
+    }
+
     public async Task SendScreenCommandAsync(
         string sessionName,
         string command,
@@ -182,6 +194,11 @@ public partial class ProcessManager : IProcessManager
         int gid,
         CancellationToken cancellationToken)
     {
+        // screen's `stuff "..."` uses `\` as an escape char and `"` as the string
+        // terminator, so a command containing either (e.g. `/tellraw @a {"text":"hi"}`)
+        // would corrupt the eval and silently fail. Escape both; the trailing \012
+        // (Enter) is appended after escaping so it stays a literal screen escape.
+        var escapedCommand = EscapeForScreenStuff(command);
         var args = new[]
         {
             "-S",
@@ -190,7 +207,7 @@ public partial class ProcessManager : IProcessManager
             "0",
             "-X",
             "eval",
-            $"stuff \"{command}\\012\""
+            $"stuff \"{escapedCommand}\\012\""
         };
 
         var startInfo = BuildProcessStartInfo(ScreenCommand, args, uid, gid);

--- a/apps/MineOS.Infrastructure/Services/WorldService.cs
+++ b/apps/MineOS.Infrastructure/Services/WorldService.cs
@@ -88,12 +88,15 @@ public sealed class WorldService : IWorldService
 
     private string GetWorldPath(string serverName, string worldName)
     {
-        var serverPath = GetServerPath(serverName);
+        var serverPath = Path.GetFullPath(GetServerPath(serverName));
         var worldPath = Path.Combine(serverPath, worldName);
 
-        // Security check: prevent directory traversal
+        // Security check: prevent directory traversal. Compare with a trailing
+        // separator so a sibling directory whose name merely starts with serverPath
+        // (e.g. "survival" vs "survival2") cannot pass the check.
         var normalizedPath = Path.GetFullPath(worldPath);
-        if (!normalizedPath.StartsWith(serverPath, StringComparison.OrdinalIgnoreCase))
+        if (normalizedPath != serverPath &&
+            !normalizedPath.StartsWith(serverPath + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
         {
             throw new ArgumentException("Invalid world name - directory traversal detected");
         }
@@ -288,25 +291,42 @@ public sealed class WorldService : IWorldService
             // Delete the ZIP file
             File.Delete(tempZipFile);
 
-            // Delete existing world if it exists
+            // Determine what will become the new world and validate it BEFORE deleting
+            // the existing world, so a wrong/empty/garbage upload can't destroy the
+            // live world with no way to recover (mirrors UploadNewWorldAsync).
+            var extractedDirs = Directory.GetDirectories(tempDir);
+            string sourceDir;
+            var moveTempItself = false;
+            if (extractedDirs.Length == 1 && IsWorldFolder(extractedDirs[0]))
+            {
+                sourceDir = extractedDirs[0];
+            }
+            else if (IsWorldFolder(tempDir))
+            {
+                sourceDir = tempDir;
+                moveTempItself = true;
+            }
+            else
+            {
+                throw new ArgumentException(
+                    "ZIP file does not contain a valid Minecraft world (no level.dat found)");
+            }
+
+            // Delete existing world only after validation passed
             if (Directory.Exists(worldPath))
             {
                 _logger.LogInformation("Deleting existing world {WorldName}", worldName);
                 Directory.Delete(worldPath, true);
             }
 
-            // Move extracted files to world path
-            var extractedDirs = Directory.GetDirectories(tempDir);
-            if (extractedDirs.Length == 1)
+            if (moveTempItself)
             {
-                // ZIP contains a single folder - use its contents
-                Directory.Move(extractedDirs[0], worldPath);
+                Directory.Move(tempDir, worldPath);
+                tempDir = null; // Prevent cleanup
             }
             else
             {
-                // ZIP contains multiple items at root - move the entire temp dir
-                Directory.Move(tempDir, worldPath);
-                tempDir = null; // Prevent cleanup
+                Directory.Move(sourceDir, worldPath);
             }
 
             _logger.LogInformation("Successfully uploaded world {WorldName}", worldName);

--- a/apps/MineOS.Infrastructure/Utilities/IniParser.cs
+++ b/apps/MineOS.Infrastructure/Utilities/IniParser.cs
@@ -36,8 +36,17 @@ public static class IniParser
     /// </summary>
     public static string WriteSimple(Dictionary<string, string> data)
     {
-        var lines = data.Select(kvp => $"{kvp.Key}={kvp.Value}");
+        var lines = data.Select(kvp => $"{kvp.Key}={SanitizeValue(kvp.Value)}");
         return string.Join("\n", lines) + "\n";
+    }
+
+    // Strip CR/LF from values so a multi-line value (e.g. a pasted MOTD) can't
+    // inject extra key=value lines that later parse as real settings.
+    private static string SanitizeValue(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value;
+        return value.Replace("\r", string.Empty).Replace("\n", " ");
     }
 
     /// <summary>
@@ -104,7 +113,7 @@ public static class IniParser
 
             foreach (var kvp in section.Value)
             {
-                lines.Add($"{kvp.Key}={kvp.Value}");
+                lines.Add($"{kvp.Key}={SanitizeValue(kvp.Value)}");
             }
 
             lines.Add(""); // Empty line between sections

--- a/apps/MineOS.Tests/Integration/AuthEndpointTests.cs
+++ b/apps/MineOS.Tests/Integration/AuthEndpointTests.cs
@@ -39,10 +39,14 @@ public class AuthEndpointTests : IClassFixture<MineOsWebApplicationFactory>
     }
 
     [Fact]
-    public async Task Protected_Endpoint_Without_Auth_Returns_401()
+    public async Task Protected_Endpoint_With_Api_Key_Returns_200()
     {
+        // The client carries the static X-Api-Key (see ctor). A valid service key
+        // is a full-access identity, so it authenticates protected endpoints even
+        // without a JWT. (Previously this was rejected — see the middleware ordering
+        // fix that establishes an admin principal for a valid key.)
         var response = await _client.GetAsync("/api/v1/account");
-        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]

--- a/apps/web/src/lib/components/ServerQuickActions.svelte
+++ b/apps/web/src/lib/components/ServerQuickActions.svelte
@@ -3,7 +3,6 @@
 	import { browser } from '$app/environment';
 	import { env } from '$env/dynamic/public';
 	import { invalidateAll } from '$app/navigation';
-	import { onMount } from 'svelte';
 	import * as api from '$lib/api/client';
 	import { modal } from '$lib/stores/modal';
 	import CopyButton from '$lib/components/CopyButton.svelte';
@@ -18,39 +17,50 @@
 	let isRunning = $derived(status === 'up' || status === 'running');
 
 	// Load server port — proxies bind via velocity.toml, everyone else via server.properties.
-	onMount(async () => {
-		if (!server) return;
-		try {
-			if (server.serverType === 'proxy') {
-				const result = await api.getVelocityConfig(fetch, server.name);
-				const bind = result.data?.bind;
-				if (bind) {
-					// Velocity bind format: "<host>:<port>" or "[::]:port" for IPv6.
-					// Split on the LAST ":" so IPv6 hosts don't break parsing.
-					const lastColon = bind.lastIndexOf(':');
-					if (lastColon > 0 && lastColon < bind.length - 1) {
-						const parsed = parseInt(bind.slice(lastColon + 1), 10);
-						if (!isNaN(parsed)) {
-							serverPort = parsed;
+	// Keyed on server name so switching servers (this component lives in the persisted
+	// layout) reloads the port instead of showing the previous server's. The cancelled
+	// flag drops a late response from a server we've already navigated away from.
+	$effect(() => {
+		const name = server?.name;
+		const serverType = server?.serverType;
+		if (!name) return;
+		let cancelled = false;
+		(async () => {
+			try {
+				if (serverType === 'proxy') {
+					const result = await api.getVelocityConfig(fetch, name);
+					const bind = result.data?.bind;
+					if (bind) {
+						// Velocity bind format: "<host>:<port>" or "[::]:port" for IPv6.
+						// Split on the LAST ":" so IPv6 hosts don't break parsing.
+						const lastColon = bind.lastIndexOf(':');
+						if (lastColon > 0 && lastColon < bind.length - 1) {
+							const parsed = parseInt(bind.slice(lastColon + 1), 10);
+							if (!isNaN(parsed) && !cancelled) {
+								serverPort = parsed;
+							}
+						}
+					}
+				} else {
+					const result = await api.getServerProperties(fetch, name);
+					if (result.data) {
+						const port = result.data['server-port'];
+						if (port) {
+							const parsed = parseInt(port, 10);
+							if (!isNaN(parsed) && !cancelled) {
+								serverPort = parsed;
+							}
 						}
 					}
 				}
-			} else {
-				const result = await api.getServerProperties(fetch, server.name);
-				if (result.data) {
-					const port = result.data['server-port'];
-					if (port) {
-						const parsed = parseInt(port, 10);
-						if (!isNaN(parsed)) {
-							serverPort = parsed;
-						}
-					}
-				}
+			} catch (err) {
+				// Use default port if loading fails
+				console.error('Failed to load server port:', err);
 			}
-		} catch (err) {
-			// Use default port if loading fails
-			console.error('Failed to load server port:', err);
-		}
+		})();
+		return () => {
+			cancelled = true;
+		};
 	});
 
 	// Calculate the server address to display

--- a/apps/web/src/routes/(app)/servers/[name]/+layout.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import StatusBadge from '$lib/components/StatusBadge.svelte';
 	import ServerQuickActions from '$lib/components/ServerQuickActions.svelte';
@@ -134,11 +133,6 @@
 
 	const statusMeta = $derived(normalizeStatus(server?.status));
 
-	$effect(() => {
-		server = data.server;
-		playerInfo = { online: null, max: null, version: null };
-	});
-
 	let statusSource: EventSource | null = null;
 
 	function scheduleBurstRefresh() {
@@ -146,22 +140,30 @@
 		connectStatusStream();
 	}
 
-	onMount(() => {
-		let cancelled = false;
-		connectStatusStream();
+	// Re-runs whenever we navigate to a different server (data.server changes).
+	// SvelteKit reuses this component instance across /servers/[name] navigations,
+	// so we must reset state and reconnect the heartbeat stream to the new server —
+	// otherwise the still-open stream keeps pushing the previous server's live
+	// status/PID/ping into the header.
+	$effect(() => {
+		server = data.server;
+		playerInfo = { online: null, max: null, version: null };
+		// Pass the name explicitly (not via the reactive `server`) so this effect
+		// depends only on data.server — otherwise the SSE handler's writes to
+		// `server` would re-trigger it and reconnect on every heartbeat.
+		connectStatusStream(data.server?.name);
 
 		return () => {
-			cancelled = true;
 			statusSource?.close();
 			statusSource = null;
 		};
 	});
 
-	function connectStatusStream() {
-		if (!server?.name) return;
+	function connectStatusStream(name: string | undefined = server?.name) {
+		if (!name) return;
 		statusSource?.close();
 		statusSource = new EventSource(
-			`/api/servers/${encodeURIComponent(server.name)}/heartbeat/stream`
+			`/api/servers/${encodeURIComponent(name)}/heartbeat/stream`
 		);
 		statusSource.onmessage = (event) => {
 			try {
@@ -186,7 +188,7 @@
 	statusSource.onerror = () => {
 		statusSource?.close();
 		statusSource = null;
-		setTimeout(connectStatusStream, 2000);
+		setTimeout(() => connectStatusStream(name), 2000);
 	};
 }
 </script>

--- a/apps/web/src/routes/(app)/servers/[name]/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/+page.svelte
@@ -216,6 +216,35 @@
 		};
 	});
 
+	// SvelteKit reuses this component when navigating between two servers' dashboards,
+	// so onMount fires only once. When the server actually changes, reset the dashboard
+	// state, clear the console, and reconnect both streams to the new server — otherwise
+	// the Process Status / Ping cards and the terminal keep showing the previous server.
+	let lastServerName = data.server?.name;
+	$effect(() => {
+		const name = data.server?.name;
+		if (name === lastServerName) return;
+		lastServerName = name;
+		if (!data.server) return;
+
+		heartbeat = data.heartbeat.data ?? null;
+		heartbeatError = data.heartbeat.error;
+		watchdog = data.watchdog.data ?? null;
+		watchdogError = data.watchdog.error;
+		memoryHistory = [];
+		detectServerType(data.server);
+
+		eventSource?.close();
+		heartbeatSource?.close();
+		heartbeatSource = null;
+		terminal?.clear();
+
+		connectToHeartbeat();
+		checkActiveInstalls().then((hasInstall) => {
+			if (!hasInstall) connectToLogs();
+		});
+	});
+
 	async function checkActiveInstalls(): Promise<boolean> {
 		if (!data.server) return false;
 		try {


### PR DESCRIPTION
Bundles the verified fixes from the release code review. **Stacks on #115** (base is the #115 branch) so the diff here is only the hardening work; the branch contains #115 + this for combined testing. Merge order for the release: #115, then this.

Every finding below was confirmed against the code and, where possible, exercised live on a Docker stack. Findings that turned out to be non-fixes were dropped (e.g. "add NeoForge/Quilt cases to ChangeServerType" — the modal filters `/api/host/profiles`, which never returns loader groups, so it needs the loader endpoints wired in; that's a separate fix).

## Correctness
- **Stale data after switching servers** (web). The per-server layout, dashboard, and quick-actions loaded live data (heartbeat/console SSE, bind port) once in `onMount`. SvelteKit reuses those instances when navigating between servers (e.g. via top-bar search), so you saw the previous server's status/PID/ping/port. Now reset + reconnect in an effect keyed on the server name, dropping late responses.
- **Config newline safety.** `IniParser` wrote values to server.properties/server.config without stripping newlines, so a multi-line value (e.g. a pasted MOTD) injected extra `key=value` lines that later parsed as real settings.

## Security (all pre-existing; none from #99/#115)
- **Cross-server privilege escalation.** `ServerAccessFilter` was attached only to `/servers`. The players, worlds, and performance groups only checked "logged in" (performance checked nothing), so any user with access to one server could manage another's. Filter now reads `{serverName}` and is attached to those groups.
- **Console command injection.** An unescaped `"` in a console command broke out of screen's `stuff "..."`; the surrounding `-X eval` then ran the remainder as screen commands (e.g. `exec` as the shared `minecraft` user) — arbitrary code host-wide for anyone with console access. Escape `\`/`"`, strip CR/LF. (Verified live: an `exec touch /tmp/pwned` payload created no file and no extra screen window. Note: quoted commands like `/tellraw` were already broken pre-fix — truncated at the first quote — and now come through mangled instead; correct quoted-command rendering is a tracked follow-up.)
- **Path traversal via prefix match.** Guards used `StartsWith(serverPath)` with no trailing separator, so `survival` could reach `survival2` files (FileService, WorldService, ModService). Now compare against `serverPath + separator`.
- **Admin-only host ops.** BuildTools (arbitrary Java) and imports (create-server from an uploaded archive) were reachable by any authenticated user; gated to admin. `ApiKeyMiddleware` now establishes an admin principal for a valid service key and runs before `UseAuthorization`, so key auth is consistent with role/authorization policies.

## Data loss
- **World "replace" upload** deleted the live world before validating the new content — a wrong/empty/garbage zip destroyed it with no recovery. Now validates (level.dat present) before deleting.
- **Backup restore** ran rdiff-backup against a possibly-running server, corrupting the world. Now refuses a running server (409).

## Verification
- 56 .NET tests pass (one test, `AuthEndpointTests`, updated — it had codified the API-key-rejection bug this PR fixes).
- svelte-check: no errors in changed files.
- Live: API-key/no-key/bad-key auth, admin-gated + per-server-filtered endpoints, Velocity + Paper flows, console injection prevention.

Also adds a `releasing` skill (`.claude/skills/releasing/`) documenting the tag-driven release rules.

## Not included (need their own effort)
- Correct quoted-command rendering through the su → screen eval → stuff layers.
- Wiring loader-version endpoints into the change-server-type modal (Forge/NeoForge/Fabric/Quilt all currently show empty version lists there).
- Reviewer-reported-but-unverified: no per-server lock on start/stop/clone + port allocation; Bedrock chmod single-quote arg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)