### PR TITLE
feat(cli): TUI UX polish — states, spinner, status TTL, help overlay, typed fields (#132)

### DIFF
--- a/tools/mineos-cli/internal/presentation/cli/tui/actions.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/actions.go
@@ -49,7 +49,7 @@ func (m TuiModel) ExecMenuItem(item MenuItem) tea.Cmd {
 
 	// Streaming commands show output in real-time (for long-running docker operations)
 	if item.Streaming {
-		return m.StartStreamingCmd(exe, args, item.Label)
+		return m.StartStreamingCmd(exe, args, item.Label, item.Effect)
 	}
 
 	// Non-interactive commands capture output for display in TUI
@@ -69,16 +69,18 @@ func (m TuiModel) ExecMenuItem(item MenuItem) tea.Cmd {
 }
 
 // StartStreamingCmd starts a command that streams output without requiring stdin
-func (m TuiModel) StartStreamingCmd(exe string, args []string, label string) tea.Cmd {
+func (m TuiModel) StartStreamingCmd(exe string, args []string, label string, effect ContainerEffect) tea.Cmd {
 	return func() tea.Msg {
 		cmd := exec.Command(exe, args...)
 
 		// Use combined output (stdout + stderr together)
 		stdoutPipe, err := cmd.StdoutPipe()
 		if err != nil {
+			// The command never ran, so its container effect must not apply.
 			return StreamingStartedMsg{
 				Output: makeErrorChan("Failed to create pipe: " + err.Error()),
 				Label:  label,
+				Effect: EffectNone,
 			}
 		}
 
@@ -90,6 +92,7 @@ func (m TuiModel) StartStreamingCmd(exe string, args []string, label string) tea
 			return StreamingStartedMsg{
 				Output: makeErrorChan("Failed to start: " + err.Error()),
 				Label:  label,
+				Effect: EffectNone,
 			}
 		}
 
@@ -134,6 +137,7 @@ func (m TuiModel) StartStreamingCmd(exe string, args []string, label string) tea
 		return StreamingStartedMsg{
 			Output: outputChan,
 			Label:  label,
+			Effect: effect,
 		}
 	}
 }

--- a/tools/mineos-cli/internal/presentation/cli/tui/dashboard.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/dashboard.go
@@ -25,7 +25,7 @@ func (m TuiModel) RenderDashboardMain(width, height int) []string {
 	} else if m.Healthy {
 		health = StyleRunning.Render("connected")
 	} else if !m.ConfigReady && m.ErrMsg == "" {
-		health = StyleSubtle.Render("loading...")
+		health = m.Spinner.View() + StyleSubtle.Render(" connecting...")
 	} else {
 		health = StyleError.Render("not connected")
 	}

--- a/tools/mineos-cli/internal/presentation/cli/tui/help.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/help.go
@@ -1,0 +1,66 @@
+package tui
+
+import "strings"
+
+// helpEntry is one key/description row in the help overlay.
+type helpEntry struct {
+	Keys string
+	Desc string
+}
+
+// helpSections lists every TUI keybinding, grouped for the overlay.
+func helpSections() []struct {
+	Title   string
+	Entries []helpEntry
+} {
+	return []struct {
+		Title   string
+		Entries []helpEntry
+	}{
+		{"Navigation", []helpEntry{
+			{"↑/↓, j/k", "Move selection / scroll logs"},
+			{"←/→, h/l", "Switch log source (Service Logs)"},
+			{"Enter", "Select / open server actions"},
+			{"Esc", "Back / close"},
+			{"PgUp/PgDn", "Page through logs"},
+			{"g / G", "Jump to top / bottom of logs"},
+		}},
+		{"Logs", []helpEntry{
+			{"/", "Search logs (Service Logs)"},
+			{"n / N", "Next / previous match"},
+		}},
+		{"Other", []helpEntry{
+			{"p", "Toggle pre-release channel (Settings)"},
+			{"?", "Toggle this help"},
+			{"q, Ctrl+C", "Quit"},
+		}},
+	}
+}
+
+// RenderHelpOverlay renders the keybinding reference as a full-pane overlay.
+func (m TuiModel) RenderHelpOverlay(width, height int) []string {
+	lines := make([]string, 0, height)
+	lines = append(lines, StyleHeader.Render(" KEYBINDINGS "))
+	lines = append(lines, StyleSubtle.Render(strings.Repeat("─", width)))
+
+	for _, section := range helpSections() {
+		lines = append(lines, "")
+		lines = append(lines, StyleHeader.Render(" "+section.Title+" "))
+		for _, e := range section.Entries {
+			lines = append(lines, TrimToWidth("  "+StyleStatus.Render(padKey(e.Keys))+" "+e.Desc, width))
+		}
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, StyleSubtle.Render("  Press ? or Esc to close."))
+	return PadLines(lines, height)
+}
+
+// padKey left-aligns key labels into a fixed column.
+func padKey(keys string) string {
+	const col = 12
+	if len(keys) >= col {
+		return keys
+	}
+	return keys + strings.Repeat(" ", col-len(keys))
+}

--- a/tools/mineos-cli/internal/presentation/cli/tui/input.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/input.go
@@ -9,6 +9,22 @@ import (
 
 // HandleKey processes key input in normal mode
 func (m TuiModel) HandleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// While the help overlay is open, any key closes it (except quit keys).
+	if m.ShowHelp {
+		switch msg.String() {
+		case "ctrl+c", "q":
+			m.Quitting = true
+			m.StopLogs()
+			return m, tea.Quit
+		}
+		m.ShowHelp = false
+		return m, nil
+	}
+	if msg.String() == "?" {
+		m.ShowHelp = true
+		return m, nil
+	}
+
 	switch msg.Type {
 	case tea.KeyCtrlC:
 		m.Quitting = true
@@ -275,7 +291,7 @@ func (m TuiModel) navSelect() (tea.Model, tea.Cmd) {
 		}
 
 		// Handle special actions
-		if item.Action.Args[0] == "console" {
+		if item.Action.Console {
 			if m.SelectedServer() == "" {
 				m.ErrMsg = "Select a server first (go to Servers view)"
 				return m, nil

--- a/tools/mineos-cli/internal/presentation/cli/tui/model.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/application/usecases"
 	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/domain/config"
@@ -146,6 +147,21 @@ type TuiModel struct {
 	StreamingOutput  <-chan string
 	StreamingRunning bool
 	StreamingLabel   string
+	StreamingEffect  ContainerEffect
+
+	// Spinner shown while work is in flight (connecting, streaming, interactive)
+	Spinner spinner.Model
+
+	// Help overlay visibility (toggled with '?')
+	ShowHelp bool
+
+	// ServersLoadedOnce distinguishes "still loading" from "genuinely empty"
+	ServersLoadedOnce bool
+
+	// Last status/error seen by the TTL sweep: a message that survives one full
+	// poll interval unchanged is cleared (persistent conditions re-set theirs).
+	StatusSeenAtTick string
+	ErrSeenAtTick    string
 
 	// Health & alert roll-up (health view; refreshed on the health tick)
 	Watchdog         map[string]api.WatchdogServerStatus
@@ -161,13 +177,25 @@ type TuiModel struct {
 	ContainersStopped bool // True when user intentionally stopped containers
 }
 
+// ContainerEffect declares how a finished command changed container state,
+// replacing label-substring inference.
+type ContainerEffect int
+
+const (
+	EffectNone ContainerEffect = iota
+	EffectStartsContainers
+	EffectStopsContainers
+)
+
 // MenuItem represents an item in the command menu
 type MenuItem struct {
 	Label       string
 	Args        []string
-	Destructive bool // If true, requires confirmation
-	Interactive bool // If true, requires user input (use tea.ExecProcess)
-	Streaming   bool // If true, stream output in real-time (for long-running commands)
+	Destructive bool            // If true, requires confirmation
+	Interactive bool            // If true, requires user input (use tea.ExecProcess)
+	Streaming   bool            // If true, stream output in real-time (for long-running commands)
+	Console     bool            // If true, opens the console-command prompt instead of executing
+	Effect      ContainerEffect // Container-state change applied when the command succeeds
 }
 
 // Message types for Bubble Tea event handling
@@ -258,6 +286,7 @@ type InteractiveFinishedMsg struct {
 type StreamingStartedMsg struct {
 	Output <-chan string
 	Label  string
+	Effect ContainerEffect
 }
 
 // StreamingOutputMsg is sent for each line of streaming command output
@@ -267,8 +296,9 @@ type StreamingOutputMsg struct {
 
 // StreamingFinishedMsg is sent when a streaming command completes
 type StreamingFinishedMsg struct {
-	Label string
-	Err   error
+	Label  string
+	Effect ContainerEffect
+	Err    error
 }
 
 // SettingsToggledMsg is sent when a setting is toggled in the TUI

--- a/tools/mineos-cli/internal/presentation/cli/tui/nav.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/nav.go
@@ -17,10 +17,10 @@ func BuildNavItems() []NavItem {
 
 		// Docker services (containers)
 		{Label: "DOCKER", ItemType: NavHeader},
-		{Label: "Start Containers", ItemType: NavAction, Action: &MenuItem{Label: "Start Containers", Args: []string{"stack", "up"}, Streaming: true}},
-		{Label: "Stop Containers", ItemType: NavAction, Action: &MenuItem{Label: "Stop Containers", Args: []string{"stack", "stop"}, Streaming: true}},
-		{Label: "Restart Containers", ItemType: NavAction, Action: &MenuItem{Label: "Restart Containers", Args: []string{"stack", "restart"}, Streaming: true}},
-		{Label: "Remove Containers", ItemType: NavAction, Action: &MenuItem{Label: "Remove Containers", Args: []string{"stack", "down"}, Destructive: true, Streaming: true}, Destructive: true},
+		{Label: "Start Containers", ItemType: NavAction, Action: &MenuItem{Label: "Start Containers", Args: []string{"stack", "up"}, Streaming: true, Effect: EffectStartsContainers}},
+		{Label: "Stop Containers", ItemType: NavAction, Action: &MenuItem{Label: "Stop Containers", Args: []string{"stack", "stop"}, Streaming: true, Effect: EffectStopsContainers}},
+		{Label: "Restart Containers", ItemType: NavAction, Action: &MenuItem{Label: "Restart Containers", Args: []string{"stack", "restart"}, Streaming: true, Effect: EffectStartsContainers}},
+		{Label: "Remove Containers", ItemType: NavAction, Action: &MenuItem{Label: "Remove Containers", Args: []string{"stack", "down"}, Destructive: true, Streaming: true, Effect: EffectStopsContainers}, Destructive: true},
 		{Label: "Update Images", ItemType: NavAction, Action: &MenuItem{Label: "Update Images", Args: []string{"stack", "update"}, Streaming: true}},
 	}
 

--- a/tools/mineos-cli/internal/presentation/cli/tui/servers.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/servers.go
@@ -54,7 +54,21 @@ func (m TuiModel) RenderServersTable(width, height int) []string {
 	}
 
 	if len(m.Servers) == 0 {
-		lines = append(lines, TrimToWidth(StyleSubtle.Render(" No servers found."), width))
+		// Distinguish loading / unreachable / genuinely empty.
+		var state string
+		switch {
+		case m.ContainersStopped:
+			state = StyleSubtle.Render(" Containers are stopped.")
+		case !m.ConfigReady:
+			state = m.Spinner.View() + StyleSubtle.Render(" Connecting to API...")
+		case m.ErrMsg != "":
+			state = StyleSubtle.Render(" Server list unavailable.")
+		case !m.ServersLoadedOnce:
+			state = m.Spinner.View() + StyleSubtle.Render(" Loading servers...")
+		default:
+			state = StyleSubtle.Render(" No servers found.")
+		}
+		lines = append(lines, TrimToWidth(" "+state, width))
 		return PadLines(lines, height)
 	}
 

--- a/tools/mineos-cli/internal/presentation/cli/tui/update.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/update.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/application/usecases"
@@ -21,9 +22,14 @@ func NewTuiModel(loadConfig *usecases.LoadConfigUseCase, ctx context.Context, ve
 	input.CharLimit = 2048
 	input.Width = 50
 
+	spin := spinner.New()
+	spin.Spinner = spinner.MiniDot
+	spin.Style = StyleStatus
+
 	navItems := BuildNavItems()
 
 	return TuiModel{
+		Spinner: spin,
 		LoadConfig:    loadConfig,
 		Ctx:           ctx,
 		Version:       version,
@@ -66,7 +72,14 @@ func RunTui(ctx context.Context, loadConfig *usecases.LoadConfigUseCase, version
 // Init initializes the TUI model
 func (m TuiModel) Init() tea.Cmd {
 	// scheduleHealthPoll arms the single, self-rescheduling refresh loop.
-	return tea.Batch(m.LoadConfigCmd(), m.LoadComposeCmd(), scheduleHealthPoll())
+	return tea.Batch(m.LoadConfigCmd(), m.LoadComposeCmd(), scheduleHealthPoll(), m.Spinner.Tick)
+}
+
+// spinnerActive reports whether any work-in-flight state warrants an animated
+// spinner. The spinner's tick loop stops when this goes false and is re-armed
+// by the states that flip it true.
+func (m TuiModel) spinnerActive() bool {
+	return (!m.ConfigReady && !m.ContainersStopped) || m.StreamingRunning || m.InteractiveRunning
 }
 
 // Update handles all incoming messages
@@ -187,7 +200,27 @@ func (m TuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case StreamingFinishedMsg:
 		return m.handleStreamingFinished(msg)
 
+	case spinner.TickMsg:
+		if !m.spinnerActive() {
+			return m, nil // Stop the tick loop; re-armed when work starts again
+		}
+		var cmd tea.Cmd
+		m.Spinner, cmd = m.Spinner.Update(msg)
+		return m, cmd
+
 	case HealthTickMsg:
+		// TTL sweep: a status/error line that survived one full poll interval
+		// unchanged is stale — clear it. Persistent conditions (API down, bad
+		// key) re-set their message every cycle and therefore survive.
+		if m.StatusMsg != "" && m.StatusMsg == m.StatusSeenAtTick {
+			m.StatusMsg = ""
+		}
+		if m.ErrMsg != "" && m.ErrMsg == m.ErrSeenAtTick {
+			m.ErrMsg = ""
+		}
+		m.StatusSeenAtTick = m.StatusMsg
+		m.ErrSeenAtTick = m.ErrMsg
+
 		// Single self-rescheduling refresh loop (armed once in Init). Always
 		// re-arm so the TUI keeps refreshing while healthy, not only while down.
 		cmds := []tea.Cmd{scheduleHealthPoll()}
@@ -202,9 +235,10 @@ func (m TuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, m.LoadHealthDataCmd())
 			}
 		} else {
-			// API was unreachable — try to reconnect.
+			// API was unreachable — try to reconnect (and keep the spinner alive).
 			m.StatusMsg = "Reconnecting to API..."
-			cmds = append(cmds, m.LoadConfigCmd())
+			m.StatusSeenAtTick = "" // Never TTL-clear the reconnect notice mid-cycle
+			cmds = append(cmds, m.LoadConfigCmd(), m.Spinner.Tick)
 		}
 		return m, tea.Batch(cmds...)
 
@@ -469,6 +503,7 @@ func (m TuiModel) handleServersLoaded(msg ServersLoadedMsg) (tea.Model, tea.Cmd)
 		m.ConfigReady = true
 	}
 	m.Servers = msg.Servers
+	m.ServersLoadedOnce = true
 	if len(m.Servers) == 0 {
 		m.Selected = 0
 		return m, nil
@@ -538,7 +573,7 @@ func (m TuiModel) handleInteractiveStarted(msg InteractiveStartedMsg) (tea.Model
 	m.InteractiveRunning = true
 	m.Input.SetValue("")
 	m.Input.Focus()
-	return m, tea.Batch(m.ListenInteractiveCmd(), textinput.Blink)
+	return m, tea.Batch(m.ListenInteractiveCmd(), textinput.Blink, m.Spinner.Tick)
 }
 
 func (m TuiModel) handleInteractiveOutput(msg InteractiveOutputMsg) (tea.Model, tea.Cmd) {
@@ -786,6 +821,7 @@ func (m TuiModel) handleStreamingStarted(msg StreamingStartedMsg) (tea.Model, te
 	m.StreamingOutput = msg.Output
 	m.StreamingRunning = true
 	m.StreamingLabel = msg.Label
+	m.StreamingEffect = msg.Effect
 
 	// Switch to output view
 	m.PreviousView = m.CurrentView
@@ -793,7 +829,7 @@ func (m TuiModel) handleStreamingStarted(msg StreamingStartedMsg) (tea.Model, te
 	m.OutputTitle = msg.Label
 	m.OutputLines = nil // Clear and let streaming populate
 
-	return m, m.ListenStreamingCmd()
+	return m, tea.Batch(m.ListenStreamingCmd(), m.Spinner.Tick)
 }
 
 // handleStreamingOutput handles a line of streaming output
@@ -811,10 +847,6 @@ func (m TuiModel) handleStreamingFinished(msg StreamingFinishedMsg) (tea.Model, 
 	m.StreamingRunning = false
 	m.StreamingOutput = nil
 
-	// Detect if containers were intentionally stopped
-	isStopAction := strings.Contains(msg.Label, "Stop") || strings.Contains(msg.Label, "Remove")
-	isStartAction := strings.Contains(msg.Label, "Start") || strings.Contains(msg.Label, "Restart")
-
 	if msg.Err != nil {
 		m.OutputLines = append(m.OutputLines, "", "Error: "+msg.Err.Error())
 		m.ErrMsg = msg.Err.Error()
@@ -823,12 +855,13 @@ func (m TuiModel) handleStreamingFinished(msg StreamingFinishedMsg) (tea.Model, 
 		m.StatusMsg = msg.Label + " complete"
 		m.ErrMsg = ""
 
-		// Track container state
-		if isStopAction {
+		// Track container state from the command's declared effect
+		switch msg.Effect {
+		case EffectStopsContainers:
 			m.ContainersStopped = true
 			m.ConfigReady = false // API is no longer available
 			m.Servers = nil
-		} else if isStartAction {
+		case EffectStartsContainers:
 			m.ContainersStopped = false
 		}
 	}
@@ -846,6 +879,7 @@ func (m TuiModel) handleStreamingFinished(msg StreamingFinishedMsg) (tea.Model, 
 func (m TuiModel) ListenStreamingCmd() tea.Cmd {
 	outputChan := m.StreamingOutput
 	label := m.StreamingLabel
+	effect := m.StreamingEffect
 
 	if outputChan == nil {
 		return nil
@@ -855,7 +889,7 @@ func (m TuiModel) ListenStreamingCmd() tea.Cmd {
 		line, ok := <-outputChan
 		if !ok {
 			// Channel closed - command finished
-			return StreamingFinishedMsg{Label: label}
+			return StreamingFinishedMsg{Label: label, Effect: effect}
 		}
 		return StreamingOutputMsg{Line: line}
 	}

--- a/tools/mineos-cli/internal/presentation/cli/tui/ux_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/ux_test.go
@@ -1,0 +1,132 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestUpdate_StatusAndErrTTLSweep(t *testing.T) {
+	m := TuiModel{StatusMsg: "Restart complete", ErrMsg: "boom", ConfigReady: true}
+
+	// First tick: messages survive (just seen).
+	out, _ := m.Update(HealthTickMsg{})
+	m = out.(TuiModel)
+	if m.StatusMsg == "" || m.ErrMsg == "" {
+		t.Fatal("messages must survive their first tick")
+	}
+
+	// Second tick with no change: swept.
+	out, _ = m.Update(HealthTickMsg{})
+	m = out.(TuiModel)
+	if m.StatusMsg != "" || m.ErrMsg != "" {
+		t.Fatalf("stale messages must be cleared, got %q / %q", m.StatusMsg, m.ErrMsg)
+	}
+}
+
+func TestUpdate_TTLSweepKeepsRefreshedMessages(t *testing.T) {
+	m := TuiModel{ErrMsg: "invalid API key", ConfigReady: true}
+	out, _ := m.Update(HealthTickMsg{})
+	m = out.(TuiModel)
+
+	// A persistent condition re-sets the message between ticks.
+	m.ErrMsg = "invalid API key (again)"
+	out, _ = m.Update(HealthTickMsg{})
+	m = out.(TuiModel)
+	if m.ErrMsg == "" {
+		t.Fatal("a re-set message must survive the sweep")
+	}
+}
+
+func TestUpdate_StreamingFinishedUsesDeclaredEffect(t *testing.T) {
+	// A stop effect marks containers stopped regardless of label wording.
+	m := TuiModel{ConfigReady: true, Servers: serverList("lobby")}
+	out, _ := m.Update(StreamingFinishedMsg{Label: "Anything", Effect: EffectStopsContainers})
+	got := out.(TuiModel)
+	if !got.ContainersStopped || got.ConfigReady || got.Servers != nil {
+		t.Fatalf("stop effect not applied: %+v", got)
+	}
+
+	// A start effect clears the stopped flag.
+	out, _ = got.Update(StreamingFinishedMsg{Label: "Anything", Effect: EffectStartsContainers})
+	if out.(TuiModel).ContainersStopped {
+		t.Fatal("start effect must clear ContainersStopped")
+	}
+
+	// A failed command applies no effect.
+	m = TuiModel{ConfigReady: true}
+	out, _ = m.Update(StreamingFinishedMsg{Effect: EffectStopsContainers, Err: errFake})
+	if out.(TuiModel).ContainersStopped {
+		t.Fatal("a failed command must not change container state")
+	}
+}
+
+func TestHandleKey_HelpOverlayToggles(t *testing.T) {
+	m := TuiModel{}
+	key := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")}
+
+	out, _ := m.Update(key)
+	m = out.(TuiModel)
+	if !m.ShowHelp {
+		t.Fatal("? must open the help overlay")
+	}
+
+	// Any key closes it.
+	out, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m = out.(TuiModel)
+	if m.ShowHelp {
+		t.Fatal("any key must close the help overlay")
+	}
+
+	// q still quits from inside the overlay.
+	m.ShowHelp = true
+	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if !out.(TuiModel).Quitting || cmd == nil {
+		t.Fatal("q must quit even with help open")
+	}
+}
+
+func TestRenderHelpOverlay_ListsBindings(t *testing.T) {
+	m := TuiModel{}
+	joined := strings.Join(m.RenderHelpOverlay(80, 30), "\n")
+	for _, want := range []string{"KEYBINDINGS", "j/k", "Search logs", "Quit"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("help overlay missing %q", want)
+		}
+	}
+}
+
+func TestRenderServersTable_DistinguishesStates(t *testing.T) {
+	width, height := 80, 10
+
+	// Loading (API not ready)
+	m := TuiModel{}
+	if !containsLine(m.RenderServersTable(width, height), "Connecting to API") {
+		t.Fatal("expected connecting state")
+	}
+
+	// Connected, list not loaded yet
+	m = TuiModel{ConfigReady: true}
+	if !containsLine(m.RenderServersTable(width, height), "Loading servers") {
+		t.Fatal("expected loading state")
+	}
+
+	// Unreachable (error set)
+	m = TuiModel{ConfigReady: true, ErrMsg: "connection refused"}
+	if !containsLine(m.RenderServersTable(width, height), "Server list unavailable") {
+		t.Fatal("expected unavailable state")
+	}
+
+	// Containers intentionally stopped
+	m = TuiModel{ContainersStopped: true}
+	if !containsLine(m.RenderServersTable(width, height), "Containers are stopped") {
+		t.Fatal("expected stopped state")
+	}
+
+	// Genuinely empty
+	m = TuiModel{ConfigReady: true, ServersLoadedOnce: true}
+	if !containsLine(m.RenderServersTable(width, height), "No servers found") {
+		t.Fatal("expected empty state")
+	}
+}

--- a/tools/mineos-cli/internal/presentation/cli/tui/view.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/view.go
@@ -65,6 +65,11 @@ func (m TuiModel) View() string {
 		rightLines = m.RenderConfirmDialog(rightWidth, contentHeight)
 	}
 
+	// Overlay help if toggled
+	if m.ShowHelp {
+		rightLines = m.RenderHelpOverlay(rightWidth, contentHeight)
+	}
+
 	// Overlay search input if active
 	if m.Mode == ModeSearch {
 		rightLines = m.RenderSearchInput(rightLines, rightWidth, contentHeight)
@@ -191,7 +196,7 @@ func (m TuiModel) RenderOutputMain(width, height int) []string {
 
 	if len(m.OutputLines) == 0 {
 		if m.StreamingRunning {
-			lines = append(lines, StyleStatus.Render("  Streaming output..."))
+			lines = append(lines, "  "+m.Spinner.View()+StyleStatus.Render(" Streaming output..."))
 			lines = append(lines, "")
 			lines = append(lines, StyleSubtle.Render("  Waiting for command output..."))
 		} else if m.InteractiveRunning {


### PR DESCRIPTION
## Summary
Implements all five #132 items:

1. **Loading vs empty vs error states** — the servers table branches on connecting / loading / unreachable / containers-stopped / empty.
2. **Spinner** — `bubbles/spinner` during connect/reconnect, streaming, and interactive commands; its tick loop stops when idle and is re-armed by the states that need it.
3. **Status/error TTL** — swept on the health tick: unchanged for a full poll interval → cleared; persistent conditions re-set their message each cycle and survive (e.g. invalid-API-key stays, "Restart complete" fades).
4. **`?` help overlay** — all keybindings documented; any key closes, q/Ctrl+C still quit.
5. **Typed fields** — `MenuItem.Console` bool and a `ContainerEffect` enum threaded through the streaming pipeline replace string probing; bonus fixes: `Args[0]` could panic on an empty slice, and a command that fails to start no longer flips container state.

## Review stack
PR 4 of the #119 stack — based on `feat/cli-log-backoff` (#146).

## Testing
`go build ./... && go vet ./... && go test ./...` green in golang:1.24 — TTL sweep, effect handling, help toggle, and table-state tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)