### PR TITLE
chore(cli): remove dead code, incl. the racy interactive goroutine

### DIFF
--- a/tools/mineos-cli/internal/presentation/cli/tui/actions.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/actions.go
@@ -1,4 +1,4 @@
-﻿package tui
+package tui
 
 import (
 	"bufio"
@@ -10,41 +10,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/application/usecases"
 )
-
-func (m TuiModel) ServerActionCmd(action string) tea.Cmd {
-	server := m.SelectedServer()
-	if server == "" || !m.ConfigReady {
-		return func() tea.Msg { return ActionResultMsg{Err: errors.New("select a server first")} }
-	}
-	ctx := m.Ctx
-	client := m.Client
-	return func() tea.Msg {
-		uc := usecases.NewServerActionUseCase(client)
-		err := uc.Execute(ctx, server, action)
-		return ActionResultMsg{
-			Message: fmt.Sprintf("%s: %s", action, server),
-			Err:     err,
-		}
-	}
-}
-
-func (m TuiModel) StopAllCmd(timeout int) tea.Cmd {
-	if !m.ConfigReady {
-		return func() tea.Msg { return ActionResultMsg{Err: errors.New("API client not ready")} }
-	}
-	ctx := m.Ctx
-	client := m.Client
-	return func() tea.Msg {
-		uc := usecases.NewStopAllServersUseCase(client)
-		_, err := uc.Execute(ctx, timeout)
-		return ActionResultMsg{
-			Message: fmt.Sprintf("stop-all requested (timeout %ds)", timeout),
-			Err:     err,
-		}
-	}
-}
 
 func (m TuiModel) ConsoleCommandCmd(command string) tea.Cmd {
 	server := m.SelectedServer()
@@ -59,17 +25,6 @@ func (m TuiModel) ConsoleCommandCmd(command string) tea.Cmd {
 			Message: fmt.Sprintf("sent to %s: %s", server, command),
 			Err:     err,
 		}
-	}
-}
-
-func (m TuiModel) ComposeActionCmd(args ...string) tea.Cmd {
-	if !m.ComposeReady {
-		return func() tea.Msg { return ActionResultMsg{Err: errors.New("docker compose not available")} }
-	}
-	return func() tea.Msg {
-		err := m.Compose.Run(args)
-		action := strings.Join(args, " ")
-		return ActionResultMsg{Message: "compose " + action + " requested", Err: err}
 	}
 }
 
@@ -189,90 +144,6 @@ func makeErrorChan(errMsg string) <-chan string {
 	ch <- errMsg
 	close(ch)
 	return ch
-}
-
-// StartInteractiveCmd starts an interactive command with piped I/O
-func (m TuiModel) StartInteractiveCmd(exe string, args []string, label string) tea.Cmd {
-	return func() tea.Msg {
-		cmd := exec.Command(exe, args...)
-
-		stdin, err := cmd.StdinPipe()
-		if err != nil {
-			return ExecFinishedMsg{Action: label, Err: err}
-		}
-
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			stdin.Close()
-			return ExecFinishedMsg{Action: label, Err: err}
-		}
-
-		stderr, err := cmd.StderrPipe()
-		if err != nil {
-			stdin.Close()
-			stdout.Close()
-			return ExecFinishedMsg{Action: label, Err: err}
-		}
-
-		if err := cmd.Start(); err != nil {
-			stdin.Close()
-			stdout.Close()
-			stderr.Close()
-			return ExecFinishedMsg{Action: label, Err: err}
-		}
-
-		// Create output channel and start readers
-		outputChan := make(chan string, 100)
-
-		// Read stdout
-		go func() {
-			buf := make([]byte, 1024)
-			for {
-				n, err := stdout.Read(buf)
-				if n > 0 {
-					lines := strings.Split(string(buf[:n]), "\n")
-					for _, line := range lines {
-						if line != "" {
-							outputChan <- line
-						}
-					}
-				}
-				if err != nil {
-					break
-				}
-			}
-		}()
-
-		// Read stderr
-		go func() {
-			buf := make([]byte, 1024)
-			for {
-				n, err := stderr.Read(buf)
-				if n > 0 {
-					lines := strings.Split(string(buf[:n]), "\n")
-					for _, line := range lines {
-						if line != "" {
-							outputChan <- line
-						}
-					}
-				}
-				if err != nil {
-					break
-				}
-			}
-		}()
-
-		// Wait for command to finish in background
-		go func() {
-			cmd.Wait()
-			close(outputChan)
-		}()
-
-		return InteractiveStartedMsg{
-			Stdin:  stdin,
-			Output: outputChan,
-		}
-	}
 }
 
 // ListenInteractiveCmd listens for output from an interactive command

