### PR TITLE
feat(cli): live per-server metrics panel (TPS/CPU/RAM/players) via SSE

### DIFF
--- a/tools/mineos-cli/internal/infrastructure/api/client.go
+++ b/tools/mineos-cli/internal/infrastructure/api/client.go
@@ -316,6 +316,93 @@ func (c *Client) StreamConsoleLogs(ctx context.Context, name, source string) (<-
 	return logs, errs
 }
 
+// PerfSample mirrors the API's PerformanceSampleDto (the fields the CLI shows).
+type PerfSample struct {
+	IsRunning   bool     `json:"isRunning"`
+	CpuPercent  float64  `json:"cpuPercent"`
+	RamUsedMb   int64    `json:"ramUsedMb"`
+	RamTotalMb  int64    `json:"ramTotalMb"`
+	Tps         *float64 `json:"tps"`
+	PlayerCount int      `json:"playerCount"`
+}
+
+// StreamPerformance opens the per-server performance SSE (2s cadence) and emits
+// each sample. Mirrors StreamConsoleLogs; cancel via ctx to stop.
+func (c *Client) StreamPerformance(ctx context.Context, name string) (<-chan PerfSample, <-chan error) {
+	samples := make(chan PerfSample)
+	errs := make(chan error, 1)
+
+	go func() {
+		defer close(samples)
+		defer close(errs)
+
+		if strings.TrimSpace(c.apiKey) == "" {
+			errs <- ErrApiKeyMissing
+			return
+		}
+		if strings.TrimSpace(name) == "" {
+			errs <- errors.New("server name is required")
+			return
+		}
+
+		endpoint := fmt.Sprintf("%s/servers/%s/performance/stream", c.apiBaseURL, url.PathEscape(strings.TrimSpace(name)))
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+		if err != nil {
+			errs <- err
+			return
+		}
+		req.Header.Set("X-Api-Key", c.apiKey)
+
+		streamClient := *c.httpClient
+		streamClient.Timeout = 0
+		resp, err := streamClient.Do(req)
+		if err != nil {
+			if ctx.Err() == nil {
+				errs <- err
+			}
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+			errs <- ErrApiKeyInvalid
+			return
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			errs <- fmt.Errorf("stream performance failed: %s", readBody(resp.Body))
+			return
+		}
+
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "data:") {
+				continue
+			}
+			payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			if payload == "" {
+				continue
+			}
+			var s PerfSample
+			if err := json.Unmarshal([]byte(payload), &s); err != nil {
+				continue
+			}
+			select {
+			case samples <- s:
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		if err := scanner.Err(); err != nil && ctx.Err() == nil {
+			errs <- err
+		}
+	}()
+
+	return samples, errs
+}
+
 func readBody(reader io.Reader) string {
 	if reader == nil {
 		return ""

--- a/tools/mineos-cli/internal/infrastructure/api/client_test.go
+++ b/tools/mineos-cli/internal/infrastructure/api/client_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -43,5 +44,36 @@ func TestListServers_DecodesRichFieldsAndDerivesStatus(t *testing.T) {
 func TestListServers_MissingKey(t *testing.T) {
 	if _, err := NewClient("http://example.invalid", "").ListServers(context.Background()); err != ErrApiKeyMissing {
 		t.Fatalf("want ErrApiKeyMissing, got %v", err)
+	}
+}
+
+func TestStreamPerformance_ParsesSSE(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `data: {"isRunning":true,"cpuPercent":12.5,"ramUsedMb":512,"ramTotalMb":1024,"tps":19.9,"playerCount":2}`+"\n\n")
+		_, _ = io.WriteString(w, `data: {"isRunning":true,"cpuPercent":30,"ramUsedMb":600,"ramTotalMb":1024,"tps":null,"playerCount":0}`+"\n\n")
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	samples, _ := NewClient(srv.URL, "k").StreamPerformance(ctx, "lobby")
+
+	first, ok := <-samples
+	if !ok {
+		t.Fatal("expected a first sample")
+	}
+	if !first.IsRunning || first.CpuPercent != 12.5 || first.RamUsedMb != 512 || first.PlayerCount != 2 {
+		t.Fatalf("bad first sample: %+v", first)
+	}
+	if first.Tps == nil || *first.Tps != 19.9 {
+		t.Fatal("tps not decoded on first sample")
+	}
+	second, ok := <-samples
+	if !ok {
+		t.Fatal("expected a second sample")
+	}
+	if second.Tps != nil {
+		t.Fatalf("expected nil tps on second sample, got %v", *second.Tps)
 	}
 }

--- a/tools/mineos-cli/internal/presentation/cli/tui/input.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/input.go
@@ -232,7 +232,7 @@ func (m TuiModel) navSelect() (tea.Model, tea.Cmd) {
 	if m.CurrentView == ViewServers && len(m.Servers) > 0 {
 		m.ServerActions = true
 		m.ActionIndex = 0
-		return m, nil
+		return m, m.StartPerfStreamCmd()
 	}
 
 	if m.NavIndex < 0 || m.NavIndex >= len(m.NavItems) {
@@ -248,6 +248,7 @@ func (m TuiModel) navSelect() (tea.Model, tea.Cmd) {
 		// Reset server actions mode when switching views
 		m.ServerActions = false
 		m.ActionIndex = 0
+		m.stopPerfStream()
 
 		// Switch log type based on view
 		var cmd tea.Cmd
@@ -311,6 +312,7 @@ func (m TuiModel) executeServerAction() (tea.Model, tea.Cmd) {
 	if action.Action == "back" {
 		m.ServerActions = false
 		m.ActionIndex = 0
+		m.stopPerfStream()
 		return m, nil
 	}
 
@@ -354,6 +356,7 @@ func (m TuiModel) navBack() (tea.Model, tea.Cmd) {
 	if m.CurrentView == ViewServers && m.ServerActions {
 		m.ServerActions = false
 		m.ActionIndex = 0
+		m.stopPerfStream()
 		return m, nil
 	}
 

--- a/tools/mineos-cli/internal/presentation/cli/tui/model.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/model.go
@@ -96,6 +96,14 @@ type TuiModel struct {
 	LogsChan        <-chan string
 	LogErrsChan     <-chan error
 	LogCancel       context.CancelFunc
+
+	// Live per-server performance stream (server-actions view)
+	PerfSample *api.PerfSample
+	PerfChan   <-chan api.PerfSample
+	PerfErrs   <-chan error
+	PerfCancel context.CancelFunc
+	PerfServer string
+
 	LogScroll       int    // Scroll offset for logs view
 	LogSearchQuery  string // Search query for logs
 	LogSearchMode   bool   // Whether in search mode
@@ -261,3 +269,17 @@ type HealthCheckedMsg struct {
 	Healthy bool
 	Err     error
 }
+
+// PerfStreamStartedMsg carries the channels for a freshly opened perf stream
+type PerfStreamStartedMsg struct {
+	Server  string
+	Samples <-chan api.PerfSample
+	Errs    <-chan error
+	Cancel  context.CancelFunc
+}
+
+// PerfSampleMsg carries one live performance sample
+type PerfSampleMsg struct{ Sample api.PerfSample }
+
+// PerfErrorMsg signals the perf stream errored or ended
+type PerfErrorMsg struct{ Err error }

--- a/tools/mineos-cli/internal/presentation/cli/tui/servers.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/servers.go
@@ -106,6 +106,26 @@ func formatMemory(b *int64) string {
 	return fmt.Sprintf("%.0fM", mib)
 }
 
+// renderMetricsLines renders the live per-server metrics panel (streamed via SSE).
+func (m TuiModel) renderMetricsLines() []string {
+	lines := []string{StyleHeader.Render(" LIVE METRICS ")}
+	p := m.PerfSample
+	if p == nil {
+		return append(lines, StyleSubtle.Render("  waiting for data…"), "")
+	}
+	tps := "—"
+	tpsStyle := StyleRunning
+	if p.Tps != nil {
+		tps = fmt.Sprintf("%.1f", *p.Tps)
+		if *p.Tps < 18 { // low-TPS highlight (matches the server-side alert threshold)
+			tpsStyle = StyleError
+		}
+	}
+	lines = append(lines, fmt.Sprintf("  TPS: %s   CPU: %.0f%%   RAM: %d/%d MB   Players: %d",
+		tpsStyle.Render(tps), p.CpuPercent, p.RamUsedMb, p.RamTotalMb, p.PlayerCount))
+	return append(lines, "")
+}
+
 // RenderMinecraftLogs renders Minecraft server logs for the selected server
 func (m TuiModel) RenderMinecraftLogs(width, height int) []string {
 	if height <= 0 {
@@ -176,6 +196,9 @@ func (m TuiModel) RenderServerActionsMain(width, height int) []string {
 		lines = append(lines, statusLine)
 		lines = append(lines, "")
 	}
+
+	// Live metrics panel (streamed via SSE while this view is open)
+	lines = append(lines, m.renderMetricsLines()...)
 
 	// Show actions
 	lines = append(lines, StyleHeader.Render(" ACTIONS "))

--- a/tools/mineos-cli/internal/presentation/cli/tui/servers_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/servers_test.go
@@ -1,6 +1,11 @@
 package tui
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/infrastructure/api"
+)
 
 func TestFormatPlayers(t *testing.T) {
 	i := func(n int) *int { return &n }
@@ -33,6 +38,24 @@ func TestFormatMemory(t *testing.T) {
 	for _, c := range cases {
 		if got := formatMemory(c.in); got != c.want {
 			t.Errorf("formatMemory = %q, want %q", got, c.want)
+		}
+	}
+}
+
+func TestRenderMetricsLines(t *testing.T) {
+	// No sample yet → a waiting line.
+	m := TuiModel{}
+	if got := strings.Join(m.renderMetricsLines(), "\n"); !strings.Contains(got, "waiting") {
+		t.Fatalf("expected a waiting line, got %q", got)
+	}
+
+	// With a sample → TPS/players are rendered.
+	tps := 19.9
+	m.PerfSample = &api.PerfSample{IsRunning: true, CpuPercent: 12, RamUsedMb: 512, RamTotalMb: 1024, Tps: &tps, PlayerCount: 3}
+	got := strings.Join(m.renderMetricsLines(), "\n")
+	for _, want := range []string{"TPS", "19.9", "Players: 3"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("metrics panel missing %q in %q", want, got)
 		}
 	}
 }

--- a/tools/mineos-cli/internal/presentation/cli/tui/update.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/update.go
@@ -201,6 +201,27 @@ func (m TuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Healthy = msg.Healthy
 		return m, nil
 
+	case PerfStreamStartedMsg:
+		if m.PerfCancel != nil {
+			m.PerfCancel()
+		}
+		m.PerfServer = msg.Server
+		m.PerfChan = msg.Samples
+		m.PerfErrs = msg.Errs
+		m.PerfCancel = msg.Cancel
+		m.PerfSample = nil
+		return m, m.ListenPerfCmd()
+
+	case PerfSampleMsg:
+		s := msg.Sample
+		m.PerfSample = &s
+		return m, m.ListenPerfCmd()
+
+	case PerfErrorMsg:
+		// Stream ended/errored — clear the panel; it restarts on re-entering the view.
+		m.PerfSample = nil
+		return m, nil
+
 	case SettingsToggledMsg:
 		if msg.Err != nil {
 			m.ErrMsg = "Failed to update setting: " + msg.Err.Error()
@@ -239,6 +260,55 @@ func (m TuiModel) HealthCheckCmd() tea.Cmd {
 		err := client.Health(ctx)
 		return HealthCheckedMsg{Healthy: err == nil, Err: err}
 	}
+}
+
+// StartPerfStreamCmd opens the performance SSE for the selected server.
+func (m TuiModel) StartPerfStreamCmd() tea.Cmd {
+	server := m.SelectedServer()
+	client := m.Client
+	if client == nil || server == "" {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithCancel(context.Background())
+		samples, errs := client.StreamPerformance(ctx, server)
+		return PerfStreamStartedMsg{Server: server, Samples: samples, Errs: errs, Cancel: cancel}
+	}
+}
+
+// ListenPerfCmd waits for the next perf sample or error and re-arms itself.
+func (m TuiModel) ListenPerfCmd() tea.Cmd {
+	samples := m.PerfChan
+	errs := m.PerfErrs
+	if samples == nil && errs == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		select {
+		case s, ok := <-samples:
+			if !ok {
+				return PerfErrorMsg{}
+			}
+			return PerfSampleMsg{Sample: s}
+		case e, ok := <-errs:
+			if !ok {
+				return PerfErrorMsg{}
+			}
+			return PerfErrorMsg{Err: e}
+		}
+	}
+}
+
+// stopPerfStream cancels any running perf stream and clears its state.
+func (m *TuiModel) stopPerfStream() {
+	if m.PerfCancel != nil {
+		m.PerfCancel()
+		m.PerfCancel = nil
+	}
+	m.PerfChan = nil
+	m.PerfErrs = nil
+	m.PerfSample = nil
+	m.PerfServer = ""
 }
 
 func (m TuiModel) handleConfigLoaded(msg ConfigLoadedMsg) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
Closes #128. Part of #119 (Tier 1 — the headline monitoring feature).

Adds a **live metrics panel** to the server-actions view (TPS / CPU / RAM / players), streamed from the API's `/servers/{name}/performance/stream` SSE (2s) — data the CLI previously ignored.

- `StreamPerformance` mirrors the existing console-log SSE reader.
- TUI wiring mirrors the log stream (start on enter, `stopPerfStream` on every exit → no goroutine leaks; `-race` clean).
- TPS turns **red below 18** (the server-side low-TPS alert threshold).

Tests: SSE parse (httptest) + render. Remaining Tier 1: #129 (alert roll-up), #130 (sparkline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)