### PR TITLE
fix(cli): verify self-update integrity + add HTTP timeouts

### DIFF
--- a/.github/workflows/publish-install-bundle.yml
+++ b/.github/workflows/publish-install-bundle.yml
@@ -43,6 +43,15 @@ jobs:
             (cd "$OUT_DIR" && zip -j "mineos-cli_${GOOS}_${GOARCH}.zip" "$OUT_NAME")
           done
 
+      - name: Generate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          # SHA-256 of the published CLI archives; `mineos upgrade` verifies its
+          # download against this before overwriting the running binary.
+          (cd dist/cli && sha256sum *.zip > checksums.txt)
+          cat dist/cli/checksums.txt
+
       - name: Build bundle
         shell: bash
         run: |
@@ -65,3 +74,4 @@ jobs:
             dist/mineos-install-bundle.tar.gz
             dist/mineos-install-bundle.zip
             dist/cli/*.zip
+            dist/cli/checksums.txt

--- a/tools/mineos-cli/internal/presentation/cli/commands/upgrade.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/upgrade.go
@@ -3,7 +3,10 @@ package commands
 import (
 	"archive/tar"
 	"archive/zip"
+	"bufio"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,6 +16,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -22,6 +26,14 @@ const (
 	githubAPIBase    = "https://api.github.com"
 	latestReleaseURL = githubAPIBase + "/repos/" + githubRepo + "/releases/latest"
 	allReleasesURL   = githubAPIBase + "/repos/" + githubRepo + "/releases"
+	checksumsAsset   = "checksums.txt"
+)
+
+var (
+	// metadataHTTPClient is for the small GitHub API JSON calls.
+	metadataHTTPClient = &http.Client{Timeout: 30 * time.Second}
+	// downloadHTTPClient allows a longer budget for fetching the release binary.
+	downloadHTTPClient = &http.Client{Timeout: 10 * time.Minute}
 )
 
 type githubRelease struct {
@@ -176,7 +188,7 @@ func runUpgrade(cmd *cobra.Command, currentVersion string, force, checkOnly, inc
 	tmpPath := tmpFile.Name()
 	defer os.Remove(tmpPath)
 
-	resp, err := http.Get(downloadURL)
+	resp, err := downloadHTTPClient.Get(downloadURL)
 	if err != nil {
 		tmpFile.Close()
 		return fmt.Errorf("failed to download: %w", err)
@@ -192,6 +204,11 @@ func runUpgrade(cmd *cobra.Command, currentVersion string, force, checkOnly, inc
 	tmpFile.Close()
 	if err != nil {
 		return fmt.Errorf("failed to save download: %w", err)
+	}
+
+	// Verify integrity before this binary overwrites the running executable.
+	if err := verifyChecksum(out, tmpPath, assetName, release); err != nil {
+		return fmt.Errorf("integrity check failed: %w", err)
 	}
 
 	// Extract binary from archive
@@ -219,8 +236,70 @@ func runUpgrade(cmd *cobra.Command, currentVersion string, force, checkOnly, inc
 	return nil
 }
 
+// verifyChecksum verifies the SHA-256 of the downloaded file against the
+// release's checksums.txt asset. A present-but-mismatching checksum is fatal.
+// If the release has no checksums.txt (e.g. an older release), it warns and
+// proceeds — transport is still HTTPS and forward upgrades always target a
+// release built with the checksums step.
+func verifyChecksum(out io.Writer, filePath, assetName string, release *githubRelease) error {
+	var checksumURL string
+	for _, a := range release.Assets {
+		if a.Name == checksumsAsset {
+			checksumURL = a.BrowserDownloadURL
+			break
+		}
+	}
+	if checksumURL == "" {
+		fmt.Fprintln(out, "Warning: no checksums.txt in release — skipping integrity verification.")
+		return nil
+	}
+
+	resp, err := metadataHTTPClient.Get(checksumURL)
+	if err != nil {
+		return fmt.Errorf("failed to fetch checksums: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to fetch checksums: status %s", resp.Status)
+	}
+
+	expected := ""
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		// checksums.txt lines are "<sha256>  <filename>".
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 2 && filepath.Base(fields[len(fields)-1]) == assetName {
+			expected = strings.ToLower(fields[0])
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to read checksums: %w", err)
+	}
+	if expected == "" {
+		return fmt.Errorf("no checksum listed for %s", assetName)
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+	if actual != expected {
+		return fmt.Errorf("sha256 mismatch for %s: expected %s, got %s", assetName, expected, actual)
+	}
+
+	fmt.Fprintln(out, "Verified checksum.")
+	return nil
+}
+
 func fetchLatestRelease() (*githubRelease, error) {
-	resp, err := http.Get(latestReleaseURL)
+	resp, err := metadataHTTPClient.Get(latestReleaseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +329,7 @@ func fetchBestRelease(includePrerelease bool) (*githubRelease, error) {
 	}
 
 	// Otherwise, fetch all releases and find the newest (including pre-releases)
-	resp, err := http.Get(allReleasesURL)
+	resp, err := metadataHTTPClient.Get(allReleasesURL)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/mineos-cli/internal/presentation/cli/commands/upgrade_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/upgrade_test.go
@@ -1,0 +1,86 @@
+package commands
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTempAsset(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "asset.zip")
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func sha256Hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+func checksumsServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, body)
+	}))
+}
+
+func TestVerifyChecksum_Match(t *testing.T) {
+	content := "fake-archive-bytes"
+	path := writeTempAsset(t, content)
+	asset := "mineos-cli_linux_amd64.zip"
+	srv := checksumsServer(t, fmt.Sprintf("%s  %s\n", sha256Hex(content), asset))
+	defer srv.Close()
+
+	rel := &githubRelease{Assets: []githubAsset{{Name: checksumsAsset, BrowserDownloadURL: srv.URL}}}
+	if err := verifyChecksum(io.Discard, path, asset, rel); err != nil {
+		t.Fatalf("expected match, got %v", err)
+	}
+}
+
+func TestVerifyChecksum_Mismatch(t *testing.T) {
+	path := writeTempAsset(t, "real-bytes")
+	asset := "mineos-cli_linux_amd64.zip"
+	// checksum for different content — must be rejected.
+	srv := checksumsServer(t, fmt.Sprintf("%s  %s\n", sha256Hex("tampered"), asset))
+	defer srv.Close()
+
+	rel := &githubRelease{Assets: []githubAsset{{Name: checksumsAsset, BrowserDownloadURL: srv.URL}}}
+	if err := verifyChecksum(io.Discard, path, asset, rel); err == nil {
+		t.Fatal("expected mismatch error, got nil")
+	}
+}
+
+func TestVerifyChecksum_NoChecksumsAssetWarnsAndPasses(t *testing.T) {
+	path := writeTempAsset(t, "bytes")
+	rel := &githubRelease{Assets: []githubAsset{{Name: "mineos-cli_linux_amd64.zip"}}}
+	var out strings.Builder
+	if err := verifyChecksum(&out, path, "mineos-cli_linux_amd64.zip", rel); err != nil {
+		t.Fatalf("expected nil (warn + proceed), got %v", err)
+	}
+	if !strings.Contains(out.String(), "no checksums.txt") {
+		t.Fatalf("expected a warning about missing checksums, got %q", out.String())
+	}
+}
+
+func TestVerifyChecksum_AssetNotListed(t *testing.T) {
+	path := writeTempAsset(t, "bytes")
+	asset := "mineos-cli_linux_amd64.zip"
+	// checksums present but for a different asset only.
+	srv := checksumsServer(t, fmt.Sprintf("%s  %s\n", sha256Hex("x"), "mineos-cli_windows_amd64.zip"))
+	defer srv.Close()
+
+	rel := &githubRelease{Assets: []githubAsset{{Name: checksumsAsset, BrowserDownloadURL: srv.URL}}}
+	if err := verifyChecksum(io.Discard, path, asset, rel); err == nil {
+		t.Fatal("expected error when the asset is not listed in checksums, got nil")
+	}
+}


### PR DESCRIPTION
Closes #122. Part of #119.

The self-update path overwrote the running binary from a download with **no integrity check**, over `http.Get` calls with **no timeout** — for a binary that drives the user's Docker stack.

- **Release workflow** now generates `checksums.txt` (SHA-256 of the CLI archives) and publishes it as a release asset.
- **`mineos upgrade`** verifies the downloaded archive against `checksums.txt` before extract/replace; a mismatch is **fatal**. Missing `checksums.txt` (older releases) → warn + proceed (transport is HTTPS; forward upgrades always target a checksummed release).
- All three GitHub fetches now use `http.Client`s with explicit timeouts (30s metadata / 10m download).

Tests cover match / mismatch / missing-file / unlisted-asset (green under `-race`). Go CLI CI (#137) will exercise these on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)