### PR TITLE
feat(cli): in-terminal performance sparkline/history (#130)

### DIFF
--- a/tools/mineos-cli/internal/infrastructure/api/client.go
+++ b/tools/mineos-cli/internal/infrastructure/api/client.go
@@ -318,12 +318,28 @@ func (c *Client) StreamConsoleLogs(ctx context.Context, name, source string) (<-
 
 // PerfSample mirrors the API's PerformanceSampleDto (the fields the CLI shows).
 type PerfSample struct {
-	IsRunning   bool     `json:"isRunning"`
-	CpuPercent  float64  `json:"cpuPercent"`
-	RamUsedMb   int64    `json:"ramUsedMb"`
-	RamTotalMb  int64    `json:"ramTotalMb"`
-	Tps         *float64 `json:"tps"`
-	PlayerCount int      `json:"playerCount"`
+	Timestamp   time.Time `json:"timestamp"`
+	IsRunning   bool      `json:"isRunning"`
+	CpuPercent  float64   `json:"cpuPercent"`
+	RamUsedMb   int64     `json:"ramUsedMb"`
+	RamTotalMb  int64     `json:"ramTotalMb"`
+	Tps         *float64  `json:"tps"`
+	PlayerCount int       `json:"playerCount"`
+}
+
+// PerformanceHistory fetches DB-backed samples for the last N minutes
+// (the API clamps minutes to 5-1440). Oldest first.
+func (c *Client) PerformanceHistory(ctx context.Context, name string, minutes int) ([]PerfSample, error) {
+	if strings.TrimSpace(name) == "" {
+		return nil, errors.New("server name is required")
+	}
+	endpoint := fmt.Sprintf("%s/servers/%s/performance/history?minutes=%d",
+		c.apiBaseURL, url.PathEscape(strings.TrimSpace(name)), minutes)
+	var samples []PerfSample
+	if err := c.getJSON(ctx, endpoint, &samples); err != nil {
+		return nil, err
+	}
+	return samples, nil
 }
 
 // StreamPerformance opens the per-server performance SSE (2s cadence) and emits

--- a/tools/mineos-cli/internal/infrastructure/api/client_test.go
+++ b/tools/mineos-cli/internal/infrastructure/api/client_test.go
@@ -77,3 +77,41 @@ func TestStreamPerformance_ParsesSSE(t *testing.T) {
 		t.Fatalf("expected nil tps on second sample, got %v", *second.Tps)
 	}
 }
+
+func TestPerformanceHistory_DecodesAndPassesMinutes(t *testing.T) {
+	var gotMinutes string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/servers/lobby/performance/history", func(w http.ResponseWriter, r *http.Request) {
+		gotMinutes = r.URL.Query().Get("minutes")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"serverName":"lobby","timestamp":"2026-07-22T00:00:00Z","isRunning":true,"cpuPercent":10,"ramUsedMb":500,"ramTotalMb":1024,"tps":20.0,"playerCount":1},
+			{"serverName":"lobby","timestamp":"2026-07-22T00:01:00Z","isRunning":true,"cpuPercent":20,"ramUsedMb":510,"ramTotalMb":1024,"tps":null,"playerCount":1}
+		]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	samples, err := NewClient(srv.URL, "k").PerformanceHistory(context.Background(), "lobby", 30)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotMinutes != "30" {
+		t.Fatalf("minutes not passed, got %q", gotMinutes)
+	}
+	if len(samples) != 2 || samples[0].Tps == nil || *samples[0].Tps != 20.0 {
+		t.Fatalf("samples not decoded: %+v", samples)
+	}
+	if samples[0].Timestamp.IsZero() {
+		t.Fatal("timestamp not decoded")
+	}
+	if samples[1].Tps != nil {
+		t.Fatal("null tps must stay nil")
+	}
+}
+
+func TestPerformanceHistory_RequiresName(t *testing.T) {
+	if _, err := NewClient("http://example.invalid", "k").PerformanceHistory(context.Background(), " ", 30); err == nil {
+		t.Fatal("want error for empty server name")
+	}
+}

--- a/tools/mineos-cli/internal/presentation/cli/tui/constants.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/constants.go
@@ -64,6 +64,13 @@ const (
 	HealthPollInterval = 10 * time.Second // Re-check API when unhealthy
 )
 
