### PR TITLE
feat(cli): log-stream retry backoff + batched line delivery (#131)

### DIFF
--- a/tools/mineos-cli/internal/presentation/cli/tui/constants.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/constants.go
@@ -51,6 +51,7 @@ const (
 	DefaultDockerLogTail = 200
 	LogRetryDelay        = 2 * time.Second
 	MaxLogRetries        = 3
+	MaxLogBatchLines     = 500 // Lines drained into one LogLinesMsg per render
 )
 
 // Streaming constants

--- a/tools/mineos-cli/internal/presentation/cli/tui/logs_retry_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/logs_retry_test.go
@@ -1,0 +1,101 @@
+package tui
+
+import (
+	"testing"
+)
+
+func TestListenLogs_BatchesBufferedLines(t *testing.T) {
+	logs := make(chan string, 10)
+	errs := make(chan error, 1)
+	for _, l := range []string{"a", "b", "c"} {
+		logs <- l
+	}
+	m := TuiModel{LogsChan: logs, LogErrsChan: errs}
+
+	msg := m.ListenLogsCmd()()
+	batch, ok := msg.(LogLinesMsg)
+	if !ok {
+		t.Fatalf("want LogLinesMsg, got %T", msg)
+	}
+	if len(batch.Lines) != 3 || batch.Lines[0] != "a" || batch.Lines[2] != "c" {
+		t.Fatalf("burst not drained in order: %v", batch.Lines)
+	}
+}
+
+func TestListenLogs_ClosedChannelSignalsClose(t *testing.T) {
+	logs := make(chan string)
+	errs := make(chan error, 1)
+	close(logs)
+	m := TuiModel{LogsChan: logs, LogErrsChan: errs}
+
+	if _, ok := m.ListenLogsCmd()().(LogStreamClosedMsg); !ok {
+		t.Fatal("closed channel must yield LogStreamClosedMsg")
+	}
+}
+
+func TestListenLogs_CloseDuringDrainDeliversCollectedLines(t *testing.T) {
+	logs := make(chan string, 2)
+	errs := make(chan error, 1)
+	logs <- "last"
+	close(logs)
+	m := TuiModel{LogsChan: logs, LogErrsChan: errs}
+
+	msg := m.ListenLogsCmd()()
+	batch, ok := msg.(LogLinesMsg)
+	if !ok {
+		t.Fatalf("want LogLinesMsg, got %T", msg)
+	}
+	if len(batch.Lines) != 1 || batch.Lines[0] != "last" {
+		t.Fatalf("lines lost on close: %v", batch.Lines)
+	}
+	// The re-armed listener then observes the close.
+	m.LogsChan = logs
+	if _, ok := m.ListenLogsCmd()().(LogStreamClosedMsg); !ok {
+		t.Fatal("re-armed listener must observe the close")
+	}
+}
+
+func TestUpdate_CleanCloseRetriesWithDelayAndCap(t *testing.T) {
+	m := TuiModel{LogsActive: true}
+
+	// First MaxLogRetries closes schedule a delayed retry.
+	for i := 0; i < MaxLogRetries; i++ {
+		out, cmd := m.Update(LogStreamClosedMsg{})
+		m = out.(TuiModel)
+		if cmd == nil {
+			t.Fatalf("close %d: expected a scheduled retry", i+1)
+		}
+	}
+	if m.LogRetries != MaxLogRetries {
+		t.Fatalf("retry counter wrong: %d", m.LogRetries)
+	}
+
+	// The next close gives up.
+	out, cmd := m.Update(LogStreamClosedMsg{})
+	m = out.(TuiModel)
+	if cmd != nil {
+		t.Fatal("retries exhausted: no further retry expected")
+	}
+
+	// Receiving lines resets the counter.
+	out, _ = m.Update(LogLinesMsg{Lines: []string{"x"}})
+	m = out.(TuiModel)
+	if m.LogRetries != 0 {
+		t.Fatal("data receipt must reset the retry counter")
+	}
+	if len(m.Logs) != 1 {
+		t.Fatal("batched lines must be appended")
+	}
+}
+
+func TestUpdate_CleanCloseDoesNotRetryWhenStopped(t *testing.T) {
+	for _, m := range []TuiModel{
+		{LogsActive: true, ContainersStopped: true},
+		{LogsActive: false},
+		{LogsActive: true, Quitting: true},
+	} {
+		if _, cmd := m.Update(LogStreamClosedMsg{}); cmd != nil {
+			t.Fatalf("no retry expected for %+v", m)
+		}
+	}
+}

--- a/tools/mineos-cli/internal/presentation/cli/tui/model.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/model.go
@@ -109,9 +109,10 @@ type TuiModel struct {
 	// live samples appended as they stream in. Cleared with the stream.
 	PerfHistory []api.PerfSample
 
-	LogScroll       int    // Scroll offset for logs view
-	LogSearchQuery  string // Search query for logs
-	LogSearchMode   bool   // Whether in search mode
+	LogScroll      int    // Scroll offset for logs view
+	LogSearchQuery string // Search query for logs
+	LogSearchMode  bool   // Whether in search mode
+	LogRetries     int    // Consecutive clean-close reconnects without data (resets on receipt)
 
 	StatusMsg string
 	ErrMsg    string
@@ -206,10 +207,14 @@ type LogStreamStartedMsg struct {
 	LogSource string
 }
 
-// LogLineMsg is sent for each log line received
-type LogLineMsg struct {
-	Line string
+// LogLinesMsg carries a batch of log lines — all lines available on the
+// channel are drained into one message so a startup burst costs one render.
+type LogLinesMsg struct {
+	Lines []string
 }
+
+// LogStreamClosedMsg signals the log channel closed cleanly (EOF, not error)
+type LogStreamClosedMsg struct{}
 
 // LogErrorMsg is sent when a log streaming error occurs
 type LogErrorMsg struct {

--- a/tools/mineos-cli/internal/presentation/cli/tui/update.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/update.go
@@ -107,13 +107,21 @@ func (m TuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case LogStreamStartedMsg:
 		return m.handleLogStreamStarted(msg)
 
-	case LogLineMsg:
-		m.AppendLog(msg.Line)
+	case LogLinesMsg:
+		for _, line := range msg.Lines {
+			m.AppendLog(line)
+		}
+		m.LogRetries = 0 // Receiving data proves the stream works
 		// Clear log-related errors on successful log receipt
 		if strings.Contains(m.ErrMsg, "log stream") || strings.Contains(m.ErrMsg, "stream") {
 			m.ErrMsg = ""
 		}
 		return m, m.ListenLogsCmd()
+
+	case LogStreamClosedMsg:
+		// Clean close — reconnect with the same backoff and retry cap as the
+		// error path so a dead source can't spin a tight reconnect loop.
+		return m.scheduleLogRetry(LogRetryDelay)
 
 	case LogErrorMsg:
 		if msg.Err != nil {
@@ -689,7 +697,8 @@ func (m TuiModel) StartLogStreamCmd() tea.Cmd {
 	}
 }
 
-// ListenLogsCmd creates a command to listen for log messages
+// ListenLogsCmd waits for log output, then drains everything already buffered
+// on the channel into a single batch so one burst costs one re-render.
 func (m TuiModel) ListenLogsCmd() tea.Cmd {
 	logsChan := m.LogsChan
 	errsChan := m.LogErrsChan
@@ -702,18 +711,46 @@ func (m TuiModel) ListenLogsCmd() tea.Cmd {
 		select {
 		case line, ok := <-logsChan:
 			if !ok {
-				// Channel closed cleanly - trigger silent retry
-				return LogRetryMsg{}
+				return LogStreamClosedMsg{}
 			}
-			return LogLineMsg{Line: line}
+			lines := []string{line}
+			for len(lines) < MaxLogBatchLines {
+				select {
+				case next, ok := <-logsChan:
+					if !ok {
+						// Deliver what we have; the re-armed listener sees the
+						// close and triggers the retry path.
+						return LogLinesMsg{Lines: lines}
+					}
+					lines = append(lines, next)
+				default:
+					return LogLinesMsg{Lines: lines}
+				}
+			}
+			return LogLinesMsg{Lines: lines}
 		case err, ok := <-errsChan:
 			if !ok {
-				// Channel closed cleanly - trigger silent retry
-				return LogRetryMsg{}
+				return LogStreamClosedMsg{}
 			}
 			return LogErrorMsg{Err: err}
 		}
 	}
+}
+
+// scheduleLogRetry re-arms the log stream after a delay, giving up after
+// MaxLogRetries consecutive reconnects that produced no data. Receiving any
+// lines resets the counter; switching views/sources restarts the stream.
+func (m TuiModel) scheduleLogRetry(delay time.Duration) (tea.Model, tea.Cmd) {
+	if m.ContainersStopped || !m.LogsActive || m.Quitting {
+		return m, nil
+	}
+	if m.LogRetries >= MaxLogRetries {
+		return m, nil
+	}
+	m.LogRetries++
+	return m, tea.Tick(delay, func(time.Time) tea.Msg {
+		return LogRetryMsg{}
+	})
 }
 
 // NormalizeComposeServices normalizes the list of compose services


### PR DESCRIPTION
## Summary
Implements #131.

- **Batched delivery**: `ListenLogsCmd` blocks for the first line, then non-blockingly drains up to 500 buffered lines into a single `LogLinesMsg` — a startup burst now triggers one re-render, not one per line. `LogLineMsg` is replaced by the batch message.
- **Clean-close backoff**: a cleanly closed channel now emits `LogStreamClosedMsg` and reconnects via `tea.Tick(LogRetryDelay)` with a `MaxLogRetries` cap on consecutive data-less reconnects (the previously unused constants now do their job). Receiving any lines resets the counter; switching views/sources restarts the stream as before. Error-path behavior (delayed, uncapped while the API is down) is unchanged.

## Review stack
PR 3 of the #119 stack — based on `feat/cli-perf-sparkline` (#145).

## Testing
`go build ./... && go vet ./... && go test ./...` green in golang:1.24 — includes batching-order, close-during-drain, retry-cap/reset, and no-retry-when-stopped tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)