### PR TITLE
ci(cli): add Go CLI PR CI (build/vet/test -race)

### DIFF
--- a/.github/workflows/go-cli-ci.yml
+++ b/.github/workflows/go-cli-ci.yml
@@ -1,0 +1,33 @@
+name: Go CLI CI
+
+on:
+  push:
+    branches: [vibing, master]
+    paths:
+      - 'tools/mineos-cli/**'
+      - '.github/workflows/go-cli-ci.yml'
+  pull_request:
+    branches: [vibing, master]
+    paths:
+      - 'tools/mineos-cli/**'
+      - '.github/workflows/go-cli-ci.yml'
+  workflow_dispatch:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/mineos-cli
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: tools/mineos-cli/go.mod
+          cache-dependency-path: tools/mineos-cli/go.sum
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test (race)
+        run: go test ./... -race

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ vibing, master ]
   pull_request:
-    branches: [ master ]
+    branches: [ vibing, master ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Closes #123. Part of #119.

- **New `go-cli-ci.yml`** — on PRs/pushes touching `tools/mineos-cli/**`, runs `go build`, `go vet`, `go test ./... -race` (Go version read from `go.mod`). Until now the only Go workflow built binaries **on `v*` tags only**, so a broken build was invisible until release time. This is what will run the tests added in #136.
- **`node.js.yml`** companion fix — also trigger on `vibing`. It was `master`-only, but PRs now target `vibing` (the default), so web CI wasn't running on the normal flow.

No untrusted-input interpolation in either workflow (no injection surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)