### PR TITLE
feat(cli): live server refresh + real health check

### DIFF
--- a/tools/mineos-cli/internal/presentation/cli/tui/dashboard.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/dashboard.go
@@ -22,7 +22,7 @@ func (m TuiModel) RenderDashboardMain(width, height int) []string {
 	var health string
 	if m.ContainersStopped {
 		health = StyleSubtle.Render("stopped (containers down)")
-	} else if m.ConfigReady && m.Client != nil && m.ErrMsg == "" {
+	} else if m.Healthy {
 		health = StyleRunning.Render("connected")
 	} else if !m.ConfigReady && m.ErrMsg == "" {
 		health = StyleSubtle.Render("loading...")

--- a/tools/mineos-cli/internal/presentation/cli/tui/header.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/header.go
@@ -12,7 +12,7 @@ func (m TuiModel) RenderHeader() string {
 	health := StyleError.Render("● UNHEALTHY")
 	if m.ContainersStopped {
 		health = StyleSubtle.Render("● STOPPED")
-	} else if m.ConfigReady && m.ErrMsg == "" {
+	} else if m.Healthy {
 		health = StyleRunning.Render("● HEALTHY")
 	}
 

--- a/tools/mineos-cli/internal/presentation/cli/tui/model.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/model.go
@@ -77,6 +77,7 @@ type TuiModel struct {
 	Compose         *ComposeRunner
 	ComposeReady    bool
 	ConfigReady     bool
+	Healthy         bool // Last real /health result (drives the header badge)
 	ComposeError    string
 	ComposeServices []string
 
@@ -252,5 +253,11 @@ type SettingsToggledMsg struct {
 	Err error
 }
 
-// HealthTickMsg is sent periodically to re-check API health when unhealthy
+// HealthTickMsg is sent periodically to drive the live refresh loop
 type HealthTickMsg struct{}
+
+// HealthCheckedMsg carries the result of a real /health probe
+type HealthCheckedMsg struct {
+	Healthy bool
+	Err     error
+}

--- a/tools/mineos-cli/internal/presentation/cli/tui/update.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/update.go
@@ -65,7 +65,8 @@ func RunTui(ctx context.Context, loadConfig *usecases.LoadConfigUseCase, version
 
 // Init initializes the TUI model
 func (m TuiModel) Init() tea.Cmd {
-	return tea.Batch(m.LoadConfigCmd(), m.LoadComposeCmd())
+	// scheduleHealthPoll arms the single, self-rescheduling refresh loop.
+	return tea.Batch(m.LoadConfigCmd(), m.LoadComposeCmd(), scheduleHealthPoll())
 }
 
 // Update handles all incoming messages
@@ -179,16 +180,26 @@ func (m TuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleStreamingFinished(msg)
 
 	case HealthTickMsg:
-		// Don't poll if containers are intentionally stopped or already healthy
+		// Single self-rescheduling refresh loop (armed once in Init). Always
+		// re-arm so the TUI keeps refreshing while healthy, not only while down.
+		cmds := []tea.Cmd{scheduleHealthPoll()}
 		if m.ContainersStopped {
-			return m, nil
+			m.Healthy = false
+			return m, tea.Batch(cmds...)
 		}
-		if m.ConfigReady && m.ErrMsg == "" {
-			return m, nil
+		if m.ConfigReady {
+			// Live refresh: real health probe + current server list.
+			cmds = append(cmds, m.HealthCheckCmd(), m.LoadServersCmd())
+		} else {
+			// API was unreachable — try to reconnect.
+			m.StatusMsg = "Reconnecting to API..."
+			cmds = append(cmds, m.LoadConfigCmd())
 		}
-		// Re-attempt config and server load
-		m.StatusMsg = "Reconnecting to API..."
-		return m, tea.Batch(m.LoadConfigCmd(), m.LoadServersCmd())
+		return m, tea.Batch(cmds...)
+
+	case HealthCheckedMsg:
+		m.Healthy = msg.Healthy
+		return m, nil
 
 	case SettingsToggledMsg:
 		if msg.Err != nil {
@@ -217,6 +228,19 @@ func scheduleHealthPoll() tea.Cmd {
 	})
 }
 
+// HealthCheckCmd probes the API's /health endpoint for the header badge.
+func (m TuiModel) HealthCheckCmd() tea.Cmd {
+	client := m.Client
+	if client == nil {
+		return func() tea.Msg { return HealthCheckedMsg{Healthy: false} }
+	}
+	ctx := m.Ctx
+	return func() tea.Msg {
+		err := client.Health(ctx)
+		return HealthCheckedMsg{Healthy: err == nil, Err: err}
+	}
+}
+
 func (m TuiModel) handleConfigLoaded(msg ConfigLoadedMsg) (tea.Model, tea.Cmd) {
 	if msg.Err != nil {
 		m.ErrMsg = msg.Err.Error()
@@ -227,9 +251,10 @@ func (m TuiModel) handleConfigLoaded(msg ConfigLoadedMsg) (tea.Model, tea.Cmd) {
 				return m.LoadConfigCmdWithRetry(msg.RetryCount + 1)()
 			})
 		}
-		// All retries exhausted — schedule periodic health poll to recover later
+		// All retries exhausted — the Init-armed refresh loop keeps retrying.
+		m.Healthy = false
 		m.StatusMsg = "API unavailable, will retry periodically..."
-		return m, scheduleHealthPoll()
+		return m, nil
 	}
 	m.Cfg = msg.Cfg
 	m.ConfigReady = true
@@ -237,7 +262,8 @@ func (m TuiModel) handleConfigLoaded(msg ConfigLoadedMsg) (tea.Model, tea.Cmd) {
 	m.StatusMsg = "" // Clear reconnecting status
 	m.RetryCount = 0
 	m.Client = api.NewClientFromConfig(msg.Cfg)
-	return m, m.LoadServersCmd()
+	// Probe health immediately so the badge doesn't wait a full interval.
+	return m, tea.Batch(m.LoadServersCmd(), m.HealthCheckCmd())
 }
 
 func (m TuiModel) handleComposeLoaded(msg ComposeLoadedMsg) (tea.Model, tea.Cmd) {
@@ -272,10 +298,8 @@ func (m TuiModel) handleServersLoaded(msg ServersLoadedMsg) (tea.Model, tea.Cmd)
 		if !isTransient {
 			m.ErrMsg = errStr
 		}
-		// Schedule health poll to retry when API comes back
-		if !m.ContainersStopped {
-			return m, scheduleHealthPoll()
-		}
+		// The Init-armed refresh loop retries; a failed list means not healthy.
+		m.Healthy = false
 		return m, nil
 	}
 	if msg.Cfg.EnvPath != "" {

--- a/tools/mineos-cli/internal/presentation/cli/tui/update_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/update_test.go
@@ -1,0 +1,37 @@
+package tui
+
+import "testing"
+
+// HealthCheckedMsg is the only thing that flips the health badge.
+func TestUpdate_HealthCheckedSetsHealthy(t *testing.T) {
+	m := TuiModel{}
+	out, _ := m.Update(HealthCheckedMsg{Healthy: true})
+	if !out.(TuiModel).Healthy {
+		t.Fatal("expected Healthy=true after a successful HealthCheckedMsg")
+	}
+	out2, _ := out.(TuiModel).Update(HealthCheckedMsg{Healthy: false})
+	if out2.(TuiModel).Healthy {
+		t.Fatal("expected Healthy=false after a failed HealthCheckedMsg")
+	}
+}
+
+// The refresh loop must keep re-arming (non-nil cmd) and stopped != healthy.
+func TestUpdate_HealthTickReschedulesAndStoppedIsUnhealthy(t *testing.T) {
+	m := TuiModel{ContainersStopped: true, Healthy: true}
+	out, cmd := m.Update(HealthTickMsg{})
+	if out.(TuiModel).Healthy {
+		t.Fatal("stopped containers must not report healthy")
+	}
+	if cmd == nil {
+		t.Fatal("health tick must always reschedule (non-nil cmd)")
+	}
+}
+
+// While ready, a tick issues refresh work (and still re-arms).
+func TestUpdate_HealthTickWhileReadyRefreshes(t *testing.T) {
+	m := TuiModel{ConfigReady: true}
+	_, cmd := m.Update(HealthTickMsg{})
+	if cmd == nil {
+		t.Fatal("expected refresh commands while ready")
+	}
+}


### PR DESCRIPTION
Closes #126. Part of #119 (Tier 1 — monitoring).

**Before:** the TUI loaded the server list once and never refreshed while healthy; the health badge was faked from `ConfigReady && ErrMsg == ""` and never actually re-probed the API.

**After:**
- A single **self-rescheduling refresh loop** (armed once in `Init`) runs every interval regardless of state: probes `/health` + reloads the server list while connected, reconnects while down. Removed the ad-hoc `scheduleHealthPoll` calls that could arm overlapping loops.
- The header + dashboard badge is now driven by a **real `/health` result** (`m.Healthy`), not the connection-state proxy. Config-load success probes health immediately so the badge doesn't wait a full interval.

Adds `Update()` transition tests (pure by design). Build/vet/gofmt clean; full suite green under `-race`.

Next in Tier 1: #127 (richer server fields) → #128 (live metrics panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)