### PR TITLE
refactor(cli): consolidate the 3 divergent .env writers (#134)

### DIFF
--- a/tools/mineos-cli/internal/infrastructure/env/dotenv_repository.go
+++ b/tools/mineos-cli/internal/infrastructure/env/dotenv_repository.go
@@ -2,7 +2,6 @@ package env
 
 import (
 	"context"
-	"os"
 
 	"github.com/joho/godotenv"
 
@@ -22,9 +21,6 @@ func (r *DotenvRepository) Load(_ context.Context) (config.Config, error) {
 
 	values, err := godotenv.Read(r.path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return cfg, err
-		}
 		return cfg, err
 	}
 

--- a/tools/mineos-cli/internal/infrastructure/env/dotenv_writer.go
+++ b/tools/mineos-cli/internal/infrastructure/env/dotenv_writer.go
@@ -1,0 +1,115 @@
+package env
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// This file is the single .env writer for the CLI. Every mutation goes through
+// SetValue/AppendLineIfMissing so quoting, structure preservation, and the
+// 0600 secret-file permission are enforced in exactly one place.
+
+// SetValue sets key=value in the env file at path (default ".env"), preserving
+// comments, blank lines, and ordering. The value is quoted when needed so it
+// round-trips through godotenv. The file is created 0600 if missing, and
+// always written back 0600.
+func SetValue(path, key, value string) error {
+	path = normalizePath(path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return os.WriteFile(path, []byte(FormatLine(key, value)+"\n"), 0o600)
+		}
+		return err
+	}
+
+	lines := strings.Split(string(data), "\n")
+	prefix := key + "="
+	found := false
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), prefix) {
+			lines[i] = FormatLine(key, value)
+			found = true
+		}
+	}
+	if !found {
+		lines = append(lines, FormatLine(key, value))
+	}
+
+	output := strings.Join(lines, "\n")
+	if !strings.HasSuffix(output, "\n") {
+		output += "\n"
+	}
+	return writeSecretFile(path, output)
+}
+
+// writeSecretFile writes content and chmods to 0600 — os.WriteFile alone
+// leaves a pre-existing file's looser mode (e.g. 0644 from older installs).
+func writeSecretFile(path, content string) error {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
+}
+
+// AppendLineIfMissing appends a raw line (typically a comment header) to the
+// env file unless it is already present. The file must exist.
+func AppendLineIfMissing(path, line string) error {
+	path = normalizePath(path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(string(data), line) {
+		return nil
+	}
+	content := string(data)
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += "\n" + line + "\n"
+	return writeSecretFile(path, content)
+}
+
+// FormatLine renders one key=value line, quoting the value when a bare write
+// would be corrupted or reinterpreted on read (spaces, '#' starting a comment,
+// quotes, '$' expansion, control characters).
+func FormatLine(key, value string) string {
+	switch {
+	case !needsQuoting(value):
+		return key + "=" + value
+	case strings.Contains(value, "$") && !strings.Contains(value, "'") && !strings.ContainsAny(value, "\n\r"):
+		// Single quotes stop godotenv's $VAR expansion, which double quotes
+		// do not.
+		return key + "='" + value + "'"
+	default:
+		escaped := strings.NewReplacer(
+			`\`, `\\`,
+			`"`, `\"`,
+			"\n", `\n`,
+			"\r", `\r`,
+		).Replace(value)
+		return key + `="` + escaped + `"`
+	}
+}
+
+func needsQuoting(value string) bool {
+	if value == "" {
+		return false
+	}
+	if value != strings.TrimSpace(value) {
+		return true
+	}
+	return strings.ContainsAny(value, " \t#\"'`$\n\r\\")
+}
+
+func normalizePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		path = ".env"
+	}
+	return filepath.Clean(path)
+}

