### PR TITLE
feat(cli): health & alert roll-up from watchdog + notifications (#129)

### DIFF
--- a/tools/mineos-cli/internal/infrastructure/api/watchdog.go
+++ b/tools/mineos-cli/internal/infrastructure/api/watchdog.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// WatchdogServerStatus mirrors the API's ServerWatchdogStatus record.
+type WatchdogServerStatus struct {
+	ServerName         string     `json:"serverName"`
+	IsMonitoring       bool       `json:"isMonitoring"`
+	WasRunning         bool       `json:"wasRunning"`
+	RestartAttempts    int        `json:"restartAttempts"`
+	LastCrashTime      *time.Time `json:"lastCrashTime"`
+	LastManualStopTime *time.Time `json:"lastManualStopTime"`
+	LastRestartAttempt *time.Time `json:"lastRestartAttempt"`
+	CooldownEndsAt     *time.Time `json:"cooldownEndsAt"`
+}
+
+// CrashEvent mirrors the API's CrashEventDto.
+type CrashEvent struct {
+	Id                   int       `json:"id"`
+	ServerName           string    `json:"serverName"`
+	DetectedAt           time.Time `json:"detectedAt"`
+	CrashType            string    `json:"crashType"` // ProcessDeath, CrashReport, OutOfMemory, Timeout
+	CrashDetails         *string   `json:"crashDetails"`
+	AutoRestartAttempted bool      `json:"autoRestartAttempted"`
+	AutoRestartSucceeded bool      `json:"autoRestartSucceeded"`
+}
+
+// Notification mirrors the API's SystemNotification entity (the fields the CLI shows).
+type Notification struct {
+	Id         int       `json:"id"`
+	Type       string    `json:"type"` // info, warning, error, success
+	Title      string    `json:"title"`
+	Message    string    `json:"message"`
+	CreatedAt  time.Time `json:"createdAt"`
+	IsRead     bool      `json:"isRead"`
+	ServerName *string   `json:"serverName"`
+}
+
+// getJSON performs an authenticated GET and decodes the JSON response into out.
+func (c *Client) getJSON(ctx context.Context, rawURL string, out any) error {
+	if strings.TrimSpace(c.apiKey) == "" {
+		return ErrApiKeyMissing
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Api-Key", c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+		return ErrApiKeyInvalid
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("request failed: %s", readBody(resp.Body))
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// WatchdogStatus fetches the watchdog roll-up for all monitored servers.
+// The global watchdog group lives at /api/watchdog, outside /api/v1.
+func (c *Client) WatchdogStatus(ctx context.Context) (map[string]WatchdogServerStatus, error) {
+	var status map[string]WatchdogServerStatus
+	if err := c.getJSON(ctx, c.baseURL+"/api/watchdog/status", &status); err != nil {
+		return nil, err
+	}
+	return status, nil
+}
+
+// WatchdogCrashes fetches the most recent crash events across all servers.
+func (c *Client) WatchdogCrashes(ctx context.Context, limit int) ([]CrashEvent, error) {
+	url := fmt.Sprintf("%s/api/watchdog/crashes?limit=%d", c.baseURL, limit)
+	var events []CrashEvent
+	if err := c.getJSON(ctx, url, &events); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+// ActiveNotifications fetches non-dismissed notifications (newest first).
+func (c *Client) ActiveNotifications(ctx context.Context) ([]Notification, error) {
+	var notifications []Notification
+	if err := c.getJSON(ctx, c.apiBaseURL+"/notifications?includeDismissed=false", &notifications); err != nil {
+		return nil, err
+	}
+	return notifications, nil
+}

--- a/tools/mineos-cli/internal/infrastructure/api/watchdog_test.go
+++ b/tools/mineos-cli/internal/infrastructure/api/watchdog_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWatchdogStatus_DecodesMap(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/watchdog/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Api-Key") != "k" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"lobby": {"serverName":"lobby","isMonitoring":true,"wasRunning":true,"restartAttempts":2,
+				"lastCrashTime":"2026-07-22T01:00:00Z","cooldownEndsAt":"2026-07-22T01:05:00Z"}
+		}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	status, err := NewClient(srv.URL, "k").WatchdogStatus(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, ok := status["lobby"]
+	if !ok {
+		t.Fatal("lobby missing from status map")
+	}
+	if !s.IsMonitoring || s.RestartAttempts != 2 {
+		t.Fatalf("fields not decoded: %+v", s)
+	}
+	if s.LastCrashTime == nil || s.CooldownEndsAt == nil {
+		t.Fatal("timestamps not decoded")
+	}
+	if s.LastManualStopTime != nil {
+		t.Fatal("absent timestamp should stay nil")
+	}
+}
+
+func TestWatchdogCrashes_DecodesListAndPassesLimit(t *testing.T) {
+	var gotLimit string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/watchdog/crashes", func(w http.ResponseWriter, r *http.Request) {
+		gotLimit = r.URL.Query().Get("limit")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"id":1,"serverName":"survival","detectedAt":"2026-07-22T00:30:00Z","crashType":"OutOfMemory",
+				"crashDetails":"heap","autoRestartAttempted":true,"autoRestartSucceeded":false}
+		]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	events, err := NewClient(srv.URL, "k").WatchdogCrashes(context.Background(), 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotLimit != "7" {
+		t.Fatalf("limit not passed, got %q", gotLimit)
+	}
+	if len(events) != 1 || events[0].CrashType != "OutOfMemory" {
+		t.Fatalf("crash not decoded: %+v", events)
+	}
+	if !events[0].AutoRestartAttempted || events[0].AutoRestartSucceeded {
+		t.Fatal("restart flags not decoded")
+	}
+}
+
+func TestActiveNotifications_DecodesAndFilters(t *testing.T) {
+	var gotQuery string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/notifications", func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"id":5,"type":"warning","title":"Low TPS","message":"lobby at 12 tps",
+				"createdAt":"2026-07-22T00:45:00Z","isRead":false,"serverName":"lobby"}
+		]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	alerts, err := NewClient(srv.URL, "k").ActiveNotifications(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotQuery != "includeDismissed=false" {
+		t.Fatalf("dismissed filter not sent, got %q", gotQuery)
+	}
+	if len(alerts) != 1 || alerts[0].Title != "Low TPS" || alerts[0].IsRead {
+		t.Fatalf("alert not decoded: %+v", alerts)
+	}
+	if alerts[0].ServerName == nil || *alerts[0].ServerName != "lobby" {
+		t.Fatal("serverName not decoded")
+	}
+}
+
+func TestWatchdogStatus_AuthErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	if _, err := NewClient(srv.URL, "bad").WatchdogStatus(context.Background()); err != ErrApiKeyInvalid {
+		t.Fatalf("want ErrApiKeyInvalid, got %v", err)
+	}
+	if _, err := NewClient(srv.URL, "").WatchdogStatus(context.Background()); err != ErrApiKeyMissing {
+		t.Fatalf("want ErrApiKeyMissing, got %v", err)
+	}
+}