--- a/tools/mineos-cli/internal/presentation/cli/tui/constants.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/constants.go
@@ -50,9 +50,7 @@ const (
 	MaxLogLines          = 5000 // Increased buffer size
 	DefaultDockerLogTail = 200
 	LogRetryDelay        = 2 * time.Second
-	ConnectionRetryDelay = 6 * time.Second
 	MaxLogRetries        = 3
-	MaxRetryAttempts     = 3
 )
 
 // Streaming constants
@@ -63,15 +61,12 @@ const (
 
 // Timeout constants
 const (
-	DefaultStopAllTimeout   = 300
-	DefaultShutdownTimeout  = 300
-	DefaultAPIHealthTimeout = 60
-	HealthPollInterval      = 10 * time.Second // Re-check API when unhealthy
+	HealthPollInterval = 10 * time.Second // Re-check API when unhealthy
 )
 
 // UI layout constants
 const (
-	SidebarWidth    = 20
+	SidebarWidth     = 20
 	MinContentHeight = 5
 	// Minimum terminal dimensions below which the TUI renders a "resize" notice
 	// instead of a layout. Guards against negative content widths (which would

--- a/tools/mineos-cli/internal/presentation/cli/tui/input.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/input.go
@@ -516,30 +516,6 @@ func (m TuiModel) HandleConfirmInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// NextLogSource cycles to the next log source
-func (m TuiModel) NextLogSource(current string, services []string) string {
-	if len(services) == 0 {
-		return DefaultDockerLogSource
-	}
-	sources := append([]string{DefaultDockerLogSource}, services...)
-	for i, s := range sources {
-		if s == current {
-			return sources[(i+1)%len(sources)]
-		}
-	}
-	return sources[0]
-}
-
-// NextMinecraftLogType cycles to the next minecraft log type
-func (m TuiModel) NextMinecraftLogType(current string) string {
-	for i, t := range MinecraftLogTypes {
-		if t == current {
-			return MinecraftLogTypes[(i+1)%len(MinecraftLogTypes)]
-		}
-	}
-	return "combined"
-}
-
 // pageUp scrolls up by one page in logs view
 func (m TuiModel) pageUp() (tea.Model, tea.Cmd) {
 	if m.CurrentView == ViewServiceLogs {

--- a/tools/mineos-cli/internal/presentation/cli/tui/logs_stream.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/logs_stream.go
@@ -1,4 +1,4 @@
-﻿package tui
+package tui
 
 import (
 	"bufio"
@@ -11,28 +11,6 @@ import (
 
 	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/infrastructure/api"
 )
-
-func (m *TuiModel) EnsureLogStream() {
-	if !m.LogsActive {
-		return
-	}
-
-	m.StopLogs()
-	ctx, cancel := context.WithCancel(context.Background())
-	m.LogCancel = cancel
-
-	if m.LogType == LogTypeDocker {
-		if !m.ComposeReady {
-			return
-		}
-		m.LogsChan, m.LogErrsChan = StreamDockerLogs(ctx, m.Compose, m.LogSource)
-	} else {
-		if !m.ConfigReady || m.MinecraftSource == "" {
-			return
-		}
-		m.LogsChan, m.LogErrsChan = StreamMinecraftLogs(ctx, m.Client, m.MinecraftSource, m.MinecraftType)
-	}
-}
 
 func StreamMinecraftLogs(ctx context.Context, client *api.Client, server, source string) (<-chan string, <-chan error) {
 	logsChan := make(chan string, 100)

--- a/tools/mineos-cli/internal/presentation/cli/tui/model.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/model.go
@@ -212,12 +212,6 @@ type ExecFinishedMsg struct {
 	Err    error
 }
 
-// ConfirmActionMsg is sent when user confirms a destructive action
-type ConfirmActionMsg struct {
-	Confirmed bool
-	Action    *MenuItem
-}
-
 // InteractiveStartedMsg is sent when an interactive command starts
 type InteractiveStartedMsg struct {
 	Stdin  io.WriteCloser

--- a/tools/mineos-cli/internal/presentation/cli/tui/styles.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/styles.go
@@ -1,4 +1,4 @@
-﻿package tui
+package tui
 
 import "github.com/charmbracelet/lipgloss"
 
@@ -10,8 +10,4 @@ var (
 	StyleStopped  = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	StyleError    = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
 	StyleStatus   = lipgloss.NewStyle().Foreground(lipgloss.Color("81"))
-	StyleServiceA = lipgloss.NewStyle().Foreground(lipgloss.Color("75"))
-	StyleServiceB = lipgloss.NewStyle().Foreground(lipgloss.Color("135"))
-	StyleServiceC = lipgloss.NewStyle().Foreground(lipgloss.Color("112"))
-	ServiceStyles = []lipgloss.Style{StyleServiceA, StyleServiceB, StyleServiceC, StyleRunning, StyleStatus}
 )

--- a/tools/mineos-cli/internal/presentation/cli/tui/update.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/update.go
@@ -160,9 +160,6 @@ func (m TuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ExecFinishedMsg:
 		return m.handleExecFinished(msg)
 
-	case ConfirmActionMsg:
-		return m.handleConfirmAction(msg)
-
 	case InteractiveStartedMsg:
 		return m.handleInteractiveStarted(msg)
 
@@ -349,19 +346,6 @@ func (m TuiModel) handleExecFinished(msg ExecFinishedMsg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(m.LoadConfigCmd(), m.LoadComposeCmd(), m.LoadServersCmd())
 }
 
-func (m TuiModel) handleConfirmAction(msg ConfirmActionMsg) (tea.Model, tea.Cmd) {
-	m.Mode = ModeNormal
-	m.ConfirmAction = nil
-	m.ConfirmMessage = ""
-
-	if !msg.Confirmed || msg.Action == nil {
-		m.StatusMsg = "Action cancelled"
-		return m, nil
-	}
-
-	return m, m.ExecMenuItem(*msg.Action)
-}
-
 func (m TuiModel) handleInteractiveStarted(msg InteractiveStartedMsg) (tea.Model, tea.Cmd) {
 	m.Mode = ModeInteractive
 	m.InteractiveStdin = msg.Stdin
@@ -526,12 +510,6 @@ func (m TuiModel) StartLogStreamCmd() tea.Cmd {
 			LogSource: logSource,
 		}
 	}
-}
-
-// EnsureLogStreamCmd is deprecated - use StartLogStreamCmd instead
-// Kept for backward compatibility
-func (m TuiModel) EnsureLogStreamCmd() tea.Cmd {
-	return m.StartLogStreamCmd()
 }
 
 // ListenLogsCmd creates a command to listen for log messages


### PR DESCRIPTION
Closes #125. Part of #119. **−217 lines** of TUI code with zero callers.

- **`StartInteractiveCmd`** — never invoked, and held a `close(chan)`-vs-send **race** (readers not coordinated with the closer). Deleting it removes the race.
- `ServerActionCmd`, `StopAllCmd`, `ComposeActionCmd` — superseded by the `ExecMenuItem` subprocess path.
- `EnsureLogStreamCmd`/`EnsureLogStream`, `NextLogSource`/`NextMinecraftLogType`.
- `ConfirmActionMsg` + its Update case + `handleConfirmAction` — nothing constructs the message (confirms resolve synchronously in `HandleConfirmInput`).
- Unused constants + the never-applied `ServiceStyles`/`StyleServiceA-C` palette.

The remaining interactive scaffolding (`ListenInteractiveCmd`, `SendInteractiveInput`, model fields, update handlers, view branches) is unreachable but interconnected across model/update/view — removed with the exec-path unification in #133.

Build/vet/gofmt clean; tests pass under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)