### PR TITLE
Enforce clean architecture + add contributor/agent rules

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!--
+  Base this PR on `vibing` (staging), not `master`. See CONTRIBUTING.md / AGENTS.md.
+-->
+
+## What & why
+
+
+
+## Checklist
+
+- [ ] Based on **`vibing`** (not `master`)
+- [ ] `.NET` tests pass locally — `dotnet test apps/MineOS.Tests/MineOS.Tests.csproj` (CI does **not** run these)
+- [ ] `apps/web` check passes if the frontend changed — `cd apps/web && npm run check`
+- [ ] Stays within the Clean Architecture layer rules (`AGENTS.md`) — no outward/framework deps in Domain or Application
+- [ ] No change to auth/access behavior — or, if there is, it's called out explicitly below
+
+## Auth / access impact
+
+<!-- None, or describe exactly what changes about who-can-do-what. -->
+None.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# Agent & contributor rules
+
+Rules for anyone — human or AI agent — changing this repo. They are not style
+preferences; several are enforced by tests and by branch protection, and a change
+that breaks them will not merge. Read this before writing code.
+
+**Violating the letter of these rules is violating the spirit of them.** If a rule
+seems to block a shortcut, the rule wins — raise it in the PR instead of routing
+around it.
+
+---
+
+## 1. Clean Architecture — dependencies point inward, always
+
+The backend is layered. Dependencies may only point **inward**:
+
+```
+Api  ──►  Infrastructure  ──►  Application  ──►  Domain
+(HTTP,        (impls, EF,         (interfaces,      (entities,
+ DI root)      external I/O)       DTOs, use cases)   enums — pure C#)
+```
+
+| Layer | May depend on | MUST NOT contain |
+|-------|---------------|------------------|
+| `MineOS.Domain` | nothing | any framework — no EF, no ASP.NET, no Npgsql, no other MineOS layer |
+| `MineOS.Application` | Domain only | Infrastructure/Api types; EF/ASP.NET/Npgsql. It defines interfaces; it does not implement I/O |
+| `MineOS.Infrastructure` | Application, Domain | references to Api |
+| `MineOS.Api` | Application, Infrastructure | business logic (it wires DI and maps HTTP; logic lives in Application/Infrastructure) |
+
+**Where things go:** new entity → Domain. New capability contract (`IFooService`) or
+DTO → Application. Implementation of that contract (HTTP calls, EF, `screen`/process
+work, filesystem) → Infrastructure. New endpoint → Api, depending on the Application
+**interface**, resolved via DI — never `new`-ing a concrete Infrastructure type.
+
+**This is enforced.** `MineOS.Tests/Architecture/LayerDependencyTests.cs` fails red if
+Domain or Application gains a framework/outward reference, or if Infrastructure
+references Api. Do not weaken or `[Skip]` those tests to make a change fit — the change
+is wrong, not the test. (The `.csproj` graph already makes outward *project* references
+circular and thus uncompilable; the tests additionally catch framework leakage, which
+compiles but is still forbidden.)
+
+## 2. Tests must be green before anything is "done"
+
+CI **only builds the web app — it does not run the .NET tests.** So the .NET suite is
+your responsibility locally:
+
+```
+dotnet test apps/MineOS.Tests/MineOS.Tests.csproj
+```
+
+Never mark a task complete, open a PR as ready, or claim success with failing or
+absent tests. If you changed backend behavior, a passing suite that never exercised
+your change is not evidence — add or extend a test. Frontend: `cd apps/web && npm run check`.
+
+## 3. Security & auth invariants — do not bypass
+
+The API is protected in layers. Keep them intact:
+
+- **`ApiKeyMiddleware`**: a valid `X-Api-Key` authenticates as an **admin** identity.
+  The middleware order in `Program.cs` is `UseAuthentication → ApiKeyMiddleware →
+  UseAuthorization` — do not reorder it.
+- **`ServerAccessFilter`**: every **server-scoped** route (`/servers/{name}/...`,
+  players, worlds, performance, console) must carry the per-server ACL check. If you
+  add a server-scoped endpoint group, add the filter — a non-admin must not reach a
+  server they lack access to.
+- **Admin-only host operations** (BuildTools, imports upload / create-server / delete)
+  live under the role-gated `adminHost` group. Keep destructive/host-wide actions there.
+- **Console commands** are delivered to `screen` via `-X stuff` (not `eval`) and the
+  payload is escaped in `ProcessManager.EscapeForScreenStuff`. Don't reintroduce an
+  `eval` re-parse or drop the escaping — it prevents screen-command injection.
+
+Changing who-can-do-what is a deliberate, reviewable decision. Call it out explicitly
+in the PR; don't smuggle it in.
+
+## 4. Branch & release flow
+
+- **`vibing` is staging and the default branch. Base every PR on `vibing`, not
+  `master`.** `master` is production/stable.
+- **Never push directly to `master`** (it is branch-protected) and **never push a
+  `v*` tag unprompted** — tags trigger real releases.
+- Releases are **tag-driven**: a `v*` tag builds images. A hyphen in the tag
+  (`v1.2.0-beta.3`) publishes `:preview`/prerelease; no hyphen (`v1.2.0`) publishes
+  `:latest`/stable. Version comes from the tag — do not bump a version in source.
+- Betas/RCs are tagged on `vibing`; stable is promoted to `master` and tagged there.
+- Full process, checklist, and common mistakes: `.claude/skills/releasing/SKILL.md`.
+
+---
+
+## Project shape (orientation)
+
+- `apps/MineOS.{Domain,Application,Infrastructure,Api}` — the .NET 8 backend (layers above).
+- `apps/MineOS.Tests` — xUnit: `Unit/`, `Integration/`, `Architecture/`.
+- `apps/web` — SvelteKit 2 / Svelte 5 (runes: `$state`/`$derived`/`$effect`). Talks to
+  the API through the `/api/v1` proxy, which forwards both `X-Api-Key` and the user JWT.
+- Servers are managed as `screen` sessions under `/var/games/minecraft` on the host.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md
+
+**Read `AGENTS.md` — it holds the full rules for changing this repo.** The
+non-negotiables, in brief:
+
+1. **Clean Architecture — dependencies point inward only.**
+   `Api → Infrastructure → Application → Domain`. Domain and Application stay
+   framework-free (no EF/ASP.NET/Npgsql). Endpoints depend on Application
+   **interfaces**, resolved via DI — never on concrete Infrastructure types.
+   Enforced by `apps/MineOS.Tests/Architecture/LayerDependencyTests.cs`; don't
+   weaken it to fit a change.
+
+2. **Tests green before "done."** CI does **not** run the .NET suite — run it
+   locally: `dotnet test apps/MineOS.Tests/MineOS.Tests.csproj`. Never claim done
+   with failing or absent tests. Frontend: `cd apps/web && npm run check`.
+
+3. **Don't bypass auth.** Valid `X-Api-Key` = admin; `ServerAccessFilter` gates
+   every server-scoped route; BuildTools/imports stay under the admin-only group;
+   console commands use `-X stuff` (not `eval`) with escaping intact. Any change to
+   who-can-do-what must be explicit in the PR.
+
+4. **Branch & release flow.** `vibing` is staging and the **default branch — base
+   PRs on it, not `master`.** Never push to `master` (protected) or push a `v*` tag
+   unprompted. Releases are tag-driven; see `.claude/skills/releasing/SKILL.md`.
+
+Full detail, the layer table, and where-things-go: **`AGENTS.md`**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to MineOS (SvelteKit)
+
+Thanks for contributing! A few things keep this project releasable and safe. Please
+skim them before opening a PR.
+
+## Branch flow — base your PR on `vibing`
+
+- **`vibing` is the staging branch and the repo default. Open your PR against
+  `vibing`.** New work is integrated and beta-tested here first.
+- `master` is the stable/production branch. It is protected — it only receives
+  vetted work promoted from `vibing`, and releases are cut from tags. Please don't
+  target `master` directly; a PR opened against it will be asked to retarget.
+
+## Before you open the PR
+
+- **Run the backend tests** — CI does *not* run them for you:
+  ```
+  dotnet test apps/MineOS.Tests/MineOS.Tests.csproj
+  ```
+- **Run the frontend check** if you touched `apps/web`:
+  ```
+  cd apps/web && npm run check
+  ```
+- Keep the change within the **Clean Architecture** boundaries (see `AGENTS.md`).
+  The architecture tests will fail the build if an inner layer gains an outward or
+  framework dependency.
+
+## Architecture, security, and release rules
+
+The full set of invariants — layer dependency rules, auth/security invariants, and
+the tag-driven release process — lives in **[`AGENTS.md`](./AGENTS.md)**. It applies
+to human and AI contributors alike. If you use an AI coding agent, point it at that
+file (and `CLAUDE.md`, which agents read automatically).
+
+## Local development
+
+The stack runs under Docker Compose (`api` + `web`). Build locally with:
+```
+docker compose -f docker-compose.yml -f docker-compose.build.yml build
+docker compose up -d
+```
+The web UI is served on port 3000 and the API on 5078. See `docker-compose*.yml` and
+`install.sh` for host/production variants.