+// Metrics sparkline constants
+const (
+	PerfHistoryMinutes    = 30  // Backfill window for the metrics panel
+	MaxPerfHistorySamples = 240 // Cap on retained samples (backfill + live)
+	SparklineWidth        = 30  // Characters per sparkline strip
+)
+
 // UI layout constants
 const (
 	SidebarWidth     = 20

--- a/tools/mineos-cli/internal/presentation/cli/tui/input.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/input.go
@@ -232,7 +232,7 @@ func (m TuiModel) navSelect() (tea.Model, tea.Cmd) {
 	if m.CurrentView == ViewServers && len(m.Servers) > 0 {
 		m.ServerActions = true
 		m.ActionIndex = 0
-		return m, m.StartPerfStreamCmd()
+		return m, tea.Batch(m.StartPerfStreamCmd(), m.LoadPerfHistoryCmd())
 	}
 
 	if m.NavIndex < 0 || m.NavIndex >= len(m.NavItems) {

--- a/tools/mineos-cli/internal/presentation/cli/tui/model.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/model.go
@@ -105,6 +105,10 @@ type TuiModel struct {
 	PerfCancel context.CancelFunc
 	PerfServer string
 
+	// Sample history backing the sparkline: history-endpoint backfill plus
+	// live samples appended as they stream in. Cleared with the stream.
+	PerfHistory []api.PerfSample
+
 	LogScroll       int    // Scroll offset for logs view
 	LogSearchQuery  string // Search query for logs
 	LogSearchMode   bool   // Whether in search mode
@@ -299,3 +303,10 @@ type PerfSampleMsg struct{ Sample api.PerfSample }
 
 // PerfErrorMsg signals the perf stream errored or ended
 type PerfErrorMsg struct{ Err error }
+
+// PerfHistoryMsg carries the history backfill for the metrics sparkline
+type PerfHistoryMsg struct {
+	Server  string
+	Samples []api.PerfSample
+	Err     error
+}

--- a/tools/mineos-cli/internal/presentation/cli/tui/servers.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/servers.go
@@ -123,7 +123,38 @@ func (m TuiModel) renderMetricsLines() []string {
 	}
 	lines = append(lines, fmt.Sprintf("  TPS: %s   CPU: %.0f%%   RAM: %d/%d MB   Players: %d",
 		tpsStyle.Render(tps), p.CpuPercent, p.RamUsedMb, p.RamTotalMb, p.PlayerCount))
+	lines = append(lines, m.renderSparklines()...)
 	return append(lines, "")
+}
+
+// renderSparklines renders TPS and CPU history strips from the sample buffer
+// (history-endpoint backfill + live samples).
+func (m TuiModel) renderSparklines() []string {
+	if len(m.PerfHistory) < 2 {
+		return nil
+	}
+	var tpsSeries, cpuSeries []float64
+	for _, s := range m.PerfHistory {
+		if s.Tps != nil {
+			tpsSeries = append(tpsSeries, *s.Tps)
+		}
+		cpuSeries = append(cpuSeries, s.CpuPercent)
+	}
+
+	var lines []string
+	if len(tpsSeries) >= 2 {
+		lo, avg, hi := SeriesStats(tpsSeries)
+		lines = append(lines, fmt.Sprintf("  TPS %s %s",
+			StyleStatus.Render(Sparkline(tpsSeries, SparklineWidth)),
+			StyleSubtle.Render(fmt.Sprintf("min %.1f  avg %.1f  max %.1f", lo, avg, hi))))
+	}
+	if len(cpuSeries) >= 2 {
+		lo, avg, hi := SeriesStats(cpuSeries)
+		lines = append(lines, fmt.Sprintf("  CPU %s %s",
+			StyleStatus.Render(Sparkline(cpuSeries, SparklineWidth)),
+			StyleSubtle.Render(fmt.Sprintf("min %.0f%%  avg %.0f%%  max %.0f%%  (last %dm)", lo, avg, hi, PerfHistoryMinutes))))
+	}
+	return lines
 }
 
 // RenderMinecraftLogs renders Minecraft server logs for the selected server

--- a/tools/mineos-cli/internal/presentation/cli/tui/sparkline.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/sparkline.go
@@ -1,0 +1,76 @@
+package tui
+
+// Sparkline rendering for the metrics panel: scales a numeric series into
+// unicode block characters, downsampling to fit the requested width.
+
+var sparkLevels = []rune("▁▂▃▄▅▆▇█")
+
+// Sparkline renders values as a fixed-width block-character strip. The series
+// is bucket-averaged down to width points and scaled min→max; a flat series
+// renders at mid height. Returns "" for an empty series or width <= 0.
+func Sparkline(values []float64, width int) string {
+	if len(values) == 0 || width <= 0 {
+		return ""
+	}
+	points := downsample(values, width)
+
+	lo, hi := points[0], points[0]
+	for _, v := range points {
+		if v < lo {
+			lo = v
+		}
+		if v > hi {
+			hi = v
+		}
+	}
+
+	out := make([]rune, len(points))
+	for i, v := range points {
+		level := len(sparkLevels) / 2
+		if hi > lo {
+			level = int((v - lo) / (hi - lo) * float64(len(sparkLevels)-1))
+		}
+		out[i] = sparkLevels[level]
+	}
+	return string(out)
+}
+
+// downsample bucket-averages values into at most width points.
+func downsample(values []float64, width int) []float64 {
+	if len(values) <= width {
+		return values
+	}
+	out := make([]float64, width)
+	for i := 0; i < width; i++ {
+		start := i * len(values) / width
+		end := (i + 1) * len(values) / width
+		if end <= start {
+			end = start + 1
+		}
+		sum := 0.0
+		for _, v := range values[start:end] {
+			sum += v
+		}
+		out[i] = sum / float64(end-start)
+	}
+	return out
+}
+
+// SeriesStats returns min/avg/max of a series (zeros for an empty one).
+func SeriesStats(values []float64) (min, avg, max float64) {
+	if len(values) == 0 {
+		return 0, 0, 0
+	}
+	min, max = values[0], values[0]
+	sum := 0.0
+	for _, v := range values {
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+		sum += v
+	}
+	return min, sum / float64(len(values)), max
+}

--- a/tools/mineos-cli/internal/presentation/cli/tui/sparkline_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/sparkline_test.go
@@ -1,0 +1,111 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/domain/ports"
+	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/infrastructure/api"
+)
+
+func TestSparkline_ScalesMinToMax(t *testing.T) {
+	got := Sparkline([]float64{0, 50, 100}, 3)
+	runes := []rune(got)
+	if len(runes) != 3 {
+		t.Fatalf("want 3 runes, got %d (%q)", len(runes), got)
+	}
+	if runes[0] != '▁' || runes[2] != '█' {
+		t.Fatalf("min/max not at extremes: %q", got)
+	}
+}
+
+func TestSparkline_FlatSeriesRendersMidLevel(t *testing.T) {
+	got := Sparkline([]float64{20, 20, 20}, 3)
+	if strings.ContainsAny(got, "▁█") {
+		t.Fatalf("flat series must not render extremes: %q", got)
+	}
+}
+
+func TestSparkline_DownsamplesToWidth(t *testing.T) {
+	values := make([]float64, 100)
+	for i := range values {
+		values[i] = float64(i)
+	}
+	got := Sparkline(values, 10)
+	if len([]rune(got)) != 10 {
+		t.Fatalf("want 10 runes, got %d", len([]rune(got)))
+	}
+}
+
+func TestSparkline_EmptyAndZeroWidth(t *testing.T) {
+	if Sparkline(nil, 10) != "" || Sparkline([]float64{1}, 0) != "" {
+		t.Fatal("empty series or zero width must render empty")
+	}
+}
+
+func TestSeriesStats(t *testing.T) {
+	lo, avg, hi := SeriesStats([]float64{10, 20, 30})
+	if lo != 10 || avg != 20 || hi != 30 {
+		t.Fatalf("got %v %v %v", lo, avg, hi)
+	}
+	lo, avg, hi = SeriesStats(nil)
+	if lo != 0 || avg != 0 || hi != 0 {
+		t.Fatal("empty series must yield zeros")
+	}
+}
+
+func TestUpdate_PerfHistoryBackfillsAndGuardsServer(t *testing.T) {
+	tps := 19.5
+	m := TuiModel{
+		Servers:  serverList("lobby"),
+		Selected: 0,
+	}
+	// Live sample arrived first
+	out, _ := m.Update(PerfSampleMsg{Sample: api.PerfSample{CpuPercent: 50}})
+	m = out.(TuiModel)
+
+	// Backfill for the selected server goes in front of live samples
+	out, _ = m.Update(PerfHistoryMsg{Server: "lobby", Samples: []api.PerfSample{{CpuPercent: 10, Tps: &tps}}})
+	m = out.(TuiModel)
+	if len(m.PerfHistory) != 2 || m.PerfHistory[0].CpuPercent != 10 {
+		t.Fatalf("history not prepended: %+v", m.PerfHistory)
+	}
+
+	// Backfill for a stale selection is ignored
+	out, _ = m.Update(PerfHistoryMsg{Server: "other", Samples: []api.PerfSample{{CpuPercent: 99}}})
+	m = out.(TuiModel)
+	if len(m.PerfHistory) != 2 {
+		t.Fatal("stale-server backfill must be ignored")
+	}
+}
+
+func TestAppendCapped_DropsOldest(t *testing.T) {
+	var history []api.PerfSample
+	for i := 0; i < 5; i++ {
+		history = appendCapped(history, api.PerfSample{CpuPercent: float64(i)}, 3)
+	}
+	if len(history) != 3 || history[0].CpuPercent != 2 {
+		t.Fatalf("cap not enforced: %+v", history)
+	}
+}
+
+func TestRenderSparklines_NeedsTwoSamples(t *testing.T) {
+	m := TuiModel{PerfHistory: []api.PerfSample{{CpuPercent: 10}}}
+	if lines := m.renderSparklines(); lines != nil {
+		t.Fatal("one sample must not render a sparkline")
+	}
+	m.PerfHistory = append(m.PerfHistory, api.PerfSample{CpuPercent: 90})
+	lines := m.renderSparklines()
+	if len(lines) != 1 || !strings.Contains(lines[0], "CPU") {
+		t.Fatalf("expected a CPU strip, got %v", lines)
+	}
+}
+
+// serverList builds a minimal server slice for selection tests.
+func serverList(names ...string) []ports.Server {
+	servers := make([]ports.Server, len(names))
+	for i, n := range names {
+		servers[i] = ports.Server{Name: n}
+	}
+	return servers
+}

--- a/tools/mineos-cli/internal/presentation/cli/tui/update.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/update.go
@@ -230,11 +230,25 @@ func (m TuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case PerfSampleMsg:
 		s := msg.Sample
 		m.PerfSample = &s
+		m.PerfHistory = appendCapped(m.PerfHistory, s, MaxPerfHistorySamples)
 		return m, m.ListenPerfCmd()
 
 	case PerfErrorMsg:
 		// Stream ended/errored — clear the panel; it restarts on re-entering the view.
 		m.PerfSample = nil
+		return m, nil
+
+	case PerfHistoryMsg:
+		// Backfill arriving for a stale selection (or failing) is just skipped —
+		// the panel falls back to live samples only.
+		if msg.Err != nil || msg.Server != m.SelectedServer() {
+			return m, nil
+		}
+		// History (older) goes in front of any live samples already collected.
+		m.PerfHistory = append(msg.Samples, m.PerfHistory...)
+		if len(m.PerfHistory) > MaxPerfHistorySamples {
+			m.PerfHistory = m.PerfHistory[len(m.PerfHistory)-MaxPerfHistorySamples:]
+		}
 		return m, nil
 
 	case SettingsToggledMsg:
@@ -351,6 +365,33 @@ func (m *TuiModel) stopPerfStream() {
 	m.PerfErrs = nil
 	m.PerfSample = nil
 	m.PerfServer = ""
+	m.PerfHistory = nil
+}
+
+// LoadPerfHistoryCmd fetches the history backfill for the metrics sparkline.
+func (m TuiModel) LoadPerfHistoryCmd() tea.Cmd {
+	server := m.SelectedServer()
+	client := m.Client
+	if client == nil || server == "" {
+		return nil
+	}
+	ctx := m.Ctx
+	return func() tea.Msg {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		samples, err := client.PerformanceHistory(ctx, server, PerfHistoryMinutes)
+		return PerfHistoryMsg{Server: server, Samples: samples, Err: err}
+	}
+}
+
+// appendCapped appends item keeping at most cap entries (drops the oldest).
+func appendCapped(history []api.PerfSample, s api.PerfSample, capacity int) []api.PerfSample {
+	history = append(history, s)
+	if len(history) > capacity {
+		history = history[len(history)-capacity:]
+	}
+	return history
 }
 
 func (m TuiModel) handleConfigLoaded(msg ConfigLoadedMsg) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
## Summary
Implements #130 — the metrics panel no longer starts from zero.

- **API client**: `PerformanceHistory(name, minutes)` against the DB-backed history endpoint; `PerfSample` gains its `timestamp`.
- **Metrics panel**: on opening server actions, a 30-minute backfill is fetched alongside the live SSE; TPS and CPU render as 30-char sparklines with min/avg/max. Live samples append to the buffer (capped at 240). Stale-selection or failed backfills are dropped — the panel degrades to live-only.
- Pure `Sparkline`/`downsample`/`SeriesStats` helpers with unit tests.

## Review stack
PR 2 of the #119 stack — **based on `feat/cli-health-rollup` (#144)**; merge that first and this PR retargets automatically.

## Testing
`go build ./... && go vet ./... && go test ./...` green in golang:1.24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)