### PR TITLE
feat(cli): richer server table — players, memory, needs-restart

### DIFF
--- a/tools/mineos-cli/internal/domain/ports/api_client.go
+++ b/tools/mineos-cli/internal/domain/ports/api_client.go
@@ -4,7 +4,16 @@ import "context"
 
 type Server struct {
 	Name   string `json:"name"`
-	Status string `json:"status"`
+	Status string `json:"status"` // derived from Up when sourced from /host/servers
+
+	// Richer fields from GET /host/servers (ServerSummaryDto).
+	Up            bool   `json:"up"`
+	Profile       string `json:"profile"`
+	Port          *int   `json:"port"`
+	PlayersOnline *int   `json:"playersOnline"`
+	PlayersMax    *int   `json:"playersMax"`
+	MemoryBytes   *int64 `json:"memoryBytes"`
+	NeedsRestart  bool   `json:"needsRestart"`
 }
 
 type StopAllResult struct {

--- a/tools/mineos-cli/internal/infrastructure/api/client.go
+++ b/tools/mineos-cli/internal/infrastructure/api/client.go
@@ -74,7 +74,10 @@ func (c *Client) ListServers(ctx context.Context) ([]ports.Server, error) {
 		return nil, ErrApiKeyMissing
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apiBaseURL+"/servers/list", nil)
+	// /host/servers (ServerSummaryDto) carries richer per-server fields — players,
+	// memory, needs-restart — that /servers/list does not. It has no status string,
+	// so derive one from Up for the existing status-based rendering/commands.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apiBaseURL+"/host/servers", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -97,6 +100,16 @@ func (c *Client) ListServers(ctx context.Context) ([]ports.Server, error) {
 	var servers []ports.Server
 	if err := json.NewDecoder(resp.Body).Decode(&servers); err != nil {
 		return nil, err
+	}
+
+	for i := range servers {
+		if servers[i].Status == "" {
+			if servers[i].Up {
+				servers[i].Status = "running"
+			} else {
+				servers[i].Status = "stopped"
+			}
+		}
 	}
 
 	return servers, nil

--- a/tools/mineos-cli/internal/infrastructure/api/client_test.go
+++ b/tools/mineos-cli/internal/infrastructure/api/client_test.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListServers_DecodesRichFieldsAndDerivesStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/host/servers", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"name":"lobby","up":true,"playersOnline":3,"playersMax":20,"memoryBytes":536870912,"needsRestart":false},
+			{"name":"survival","up":false,"needsRestart":true}
+		]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	servers, err := NewClient(srv.URL, "k").ListServers(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 2 {
+		t.Fatalf("want 2 servers, got %d", len(servers))
+	}
+	if servers[0].Status != "running" || servers[1].Status != "stopped" {
+		t.Fatalf("status derivation wrong: %q %q", servers[0].Status, servers[1].Status)
+	}
+	if servers[0].PlayersOnline == nil || *servers[0].PlayersOnline != 3 {
+		t.Fatal("playersOnline not decoded")
+	}
+	if servers[0].MemoryBytes == nil || *servers[0].MemoryBytes != 536870912 {
+		t.Fatal("memoryBytes not decoded")
+	}
+	if !servers[1].NeedsRestart {
+		t.Fatal("needsRestart not decoded")
+	}
+}
+
+func TestListServers_MissingKey(t *testing.T) {
+	if _, err := NewClient("http://example.invalid", "").ListServers(context.Background()); err != ErrApiKeyMissing {
+		t.Fatalf("want ErrApiKeyMissing, got %v", err)
+	}
+}

--- a/tools/mineos-cli/internal/presentation/cli/tui/servers.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/servers.go
@@ -45,7 +45,7 @@ func (m TuiModel) RenderServersTable(width, height int) []string {
 	lines := make([]string, 0, height)
 
 	// Table Header
-	header := fmt.Sprintf("  %-25s %-15s", "SERVER NAME", "STATUS")
+	header := fmt.Sprintf("  %-20s %-10s %-8s %-7s", "SERVER NAME", "STATUS", "PLAYERS", "MEM")
 	lines = append(lines, StyleHeader.Render(header))
 	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width)))
 