--- a/tools/mineos-cli/internal/presentation/cli/commands/health.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/health.go
@@ -2,6 +2,9 @@ package commands
 
 import (
 	"context"
+	"fmt"
+	"sort"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -10,9 +13,11 @@ import (
 )
 
 func NewHealthCommand(loadConfig *usecases.LoadConfigUseCase) *cobra.Command {
-	return &cobra.Command{
+	var all bool
+	cmd := &cobra.Command{
 		Use:   "health",
 		Short: "Check MineOS API health",
+		Long:  "Check MineOS API health. With --all, also show the watchdog roll-up, recent crashes, and active alerts.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			cfg, err := loadConfig.Execute(ctx)
@@ -25,7 +30,96 @@ func NewHealthCommand(loadConfig *usecases.LoadConfigUseCase) *cobra.Command {
 				return err
 			}
 			cmd.Println("OK")
-			return nil
+			if !all {
+				return nil
+			}
+			return printHealthRollup(ctx, cmd, client)
 		},
 	}
+	cmd.Flags().BoolVar(&all, "all", false, "include watchdog status, recent crashes, and active alerts")
+	return cmd
+}
+
+func printHealthRollup(ctx context.Context, cmd *cobra.Command, client *api.Client) error {
+	watchdog, err := client.WatchdogStatus(ctx)
+	if err != nil {
+		return fmt.Errorf("watchdog status: %w", err)
+	}
+	crashes, err := client.WatchdogCrashes(ctx, 10)
+	if err != nil {
+		return fmt.Errorf("crash history: %w", err)
+	}
+	alerts, err := client.ActiveNotifications(ctx)
+	if err != nil {
+		return fmt.Errorf("notifications: %w", err)
+	}
+
+	now := time.Now()
+
+	cmd.Println("\nWatchdog:")
+	if len(watchdog) == 0 {
+		cmd.Println("  (no servers monitored)")
+	}
+	names := make([]string, 0, len(watchdog))
+	for name := range watchdog {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		s := watchdog[name]
+		state := "idle"
+		if s.CooldownEndsAt != nil && s.CooldownEndsAt.After(now) {
+			state = "cooldown until " + s.CooldownEndsAt.Local().Format("15:04:05")
+		} else if s.IsMonitoring {
+			state = "monitoring"
+		}
+		line := fmt.Sprintf("  %-20s %s", name, state)
+		if s.RestartAttempts > 0 {
+			line += fmt.Sprintf("  restarts=%d", s.RestartAttempts)
+		}
+		if s.LastCrashTime != nil {
+			line += "  last-crash=" + s.LastCrashTime.Local().Format("2006-01-02 15:04")
+		}
+		cmd.Println(line)
+	}
+
+	cmd.Println("\nRecent crashes:")
+	if len(crashes) == 0 {
+		cmd.Println("  (none)")
+	}
+	for _, c := range crashes {
+		restart := "no auto-restart"
+		if c.AutoRestartAttempted {
+			if c.AutoRestartSucceeded {
+				restart = "auto-restart ok"
+			} else {
+				restart = "auto-restart FAILED"
+			}
+		}
+		cmd.Printf("  %s  %-20s %-13s %s\n",
+			c.DetectedAt.Local().Format("2006-01-02 15:04"), c.ServerName, c.CrashType, restart)
+	}
+
+	unread := 0
+	for _, a := range alerts {
+		if !a.IsRead {
+			unread++
+		}
+	}
+	cmd.Printf("\nAlerts (%d active, %d unread):\n", len(alerts), unread)
+	if len(alerts) == 0 {
+		cmd.Println("  (none)")
+	}
+	for _, a := range alerts {
+		scope := ""
+		if a.ServerName != nil && *a.ServerName != "" {
+			scope = " [" + *a.ServerName + "]"
+		}
+		marker := " "
+		if !a.IsRead {
+			marker = "*"
+		}
+		cmd.Printf("  %s %-8s %s%s — %s\n", marker, a.Type, a.Title, scope, a.Message)
+	}
+	return nil
 }

--- a/tools/mineos-cli/internal/presentation/cli/tui/health.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/health.go
@@ -1,0 +1,172 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// MaxHealthRows caps each health-view section so one busy section can't push
+// the others off-screen.
+const MaxHealthRows = 8
+
+func (m TuiModel) RenderHealthMain(width, height int) []string {
+	lines := make([]string, 0, height)
+	lines = append(lines, StyleHeader.Render(" HEALTH & ALERTS "))
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width)))
+
+	if !m.ConfigReady {
+		lines = append(lines, TrimToWidth(StyleSubtle.Render("  API not connected."), width))
+		return PadLines(lines, height)
+	}
+	if m.HealthDataErr != "" {
+		lines = append(lines, TrimToWidth(StyleError.Render("  Error: "+m.HealthDataErr), width))
+		return PadLines(lines, height)
+	}
+	if !m.HealthDataLoaded {
+		lines = append(lines, TrimToWidth(StyleSubtle.Render("  Loading health data..."), width))
+		return PadLines(lines, height)
+	}
+
+	now := time.Now()
+	lines = append(lines, "")
+	lines = append(lines, m.renderWatchdogSection(width, now)...)
+	lines = append(lines, "")
+	lines = append(lines, m.renderCrashesSection(width, now)...)
+	lines = append(lines, "")
+	lines = append(lines, m.renderAlertsSection(width, now)...)
+
+	return PadLines(lines, height)
+}
+
+func (m TuiModel) renderWatchdogSection(width int, now time.Time) []string {
+	lines := []string{StyleHeader.Render(" WATCHDOG ")}
+	if len(m.Watchdog) == 0 {
+		return append(lines, TrimToWidth(StyleSubtle.Render("  No servers monitored."), width))
+	}
+
+	names := make([]string, 0, len(m.Watchdog))
+	for name := range m.Watchdog {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for i, name := range names {
+		if i >= MaxHealthRows {
+			lines = append(lines, TrimToWidth(StyleSubtle.Render(fmt.Sprintf("  … %d more", len(names)-MaxHealthRows)), width))
+			break
+		}
+		s := m.Watchdog[name]
+		state := StyleSubtle.Render("idle")
+		if s.CooldownEndsAt != nil && s.CooldownEndsAt.After(now) {
+			state = StyleStopped.Render("cooldown " + formatDuration(s.CooldownEndsAt.Sub(now)))
+		} else if s.IsMonitoring {
+			state = StyleRunning.Render("monitoring")
+		}
+		detail := ""
+		if s.RestartAttempts > 0 {
+			detail += fmt.Sprintf("  restarts: %d", s.RestartAttempts)
+		}
+		if s.LastCrashTime != nil {
+			detail += "  last crash: " + timeAgo(*s.LastCrashTime, now)
+		}
+		line := fmt.Sprintf("  %-20s %s%s", name, state, StyleSubtle.Render(detail))
+		lines = append(lines, TrimToWidth(line, width))
+	}
+	return lines
+}
+
+func (m TuiModel) renderCrashesSection(width int, now time.Time) []string {
+	lines := []string{StyleHeader.Render(" RECENT CRASHES ")}
+	if len(m.Crashes) == 0 {
+		return append(lines, TrimToWidth(StyleSubtle.Render("  No crashes recorded."), width))
+	}
+	for i, c := range m.Crashes {
+		if i >= MaxHealthRows {
+			lines = append(lines, TrimToWidth(StyleSubtle.Render(fmt.Sprintf("  … %d more", len(m.Crashes)-MaxHealthRows)), width))
+			break
+		}
+		restart := StyleSubtle.Render("no auto-restart")
+		if c.AutoRestartAttempted {
+			if c.AutoRestartSucceeded {
+				restart = StyleRunning.Render("auto-restart ✓")
+			} else {
+				restart = StyleError.Render("auto-restart ✗")
+			}
+		}
+		line := fmt.Sprintf("  %-9s %-20s %-13s %s",
+			timeAgo(c.DetectedAt, now), c.ServerName, c.CrashType, restart)
+		lines = append(lines, TrimToWidth(line, width))
+	}
+	return lines
+}
+
+func (m TuiModel) renderAlertsSection(width int, now time.Time) []string {
+	unread := 0
+	for _, a := range m.Alerts {
+		if !a.IsRead {
+			unread++
+		}
+	}
+	title := fmt.Sprintf(" ALERTS (%d unread) ", unread)
+	lines := []string{StyleHeader.Render(title)}
+	if len(m.Alerts) == 0 {
+		return append(lines, TrimToWidth(StyleSubtle.Render("  No active alerts."), width))
+	}
+	for i, a := range m.Alerts {
+		if i >= MaxHealthRows {
+			lines = append(lines, TrimToWidth(StyleSubtle.Render(fmt.Sprintf("  … %d more", len(m.Alerts)-MaxHealthRows)), width))
+			break
+		}
+		badge := formatAlertType(a.Type)
+		scope := ""
+		if a.ServerName != nil && *a.ServerName != "" {
+			scope = " — " + *a.ServerName
+		}
+		marker := "  "
+		if !a.IsRead {
+			marker = StyleSelected.Render("• ")
+		}
+		line := fmt.Sprintf("  %s%s %s%s %s",
+			marker, badge, a.Title, scope, StyleSubtle.Render("("+timeAgo(a.CreatedAt, now)+")"))
+		lines = append(lines, TrimToWidth(line, width))
+	}
+	return lines
+}
+
+func formatAlertType(t string) string {
+	switch strings.ToLower(t) {
+	case "error":
+		return StyleError.Render("[error]")
+	case "warning":
+		return StyleStopped.Render("[warn] ")
+	case "success":
+		return StyleRunning.Render("[ok]   ")
+	default:
+		return StyleSubtle.Render("[info] ")
+	}
+}
+
+// timeAgo renders a compact relative timestamp ("5m ago", "2h ago").
+func timeAgo(t time.Time, now time.Time) string {
+	d := now.Sub(t)
+	if d < 0 {
+		d = 0
+	}
+	return formatDuration(d) + " ago"
+}
+
+// formatDuration renders a duration compactly at a single unit ("45s", "5m", "2h", "3d").
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}