--- a/tools/mineos-cli/internal/infrastructure/env/dotenv_writer_test.go
+++ b/tools/mineos-cli/internal/infrastructure/env/dotenv_writer_test.go
@@ -1,0 +1,157 @@
+package env
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/joho/godotenv"
+)
+
+func writeFixture(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestSetValue_UpdatesInPlacePreservingStructure(t *testing.T) {
+	path := writeFixture(t, "# MineOS config\nAPI_PORT=5078\n\n# Keys\nMINEOS_API_KEY=old\n")
+
+	if err := SetValue(path, "MINEOS_API_KEY", "new"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if !strings.Contains(content, "# MineOS config") || !strings.Contains(content, "# Keys") {
+		t.Fatalf("comments lost:\n%s", content)
+	}
+	if !strings.Contains(content, "MINEOS_API_KEY=new") || strings.Contains(content, "old") {
+		t.Fatalf("value not replaced:\n%s", content)
+	}
+	if strings.Index(content, "API_PORT") > strings.Index(content, "MINEOS_API_KEY") {
+		t.Fatalf("ordering changed:\n%s", content)
+	}
+}
+
+func TestSetValue_AppendsMissingKey(t *testing.T) {
+	path := writeFixture(t, "API_PORT=5078\n")
+	if err := SetValue(path, "NEW_KEY", "val"); err != nil {
+		t.Fatal(err)
+	}
+	values, err := godotenv.Read(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if values["NEW_KEY"] != "val" || values["API_PORT"] != "5078" {
+		t.Fatalf("append failed: %v", values)
+	}
+}
+
+func TestSetValue_CreatesMissingFileWith0600(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := SetValue(path, "KEY", "val"); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("want 0600, got %o", info.Mode().Perm())
+	}
+}
+
+func TestSetValue_TightensPermissionsOnRewrite(t *testing.T) {
+	path := writeFixture(t, "KEY=old\n") // fixture is written 0644
+	if err := SetValue(path, "KEY", "new"); err != nil {
+		t.Fatal(err)
+	}
+	info, _ := os.Stat(path)
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("want 0600 after rewrite, got %o", info.Mode().Perm())
+	}
+}
+
+// The bug that motivated #134: values with '#', spaces, quotes, or '$' were
+// written bare by the hand-rolled writers and then silently corrupted on read.
+func TestSetValue_RoundTripsTrickyValues(t *testing.T) {
+	tricky := []string{
+		"plain",
+		"has spaces here",
+		"trailing#comment",
+		"quote\"inside",
+		"single'quote",
+		"dollar$sign",
+		"${looks_like_var}",
+		"back\\slash",
+		"semi;colon",
+	}
+	for _, want := range tricky {
+		path := writeFixture(t, "OTHER=1\n")
+		if err := SetValue(path, "KEY", want); err != nil {
+			t.Fatalf("%q: %v", want, err)
+		}
+		values, err := godotenv.Read(path)
+		if err != nil {
+			t.Fatalf("%q: read failed: %v", want, err)
+		}
+		if got := values["KEY"]; got != want {
+			t.Fatalf("round-trip corrupted %q -> %q", want, got)
+		}
+		if values["OTHER"] != "1" {
+			t.Fatalf("%q: sibling key corrupted", want)
+		}
+	}
+}
+
+func TestSetValue_ReplacesQuotedExistingValue(t *testing.T) {
+	path := writeFixture(t, `KEY="old value"`+"\n")
+	if err := SetValue(path, "KEY", "new"); err != nil {
+		t.Fatal(err)
+	}
+	values, _ := godotenv.Read(path)
+	if values["KEY"] != "new" {
+		t.Fatalf("quoted value not replaced: %v", values)
+	}
+}
+
+func TestAppendLineIfMissing(t *testing.T) {
+	path := writeFixture(t, "KEY=1\n")
+
+	if err := AppendLineIfMissing(path, "# Section"); err != nil {
+		t.Fatal(err)
+	}
+	if err := AppendLineIfMissing(path, "# Section"); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(path)
+	if strings.Count(string(data), "# Section") != 1 {
+		t.Fatalf("comment duplicated:\n%s", data)
+	}
+
+	if err := AppendLineIfMissing(filepath.Join(t.TempDir(), "missing"), "x"); err == nil {
+		t.Fatal("missing file must error")
+	}
+}
+
+func TestFormatLine(t *testing.T) {
+	cases := map[string]string{
+		"plain":       "K=plain",
+		"":            "K=",
+		"with space":  `K="with space"`,
+		"a#b":         `K="a#b"`,
+		"pa$$word":    "K='pa$$word'",
+		"d'oh $1":     `K="d'oh $1"`, // single quote inside forces double quotes
+		"line\nbreak": `K="line\nbreak"`,
+	}
+	for value, want := range cases {
+		if got := FormatLine("K", value); got != want {
+			t.Fatalf("FormatLine(%q) = %q, want %q", value, got, want)
+		}
+	}
+}

--- a/tools/mineos-cli/internal/presentation/cli/commands/config.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/config.go
@@ -3,13 +3,12 @@ package commands
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
-	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 
 	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/application/usecases"
+	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/infrastructure/env"
 )
 
 func NewConfigCommand(loadConfig *usecases.LoadConfigUseCase) *cobra.Command {
@@ -97,18 +96,9 @@ Examples:
 				return fmt.Errorf("invalid channel: %s (must be 'stable' or 'prerelease')", args[0])
 			}
 