@@ -60,23 +60,50 @@ func (m TuiModel) RenderServersTable(width, height int) []string {
 
 	for i, server := range m.Servers {
 		prefix := "  "
-		name := server.Name
-		status := server.Status
-
 		nameStyle := StyleHeader // Default
 		if i == m.Selected {
 			prefix = StyleSelected.Render("▶ ")
 			nameStyle = StyleSelected
 		}
 
-		statusFormatted := FormatStatus(status)
+		// Pad plain text before styling so column widths stay honest.
+		name := nameStyle.Render(fmt.Sprintf("%-20s", server.Name))
+		status := FormatStatus(fmt.Sprintf("%-10s", server.Status))
+		players := fmt.Sprintf("%-8s", formatPlayers(server.PlayersOnline, server.PlayersMax))
+		mem := fmt.Sprintf("%-7s", formatMemory(server.MemoryBytes))
+		restart := ""
+		if server.NeedsRestart {
+			restart = " " + StyleError.Render("⟳ restart")
+		}
 
-		// Align columns
-		line := fmt.Sprintf("%s%-25s %-15s", prefix, nameStyle.Render(name), statusFormatted)
+		line := fmt.Sprintf("%s%s %s %s %s%s", prefix, name, status, players, mem, restart)
 		lines = append(lines, TrimToWidth(line, width))
 	}
 
 	return PadLines(lines, height)
+}
+
+// formatPlayers renders "online/max" (or "online", or "—" when unknown).
+func formatPlayers(online, max *int) string {
+	if online == nil {
+		return "—"
+	}
+	if max == nil {
+		return fmt.Sprintf("%d", *online)
+	}
+	return fmt.Sprintf("%d/%d", *online, *max)
+}
+
+// formatMemory renders a byte count as a compact MiB/GiB value ("—" when unknown).
+func formatMemory(b *int64) string {
+	if b == nil || *b <= 0 {
+		return "—"
+	}
+	mib := float64(*b) / (1024 * 1024)
+	if mib >= 1024 {
+		return fmt.Sprintf("%.1fG", mib/1024)
+	}
+	return fmt.Sprintf("%.0fM", mib)
 }
 
 // RenderMinecraftLogs renders Minecraft server logs for the selected server

--- a/tools/mineos-cli/internal/presentation/cli/tui/servers_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/servers_test.go
@@ -1,0 +1,38 @@
+package tui
+
+import "testing"
+
+func TestFormatPlayers(t *testing.T) {
+	i := func(n int) *int { return &n }
+	cases := []struct {
+		on, mx *int
+		want   string
+	}{
+		{nil, nil, "—"},
+		{i(3), i(20), "3/20"},
+		{i(5), nil, "5"},
+	}
+	for _, c := range cases {
+		if got := formatPlayers(c.on, c.mx); got != c.want {
+			t.Errorf("formatPlayers = %q, want %q", got, c.want)
+		}
+	}
+}
+
+func TestFormatMemory(t *testing.T) {
+	b := func(n int64) *int64 { return &n }
+	cases := []struct {
+		in   *int64
+		want string
+	}{
+		{nil, "—"},
+		{b(0), "—"},
+		{b(536870912), "512M"},
+		{b(2 * 1024 * 1024 * 1024), "2.0G"},
+	}
+	for _, c := range cases {
+		if got := formatMemory(c.in); got != c.want {
+			t.Errorf("formatMemory = %q, want %q", got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #127. Part of #119 (Tier 1).

Sources the server list from `/host/servers` (ServerSummaryDto) instead of `/servers/list`, so the table can show **players**, **memory**, and a **⟳ restart** indicator — data the API already returns. Status is derived from `Up` for backward compat with existing rendering + the `mineos servers list` command.

Tests: `ListServers` decode + status derivation (httptest); `formatPlayers`/`formatMemory`. Green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)