### PR TITLE
fix(cli): Tier 0 safety — narrow-terminal crash, .env perms, docs

### DIFF
--- a/tools/mineos-cli/README.md
+++ b/tools/mineos-cli/README.md
@@ -51,8 +51,7 @@ After installation, start the terminal dashboard:
 
 ```bash
 mineos tui
-# or simply:
-mineos
+# or: mineos ui
 ```
 
 ## Commands
@@ -61,8 +60,8 @@ mineos
 
 | Command | Description |
 |---------|-------------|
-| `mineos` | Launch the TUI dashboard (default) |
-| `mineos tui` | Full-screen terminal dashboard |
+| `mineos` | Show help / command overview |
+| `mineos tui` | Full-screen terminal dashboard (alias: `mineos ui`) |
 | `mineos interactive` | REPL-style command shell |
 | `mineos install` | Interactive installer |
 | `mineos uninstall` | Remove MineOS installation |

--- a/tools/mineos-cli/internal/presentation/cli/commands/env_edit.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/env_edit.go
@@ -85,7 +85,7 @@ func appendLineIfMissing(path string, line string) error {
 		content += "\n"
 	}
 	content += "\n" + line + "\n"
-	return os.WriteFile(path, []byte(content), 0o644)
+	return os.WriteFile(path, []byte(content), 0o600)
 }
 
 func loadEnvValues(path string) (map[string]string, error) {
@@ -106,7 +106,7 @@ func setEnvFileValue(path, key, value string) error {
 	data, err := os.ReadFile(envPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return os.WriteFile(envPath, []byte(key+"="+value+"\n"), 0o644)
+			return os.WriteFile(envPath, []byte(key+"="+value+"\n"), 0o600)
 		}
 		return err
 	}
@@ -129,5 +129,5 @@ func setEnvFileValue(path, key, value string) error {
 	if !strings.HasSuffix(output, "\n") {
 		output += "\n"
 	}
-	return os.WriteFile(envPath, []byte(output), 0o644)
+	return os.WriteFile(envPath, []byte(output), 0o600)
 }

--- a/tools/mineos-cli/internal/presentation/cli/commands/install.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/install.go
@@ -440,9 +440,13 @@ func runInstall(cmd *cobra.Command, opts installOptions) error {
 		installationID:   installationID,
 	})
 
-	if err := os.WriteFile(".env", []byte(envContents), 0o644); err != nil {
+	// .env holds the seed password, JWT secret, and API key — keep it owner-only.
+	if err := os.WriteFile(".env", []byte(envContents), 0o600); err != nil {
 		return err
 	}
+	// WriteFile leaves permissions untouched on a pre-existing file; force-tighten
+	// so re-running install over a 0644 .env still ends up owner-only.
+	_ = os.Chmod(".env", 0o600)
 
 	if err := createDirectories(out, opts.hostBaseDir, opts.dataDir); err != nil {
 		return err
@@ -945,7 +949,7 @@ func primaryLanIP() string {
 
 // appendToEnv appends a KEY=VALUE line to the given .env file.
 func appendToEnv(path, key, value string) {
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		return
 	}

--- a/tools/mineos-cli/internal/presentation/cli/commands/tui.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/tui.go
@@ -13,7 +13,8 @@ func NewTuiCommand(loadConfig *usecases.LoadConfigUseCase, version string) *cobr
 		Aliases: []string{"ui"},
 		Short:   "Full-screen MineOS dashboard",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			// This command is kept for explicit access, but the default `mineos` already launches the TUI.
+			// The TUI is launched explicitly via `mineos tui` / `mineos ui`.
+			// Bare `mineos` shows help (see NewRootCommand) rather than the dashboard.
 			return tui.RunTui(cmd.Context(), loadConfig, version, cmd.InOrStdin(), cmd.OutOrStdout())
 		},
 	}

--- a/tools/mineos-cli/internal/presentation/cli/tui/actions.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/actions.go
@@ -328,7 +328,7 @@ func writeEnvValue(path, key, value string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return os.WriteFile(path, []byte(key+"="+value+"\n"), 0o644)
+			return os.WriteFile(path, []byte(key+"="+value+"\n"), 0o600)
 		}
 		return err
 	}