--- a/tools/mineos-cli/internal/presentation/cli/tui/health_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/health_test.go
@@ -1,0 +1,107 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/infrastructure/api"
+)
+
+func TestUpdate_HealthDataMsgPopulatesModel(t *testing.T) {
+	m := TuiModel{}
+	msg := HealthDataMsg{
+		Watchdog: map[string]api.WatchdogServerStatus{"lobby": {ServerName: "lobby", IsMonitoring: true}},
+		Crashes:  []api.CrashEvent{{ServerName: "lobby", CrashType: "OutOfMemory"}},
+		Alerts:   []api.Notification{{Title: "Low TPS"}},
+	}
+	out, _ := m.Update(msg)
+	got := out.(TuiModel)
+	if !got.HealthDataLoaded {
+		t.Fatal("HealthDataLoaded should be true after a successful fetch")
+	}
+	if len(got.Watchdog) != 1 || len(got.Crashes) != 1 || len(got.Alerts) != 1 {
+		t.Fatalf("data not stored: %+v", got)
+	}
+}
+
+func TestUpdate_HealthDataMsgErrorKeepsOldData(t *testing.T) {
+	m := TuiModel{HealthDataLoaded: true, Crashes: []api.CrashEvent{{ServerName: "lobby"}}}
+	out, _ := m.Update(HealthDataMsg{Err: errFake})
+	got := out.(TuiModel)
+	if got.HealthDataErr == "" {
+		t.Fatal("error should be surfaced")
+	}
+	if len(got.Crashes) != 1 {
+		t.Fatal("previous data must survive a failed refresh")
+	}
+}
+
+func TestRenderHealthMain_States(t *testing.T) {
+	// Not connected
+	m := TuiModel{}
+	if !containsLine(m.RenderHealthMain(80, 20), "API not connected") {
+		t.Fatal("expected not-connected state")
+	}
+
+	// Connected but still loading
+	m.ConfigReady = true
+	if !containsLine(m.RenderHealthMain(80, 20), "Loading health data") {
+		t.Fatal("expected loading state")
+	}
+
+	// Loaded and empty
+	m.HealthDataLoaded = true
+	lines := m.RenderHealthMain(80, 30)
+	if !containsLine(lines, "No servers monitored") || !containsLine(lines, "No crashes recorded") || !containsLine(lines, "No active alerts") {
+		t.Fatalf("expected empty sections, got:\n%s", strings.Join(lines, "\n"))
+	}
+
+	// Populated
+	crashTime := time.Now().Add(-5 * time.Minute)
+	server := "survival"
+	m.Watchdog = map[string]api.WatchdogServerStatus{
+		"survival": {ServerName: "survival", IsMonitoring: true, RestartAttempts: 2, LastCrashTime: &crashTime},
+	}
+	m.Crashes = []api.CrashEvent{{ServerName: "survival", DetectedAt: crashTime, CrashType: "OutOfMemory", AutoRestartAttempted: true, AutoRestartSucceeded: true}}
+	m.Alerts = []api.Notification{{Type: "warning", Title: "Low TPS", CreatedAt: crashTime, ServerName: &server}}
+	lines = m.RenderHealthMain(80, 30)
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{"survival", "monitoring", "restarts: 2", "OutOfMemory", "Low TPS", "5m ago"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "30s"},
+		{5 * time.Minute, "5m"},
+		{3 * time.Hour, "3h"},
+		{48 * time.Hour, "2d"},
+	}
+	for _, c := range cases {
+		if got := formatDuration(c.d); got != c.want {
+			t.Fatalf("formatDuration(%v) = %q, want %q", c.d, got, c.want)
+		}
+	}
+}
+
+func containsLine(lines []string, substr string) bool {
+	for _, l := range lines {
+		if strings.Contains(l, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+var errFake = &fakeError{}
+
+type fakeError struct{}
+
+func (*fakeError) Error() string { return "boom" }

--- a/tools/mineos-cli/internal/presentation/cli/tui/input.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/input.go
@@ -263,6 +263,9 @@ func (m TuiModel) navSelect() (tea.Model, tea.Cmd) {
 			m.LogType = LogTypeDocker
 			m.Logs = nil
 			cmd = m.StartLogStreamCmd()
+		} else if item.View == ViewHealth {
+			// Fetch immediately; the health tick keeps it fresh afterwards.
+			cmd = m.LoadHealthDataCmd()
 		}
 		return m, cmd
 

--- a/tools/mineos-cli/internal/presentation/cli/tui/model.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/model.go
@@ -20,6 +20,7 @@ const (
 	ViewServiceLogs // Docker container logs
 	ViewSettings
 	ViewOutput // Shows command output
+	ViewHealth // Watchdog + alert roll-up
 )
 
 // TuiMode represents the input mode of the TUI
@@ -140,6 +141,13 @@ type TuiModel struct {
 	StreamingOutput  <-chan string
 	StreamingRunning bool
 	StreamingLabel   string
+
+	// Health & alert roll-up (health view; refreshed on the health tick)
+	Watchdog         map[string]api.WatchdogServerStatus
+	Crashes          []api.CrashEvent
+	Alerts           []api.Notification
+	HealthDataLoaded bool   // First fetch completed (distinguishes loading from empty)
+	HealthDataErr    string // Last fetch error, if any
 
 	// Retry state for error recovery
 	RetryCount int
@@ -268,6 +276,14 @@ type HealthTickMsg struct{}
 type HealthCheckedMsg struct {
 	Healthy bool
 	Err     error
+}
+
+// HealthDataMsg carries the watchdog/crash/alert roll-up for the health view
+type HealthDataMsg struct {
+	Watchdog map[string]api.WatchdogServerStatus
+	Crashes  []api.CrashEvent
+	Alerts   []api.Notification
+	Err      error
 }
 
 // PerfStreamStartedMsg carries the channels for a freshly opened perf stream

--- a/tools/mineos-cli/internal/presentation/cli/tui/nav.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/nav.go
@@ -9,6 +9,7 @@ func BuildNavItems() []NavItem {
 		{Label: "VIEWS", ItemType: NavHeader},
 		{Label: "Dashboard", ItemType: NavView, View: ViewDashboard},
 		{Label: "Minecraft Servers", ItemType: NavView, View: ViewServers},
+		{Label: "Health & Alerts", ItemType: NavView, View: ViewHealth},
 		{Label: "Service Logs", ItemType: NavView, View: ViewServiceLogs},
 		{Label: "Settings", ItemType: NavView, View: ViewSettings},
 

--- a/tools/mineos-cli/internal/presentation/cli/tui/update.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/update.go
@@ -190,6 +190,9 @@ func (m TuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.ConfigReady {
 			// Live refresh: real health probe + current server list.
 			cmds = append(cmds, m.HealthCheckCmd(), m.LoadServersCmd())
+			if m.CurrentView == ViewHealth {
+				cmds = append(cmds, m.LoadHealthDataCmd())
+			}
 		} else {
 			// API was unreachable — try to reconnect.
 			m.StatusMsg = "Reconnecting to API..."
@@ -199,6 +202,18 @@ func (m TuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case HealthCheckedMsg:
 		m.Healthy = msg.Healthy
+		return m, nil
+
+	case HealthDataMsg:
+		if msg.Err != nil {
+			m.HealthDataErr = msg.Err.Error()
+			return m, nil
+		}
+		m.Watchdog = msg.Watchdog
+		m.Crashes = msg.Crashes
+		m.Alerts = msg.Alerts
+		m.HealthDataLoaded = true
+		m.HealthDataErr = ""
 		return m, nil
 
 	case PerfStreamStartedMsg:
@@ -259,6 +274,33 @@ func (m TuiModel) HealthCheckCmd() tea.Cmd {
 	return func() tea.Msg {
 		err := client.Health(ctx)
 		return HealthCheckedMsg{Healthy: err == nil, Err: err}
+	}
+}
+
+// LoadHealthDataCmd fetches the watchdog/crash/alert roll-up in one shot.
+func (m TuiModel) LoadHealthDataCmd() tea.Cmd {
+	client := m.Client
+	if client == nil {
+		return nil
+	}
+	ctx := m.Ctx
+	return func() tea.Msg {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		watchdog, err := client.WatchdogStatus(ctx)
+		if err != nil {
+			return HealthDataMsg{Err: err}
+		}
+		crashes, err := client.WatchdogCrashes(ctx, MaxHealthRows*2)
+		if err != nil {
+			return HealthDataMsg{Err: err}
+		}
+		alerts, err := client.ActiveNotifications(ctx)
+		if err != nil {
+			return HealthDataMsg{Err: err}
+		}
+		return HealthDataMsg{Watchdog: watchdog, Crashes: crashes, Alerts: alerts}
 	}
 }
 

--- a/tools/mineos-cli/internal/presentation/cli/tui/view.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/view.go
@@ -52,6 +52,8 @@ func (m TuiModel) View() string {
 		rightLines = m.RenderServiceLogsMain(rightWidth, contentHeight)
 	case ViewSettings:
 		rightLines = m.RenderSettingsMain(rightWidth, contentHeight)
+	case ViewHealth:
+		rightLines = m.RenderHealthMain(rightWidth, contentHeight)
 	case ViewOutput:
 		rightLines = m.RenderOutputMain(rightWidth, contentHeight)
 	default:


### PR DESCRIPTION
## Summary
Implements #129 — wires the CLI to the monitoring the API already computes.

- **New \"Health & Alerts\" TUI view** (nav, under Minecraft Servers): per-server watchdog roll-up (monitoring/cooldown state, restart attempts, last crash), recent crashes with auto-restart outcome, and active alerts with unread markers. Fetched on entry, refreshed by the existing health tick while the view is open; failed refreshes keep the last good data and surface the error.
- **`mineos health --all`**: plain-text version of the same roll-up (plain `mineos health` output unchanged).
- **API client**: `WatchdogStatus`, `WatchdogCrashes(limit)`, `ActiveNotifications` + a shared authenticated-GET/JSON helper. Note the global watchdog group lives at `/api/watchdog`, outside `/api/v1`.

## Review stack
PR 1 of the #119 stack (`#129 → #130 → #131 → #132 → #134 → #135`). Merge this first; the next PR is based on this branch.

## Testing
`go build ./... && go vet ./... && go test ./...` green in golang:1.24 (client decode/auth tests, view state tests, Update transition tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)