-			// Update .env file
-			envMap, err := godotenv.Read(cfg.EnvPath)
-			if err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("failed to read .env: %w", err)
-			}
-			if envMap == nil {
-				envMap = make(map[string]string)
-			}
-
-			envMap["MINEOS_CLI_PRERELEASE_UPDATES"] = value
-
-			if err := godotenv.Write(envMap, cfg.EnvPath); err != nil {
+			// Update .env in place — the single writer preserves comments and
+			// keeps the file 0600 (godotenv.Write did neither).
+			if err := env.SetValue(cfg.EnvPath, "MINEOS_CLI_PRERELEASE_UPDATES", value); err != nil {
 				return fmt.Errorf("failed to write .env: %w", err)
 			}
 

--- a/tools/mineos-cli/internal/presentation/cli/commands/env_edit.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/env_edit.go
@@ -3,12 +3,12 @@ package commands
 import (
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"
+
+	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/infrastructure/env"
 )
 
 // envDefault defines a required env var and its default value.
@@ -72,20 +72,9 @@ func ensureEnvDefaults(envPath string, out io.Writer) ([]string, error) {
 }
 
 // appendLineIfMissing appends a line to a file if it doesn't already contain it.
+// Thin alias over the single writer in infrastructure/env.
 func appendLineIfMissing(path string, line string) error {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-	if strings.Contains(string(data), line) {
-		return nil
-	}
-	content := string(data)
-	if !strings.HasSuffix(content, "\n") {
-		content += "\n"
-	}
-	content += "\n" + line + "\n"
-	return os.WriteFile(path, []byte(content), 0o600)
+	return env.AppendLineIfMissing(path, line)
 }
 
 func loadEnvValues(path string) (map[string]string, error) {
@@ -96,38 +85,8 @@ func loadEnvValues(path string) (map[string]string, error) {
 	return godotenv.Read(envPath)
 }
 
+// setEnvFileValue sets key=value in the .env file.
+// Thin alias over the single writer in infrastructure/env.
 func setEnvFileValue(path, key, value string) error {
-	envPath := strings.TrimSpace(path)
-	if envPath == "" {
-		envPath = ".env"
-	}
-	envPath = filepath.Clean(envPath)
-
-	data, err := os.ReadFile(envPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return os.WriteFile(envPath, []byte(key+"="+value+"\n"), 0o600)
-		}
-		return err
-	}
-
-	lines := strings.Split(string(data), "\n")
-	found := false
-	prefix := key + "="
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, prefix) {
-			lines[i] = prefix + value
-			found = true
-		}
-	}
-	if !found {
-		lines = append(lines, prefix+value)
-	}
-
-	output := strings.Join(lines, "\n")
-	if !strings.HasSuffix(output, "\n") {
-		output += "\n"
-	}
-	return os.WriteFile(envPath, []byte(output), 0o600)
+	return env.SetValue(path, key, value)
 }

--- a/tools/mineos-cli/internal/presentation/cli/tui/actions.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/actions.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/infrastructure/env"
 )
 
 func (m TuiModel) ConsoleCommandCmd(command string) tea.Cmd {
@@ -182,7 +184,8 @@ func (m TuiModel) SendInteractiveInput(input string) tea.Cmd {
 	}
 }
 
-// ToggleEnvSettingCmd toggles a boolean env var between "true" and "false" in the .env file
+// ToggleEnvSettingCmd toggles a boolean env var between "true" and "false" in
+// the .env file (via the single writer in infrastructure/env).
 func (m TuiModel) ToggleEnvSettingCmd(envKey, currentValue string) tea.Cmd {
 	envPath := m.Cfg.EnvPath
 	newVal := "true"
@@ -190,40 +193,9 @@ func (m TuiModel) ToggleEnvSettingCmd(envKey, currentValue string) tea.Cmd {
 		newVal = "false"
 	}
 	return func() tea.Msg {
-		err := writeEnvValue(envPath, envKey, newVal)
+		err := env.SetValue(envPath, envKey, newVal)
 		return SettingsToggledMsg{Key: envKey, Val: newVal, Err: err}
 	}
-}
-
-// writeEnvValue sets a key=value in the .env file
-func writeEnvValue(path, key, value string) error {
-	if path == "" {
-		path = ".env"
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return os.WriteFile(path, []byte(key+"="+value+"\n"), 0o600)
-		}
-		return err
-	}
-	lines := strings.Split(string(data), "\n")
-	found := false
-	prefix := key + "="
-	for i, line := range lines {
-		if strings.HasPrefix(strings.TrimSpace(line), prefix) {
-			lines[i] = prefix + value
-			found = true
-		}
-	}
-	if !found {
-		lines = append(lines, prefix+value)
-	}
-	output := strings.Join(lines, "\n")
-	if !strings.HasSuffix(output, "\n") {
-		output += "\n"
-	}
-	return os.WriteFile(path, []byte(output), 0o600)
 }
 
 func (m TuiModel) SelectedServer() string {


### PR DESCRIPTION
## Summary
Implements #134 — one writer, one permission bit, one quoting policy.

- **New single writer** `infrastructure/env.SetValue` (+ `AppendLineIfMissing`, `FormatLine`): preserves comments/ordering, quotes values that would be corrupted bare (`#`, spaces, quotes, `$` — single-quoted to stop godotenv `$VAR` expansion), creates files 0600 and **chmods pre-existing looser files to 0600** (os.WriteFile alone doesn't; the round-trip test caught it).
- `commands/setEnvFileValue`/`appendLineIfMissing` are now thin aliases (≈35 call sites in reconfigure/api-key-refresh unchanged); the TUI's near-verbatim `writeEnvValue` copy is deleted; `config.go`'s `godotenv.Write` path (which dropped every comment and wrote 0644) now goes through the writer too.
- Removes the dead identical-branch in `DotenvRepository.Load` (flagged in the issue).

## Review stack
PR 5 of the #119 stack — based on `feat/cli-ux-polish` (#147).

## Testing
`go build ./... && go vet ./... && go test ./...` green in golang:1.24. Writer tests include godotenv round-trips for the corruption cases, structure preservation, permission tightening, and quoted-value replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)