@@ -348,7 +348,7 @@ func writeEnvValue(path, key, value string) error {
 	if !strings.HasSuffix(output, "\n") {
 		output += "\n"
 	}
-	return os.WriteFile(path, []byte(output), 0o644)
+	return os.WriteFile(path, []byte(output), 0o600)
 }
 
 func (m TuiModel) SelectedServer() string {

--- a/tools/mineos-cli/internal/presentation/cli/tui/constants.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/constants.go
@@ -73,6 +73,11 @@ const (
 const (
 	SidebarWidth    = 20
 	MinContentHeight = 5
+	// Minimum terminal dimensions below which the TUI renders a "resize" notice
+	// instead of a layout. Guards against negative content widths (which would
+	// panic strings.Repeat). Tunable.
+	MinTerminalWidth  = 40
+	MinTerminalHeight = 10
 )
 
 // Default source for docker logs

--- a/tools/mineos-cli/internal/presentation/cli/tui/view.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/view.go
@@ -12,6 +12,15 @@ func (m TuiModel) View() string {
 		return "Loading..."
 	}
 
+	// Below a usable size the split layout can't render — and an unclamped
+	// content width would panic strings.Repeat with a negative count. Show a
+	// resize notice instead of crashing.
+	if m.Width < MinTerminalWidth || m.Height < MinTerminalHeight {
+		return fmt.Sprintf(
+			"Terminal too small.\nResize to at least %dx%d (current %dx%d).",
+			MinTerminalWidth, MinTerminalHeight, m.Width, m.Height)
+	}
+
 	// 1. Render Header
 	header := m.RenderHeader()
 	headerHeight := lipgloss.Height(header)
@@ -22,8 +31,13 @@ func (m TuiModel) View() string {
 		contentHeight = MinContentHeight
 	}
 
+	// Clamp defensively so a renderer is never handed a negative width, even if
+	// the thresholds above change (leftWidth+separator must leave room).
 	leftWidth := SidebarWidth
-	rightWidth := m.Width - leftWidth - 1
+	if leftWidth > m.Width-1 {
+		leftWidth = max(0, m.Width-1)
+	}
+	rightWidth := max(0, m.Width-leftWidth-1)
 
 	// 3. Render Navigation and Content
 	leftLines := m.RenderNavSidebar(leftWidth, contentHeight)

--- a/tools/mineos-cli/internal/presentation/cli/tui/view_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/view_test.go
@@ -1,0 +1,30 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// A terminal narrower than the sidebar used to drive the content width negative
+// and panic strings.Repeat. View must degrade to a resize notice instead.
+func TestView_SmallTerminal_DoesNotPanic(t *testing.T) {
+	sizes := []struct{ w, h int }{
+		{0, 0},   // pre-size: existing "Loading..." path
+		{1, 1},   // absurdly small
+		{15, 4},  // narrower than SidebarWidth — the historical panic case
+		{MinTerminalWidth - 1, MinTerminalHeight - 1}, // just under the threshold
+	}
+	for _, s := range sizes {
+		m := TuiModel{Width: s.w, Height: s.h}
+		// Must not panic.
+		_ = m.View()
+	}
+}
+
+func TestView_TooSmall_ShowsResizeNotice(t *testing.T) {
+	m := TuiModel{Width: MinTerminalWidth - 1, Height: MinTerminalHeight - 1}
+	out := m.View()
+	if !strings.Contains(out, "too small") {
+		t.Fatalf("expected a resize notice for a too-small terminal, got %q", out)
+	}
+}


### PR DESCRIPTION
First slice of the CLI overhaul (#119) — Tier 0 safety/correctness. All verified via `golang:1.24` (build + vet + tests green).

### Closes #120 — TUI crash on narrow terminals
`View()` computed `rightWidth = m.Width - SidebarWidth - 1` unclamped; on a terminal narrower than the sidebar this went negative and `strings.Repeat("─", width)` **panicked**. Now renders a resize notice below `MinTerminalWidth/Height`, with defensive clamping so no renderer ever receives a negative width. **Adds the module's first tests** (`view_test.go`).

### Closes #121 — `.env` secrets world-readable
`.env` (seed password, JWT secret, API key) was written `0644`. Now `0600` at every writer, plus an explicit `chmod 0600` on install so re-running over a pre-existing `0644` file still tightens it (`os.WriteFile` doesn't change perms on an existing file).

### Closes #124 — bare `mineos` vs docs
Per maintainer: the TUI is still maturing, so bare `mineos` **intentionally stays as help**. Corrected the README and the stale `tui.go` comment that claimed `mineos` launches the dashboard. `mineos tui` / `mineos ui` remains the launcher.

Based on `vibing` per the branch flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)