--- a/apps/MineOS.Tests/Architecture/LayerDependencyTests.cs
+++ b/apps/MineOS.Tests/Architecture/LayerDependencyTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using MineOS.Api.Endpoints;
+using MineOS.Application.Interfaces;
+using MineOS.Domain.Entities;
+using MineOS.Infrastructure.Services;
+using Xunit;
+
+namespace MineOS.Tests.Architecture;
+
+/// <summary>
+/// Enforces the Clean Architecture dependency rule at build time: dependencies point
+/// INWARD only. Domain (innermost) knows nothing of the outer layers or of any
+/// delivery/persistence framework; Application depends only on Domain; Infrastructure
+/// and Api implement and compose the inner layers.
+///
+/// This is the rule a contributor's AI agent must never violate. Unlike a written
+/// guideline, a violation fails these tests red — the ".NET tests must pass locally"
+/// gate then blocks it from being called done.
+///
+/// Reflection-only by design (no NetArchTest dependency — a test that enforces
+/// dependency hygiene should not add one): each layer is anchored by a real public
+/// type, and assertions read Assembly.GetReferencedAssemblies(), which reflects the
+/// actual compiled metadata references, i.e. both project references and framework
+/// package references that are genuinely used.
+/// </summary>
+public class LayerDependencyTests
+{
+    private static readonly Assembly Domain = typeof(MinecraftServer).Assembly;
+    private static readonly Assembly Application = typeof(IServerService).Assembly;
+    private static readonly Assembly Infrastructure = typeof(ServerService).Assembly;
+    private static readonly Assembly Api = typeof(WorldEndpoints).Assembly;
+
+    private static void AssertDoesNotReference(Assembly assembly, params string[] forbiddenPrefixes)
+    {
+        var violations = assembly.GetReferencedAssemblies()
+            .Select(a => a.Name ?? string.Empty)
+            .Where(name => forbiddenPrefixes.Any(prefix =>
+                name.Equals(prefix, StringComparison.OrdinalIgnoreCase) ||
+                name.StartsWith(prefix + ".", StringComparison.OrdinalIgnoreCase)))
+            .Distinct()
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.True(
+            violations.Length == 0,
+            $"{assembly.GetName().Name} must not depend on [{string.Join(", ", forbiddenPrefixes)}] " +
+            $"but references: {string.Join(", ", violations)}. " +
+            "Dependencies must point inward: Api -> Infrastructure -> Application -> Domain.");
+    }
+
+    [Fact]
+    public void Domain_is_pure_and_depends_on_nothing_outward()
+    {
+        // The innermost layer: no outer MineOS layer, and no web/persistence framework.
+        AssertDoesNotReference(Domain,
+            "MineOS.Application", "MineOS.Infrastructure", "MineOS.Api",
+            "Microsoft.AspNetCore", "Microsoft.EntityFrameworkCore", "Npgsql");
+    }
+
+    [Fact]
+    public void Application_depends_only_on_Domain()
+    {
+        // Business rules and the interfaces they define never reach out to Infrastructure
+        // or Api, and never bind to a delivery (ASP.NET) or persistence (EF/Npgsql) framework.
+        AssertDoesNotReference(Application,
+            "MineOS.Infrastructure", "MineOS.Api",
+            "Microsoft.AspNetCore", "Microsoft.EntityFrameworkCore", "Npgsql");
+    }
+
+    [Fact]
+    public void Infrastructure_does_not_depend_on_Api()
+    {
+        // Infrastructure implements Application's interfaces; the composition root (Api)
+        // depends on Infrastructure, never the reverse.
+        AssertDoesNotReference(Infrastructure, "MineOS.Api");
+    }
+}


### PR DESCRIPTION
Adds the guardrails you asked for: a **hard, tool-agnostic** enforcement of the Clean Architecture boundary, plus the committed rules contributors and their AI agents must follow.

## Enforcement (the "NEVER violate" part)
`apps/MineOS.Tests/Architecture/LayerDependencyTests.cs` — reflection-only, **no new dependency**:
- `Domain` is pure (no outward MineOS layer, no EF/ASP.NET/Npgsql)
- `Application` depends only on `Domain`
- `Infrastructure` does not reference `Api`

TDD-verified: passes on the current tree, and **fails red** when a real framework leak (EF into Application) is injected — the exact mistake an agent would make. Since CI doesn't run .NET tests, the "tests-green-before-done" rule is what makes this bite locally.

## Rules (docs)
- **AGENTS.md** — canonical rules: clean architecture (+ where-things-go table), tests-green-before-done, security/auth invariants (ApiKey=admin, `ServerAccessFilter`, admin-only host ops, `stuff`-not-`eval` console), branch/release flow.
- **CLAUDE.md** — concise, auto-loaded by Claude Code; points at AGENTS.md.
- **CONTRIBUTING.md** + **.github/pull_request_template.md** — base PRs on `vibing`, run both suites, stay within the layer rules.

## Tests
`dotnet test`: **59/59** (56 + 3 new arch tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)