### PR TITLE
test(cli): add test seams + first test wave (#135)

### DIFF
--- a/tools/mineos-cli/internal/domain/config/config_test.go
+++ b/tools/mineos-cli/internal/domain/config/config_test.go
@@ -1,0 +1,53 @@
+package config
+
+import "testing"
+
+func TestEffectiveApiKey_Precedence(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{"management wins", Config{ManagementApiKey: "m", ApiKeyStatic: "s", ApiKeySeed: "d"}, "m"},
+		{"static over seed", Config{ApiKeyStatic: "s", ApiKeySeed: "d"}, "s"},
+		{"seed as fallback", Config{ApiKeySeed: "d"}, "d"},
+		{"all empty", Config{}, ""},
+	}
+	for _, c := range cases {
+		if got := c.cfg.EffectiveApiKey(); got != c.want {
+			t.Fatalf("%s: got %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+func TestIsPreReleaseEnabled(t *testing.T) {
+	if (Config{PreReleaseUpdates: "true"}).IsPreReleaseEnabled() != true {
+		t.Fatal("'true' must enable pre-release")
+	}
+	for _, v := range []string{"", "false", "TRUE", "1", "yes"} {
+		if (Config{PreReleaseUpdates: v}).IsPreReleaseEnabled() {
+			t.Fatalf("%q must not enable pre-release (exact 'true' only)", v)
+		}
+	}
+}
+
+func TestIsTelemetryEnabled_DefaultsOn(t *testing.T) {
+	if !(Config{}).IsTelemetryEnabled() {
+		t.Fatal("unset telemetry must default to enabled")
+	}
+	if (Config{TelemetryEnabled: "false"}).IsTelemetryEnabled() {
+		t.Fatal("'false' must disable telemetry")
+	}
+	if !(Config{TelemetryEnabled: "anything-else"}).IsTelemetryEnabled() {
+		t.Fatal("only exact 'false' disables telemetry")
+	}
+}
+
+func TestEffectiveTelemetryEndpoint(t *testing.T) {
+	if got := (Config{}).EffectiveTelemetryEndpoint(); got != "https://mineos.net" {
+		t.Fatalf("default endpoint wrong: %q", got)
+	}
+	if got := (Config{TelemetryEndpoint: "http://localhost:9"}).EffectiveTelemetryEndpoint(); got != "http://localhost:9" {
+		t.Fatalf("override ignored: %q", got)
+	}
+}

--- a/tools/mineos-cli/internal/infrastructure/api/client_test.go
+++ b/tools/mineos-cli/internal/infrastructure/api/client_test.go
@@ -115,3 +115,38 @@ func TestPerformanceHistory_RequiresName(t *testing.T) {
 		t.Fatal("want error for empty server name")
 	}
 }
+
+func TestListServers_InvalidKeyMapsAuthErrors(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(status)
+		}))
+		if _, err := NewClient(srv.URL, "bad").ListServers(context.Background()); err != ErrApiKeyInvalid {
+			t.Fatalf("status %d: want ErrApiKeyInvalid, got %v", status, err)
+		}
+		srv.Close()
+	}
+}
+
+func TestStreamConsoleLogs_ParsesSSEAndSkipsJunk(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ": comment to ignore\n")
+		_, _ = io.WriteString(w, "data: {\"timestamp\":\"2026-07-22T00:00:00Z\",\"message\":\"hello\"}\n\n")
+		_, _ = io.WriteString(w, "data: not-json\n\n")
+		_, _ = io.WriteString(w, "data: {\"timestamp\":\"2026-07-22T00:00:01Z\",\"message\":\"world\"}\n\n")
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logs, _ := NewClient(srv.URL, "k").StreamConsoleLogs(ctx, "lobby", "")
+
+	var got []string
+	for entry := range logs {
+		got = append(got, entry.Message)
+	}
+	if len(got) != 2 || got[0] != "hello" || got[1] != "world" {
+		t.Fatalf("SSE parse wrong: %v", got)
+	}
+}

--- a/tools/mineos-cli/internal/infrastructure/env/dotenv_repository_test.go
+++ b/tools/mineos-cli/internal/infrastructure/env/dotenv_repository_test.go
@@ -1,0 +1,88 @@
+package env
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoad_MissingFileErrorsButKeepsPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".env")
+	cfg, err := NewDotenvRepository(path).Load(context.Background())
+	if !os.IsNotExist(err) {
+		t.Fatalf("want not-exist error, got %v", err)
+	}
+	if cfg.EnvPath != path {
+		t.Fatal("EnvPath must be set even on error")
+	}
+}
+
+func TestLoad_MapsAllKeys(t *testing.T) {
+	content := `API_PORT=5078
+WEB_ORIGIN_PROD=https://example.com
+MINEOS_NETWORK_MODE=host
+MINEOS_BUILD_FROM_SOURCE=true
+MINEOS_IMAGE_TAG=preview
+ApiKey__SeedKey=seed
+ApiKey__StaticKey=static
+MINEOS_API_KEY=mgmt
+PUBLIC_MINECRAFT_HOST=mc.example.com
+BODY_SIZE_LIMIT=512M
+DB_TYPE=postgres
+ConnectionStrings__DefaultConnection=Host=db
+Data__Directory=/data
+MINEOS_SHUTDOWN_TIMEOUT=300
+MINEOS_CLI_PRERELEASE_UPDATES=true
+MINEOS_TELEMETRY_ENABLED=false
+MINEOS_TELEMETRY_ENDPOINT=http://t
+MINEOS_INSTALLATION_ID=uuid-1
+MINEOS_TELEMETRY_KEY=tk
+`
+	path := writeFixture(t, content)
+	cfg, err := NewDotenvRepository(path).Load(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	checks := map[string]string{
+		"ApiPort":            cfg.ApiPort,
+		"WebOrigin":          cfg.WebOrigin,
+		"NetworkMode":        cfg.NetworkMode,
+		"ManagementApiKey":   cfg.ManagementApiKey,
+		"DatabaseConnection": cfg.DatabaseConnection,
+		"InstallationID":     cfg.InstallationID,
+	}
+	wants := map[string]string{
+		"ApiPort":            "5078",
+		"WebOrigin":          "https://example.com",
+		"NetworkMode":        "host",
+		"ManagementApiKey":   "mgmt",
+		"DatabaseConnection": "Host=db",
+		"InstallationID":     "uuid-1",
+	}
+	for field, got := range checks {
+		if got != wants[field] {
+			t.Fatalf("%s = %q, want %q", field, got, wants[field])
+		}
+	}
+	if !cfg.IsPreReleaseEnabled() || cfg.IsTelemetryEnabled() {
+		t.Fatal("boolean-ish fields not mapped")
+	}
+}
+
+func TestLoad_WebOriginFallsBackToOrigin(t *testing.T) {
+	path := writeFixture(t, "ORIGIN=http://fallback\n")
+	cfg, err := NewDotenvRepository(path).Load(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.WebOrigin != "http://fallback" {
+		t.Fatalf("ORIGIN fallback not applied: %q", cfg.WebOrigin)
+	}
+
+	path = writeFixture(t, "WEB_ORIGIN_PROD=http://primary\nORIGIN=http://fallback\n")
+	cfg, _ = NewDotenvRepository(path).Load(context.Background())
+	if cfg.WebOrigin != "http://primary" {
+		t.Fatalf("WEB_ORIGIN_PROD must win: %q", cfg.WebOrigin)
+	}
+}

--- a/tools/mineos-cli/internal/presentation/cli/commands/compose_config_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/compose_config_test.go
@@ -1,0 +1,80 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/domain/config"
+)
+
+func writeEnvFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(path, []byte("API_PORT=5078\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func argsString(r composeRunner) string {
+	return strings.Join(r.baseArgs, " ")
+}
+
+func TestComposeWithConfig_DefaultBridgeMode(t *testing.T) {
+	envPath := writeEnvFixture(t)
+	base := composeRunner{exe: "docker", baseArgs: []string{"compose"}}
+
+	got := composeWithConfig(base, config.Config{EnvPath: envPath})
+	args := argsString(got)
+
+	if !strings.Contains(args, "--env-file "+envPath) {
+		t.Fatalf("env file not wired: %s", args)
+	}
+	if !strings.Contains(args, "docker-compose.yml") {
+		t.Fatalf("base compose file missing: %s", args)
+	}
+	if strings.Contains(args, "host.yml") || strings.Contains(args, "build.yml") {
+		t.Fatalf("unexpected overlay files: %s", args)
+	}
+}
+
+func TestComposeWithConfig_HostModeAndBuildOverlays(t *testing.T) {
+	envPath := writeEnvFixture(t)
+	base := composeRunner{exe: "docker", baseArgs: []string{"compose"}}
+
+	got := composeWithConfig(base, config.Config{
+		EnvPath:         envPath,
+		NetworkMode:     "HOST", // case-insensitive
+		BuildFromSource: "true",
+	})
+	args := argsString(got)
+
+	for _, want := range []string{"docker-compose.yml", "docker-compose.host.yml", "docker-compose.build.yml"} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("missing %s in: %s", want, args)
+		}
+	}
+	// Overlays must come after the base file (compose merge order matters).
+	if strings.Index(args, "docker-compose.host.yml") < strings.Index(args, "-f docker-compose.yml")+2 &&
+		strings.Index(args, "docker-compose.yml") > strings.Index(args, "docker-compose.host.yml") {
+		t.Fatalf("overlay ordering wrong: %s", args)
+	}
+}
+
+func TestComposeWithConfig_MissingEnvFileSkipsFlag(t *testing.T) {
+	base := composeRunner{exe: "docker", baseArgs: []string{"compose"}}
+	got := composeWithConfig(base, config.Config{EnvPath: filepath.Join(t.TempDir(), "nope.env")})
+	if strings.Contains(argsString(got), "--env-file") {
+		t.Fatalf("nonexistent env file must not be passed: %s", argsString(got))
+	}
+}
+
+func TestComposeWithConfig_DoesNotMutateBase(t *testing.T) {
+	base := composeRunner{exe: "docker", baseArgs: []string{"compose"}}
+	_ = composeWithConfig(base, config.Config{EnvPath: writeEnvFixture(t), BuildFromSource: "true"})
+	if len(base.baseArgs) != 1 || base.baseArgs[0] != "compose" {
+		t.Fatalf("base runner mutated: %v", base.baseArgs)
+	}
+}

--- a/tools/mineos-cli/internal/presentation/cli/commands/helpers_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/helpers_test.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestIsValidRelativePath(t *testing.T) {
+	valid := []string{"mineos", "sub/dir", "./here", "a.b"}
+	invalid := []string{"", "  ", "/abs", "~home", "..", "../up", "sub/../../out", "\\win"}
+	for _, p := range valid {
+		if !isValidRelativePath(p) {
+			t.Fatalf("%q should be valid", p)
+		}
+	}
+	for _, p := range invalid {
+		if isValidRelativePath(p) {
+			t.Fatalf("%q should be invalid", p)
+		}
+	}
+}
+
+func TestParseEnvInt(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want int
+	}{
+		{"", 42}, {"  ", 42}, {"7", 7}, {" 7 ", 7}, {"x", 42}, {"-3", -3},
+	}
+	for _, c := range cases {
+		if got := parseEnvInt(c.raw, 42); got != c.want {
+			t.Fatalf("parseEnvInt(%q) = %d, want %d", c.raw, got, c.want)
+		}
+	}
+}
+
+func TestParseEnvBool(t *testing.T) {
+	for _, truthy := range []string{"true", "TRUE", "1", " t "} {
+		if !parseEnvBool(truthy) {
+			t.Fatalf("%q should parse true", truthy)
+		}
+	}
+	for _, falsy := range []string{"", "false", "0", "yes", "junk"} {
+		if parseEnvBool(falsy) {
+			t.Fatalf("%q should parse false", falsy)
+		}
+	}
+}
+
+func TestIsPreviewTag(t *testing.T) {
+	preview := []string{"preview", "Preview", "v1.2.0-beta.4", "v2.0.0-alpha.1", "v1.0.0-rc.2"}
+	stable := []string{"latest", "v1.2.0", "stable", ""}
+	for _, tag := range preview {
+		if !isPreviewTag(tag) {
+			t.Fatalf("%q should be preview", tag)
+		}
+	}
+	for _, tag := range stable {
+		if isPreviewTag(tag) {
+			t.Fatalf("%q should be stable", tag)
+		}
+	}
+}
+
+func TestGetAssetName(t *testing.T) {
+	want := fmt.Sprintf("mineos-cli_%s_%s.zip", runtime.GOOS, runtime.GOARCH)
+	if got := getAssetName(); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	if !strings.HasSuffix(getAssetName(), ".zip") {
+		t.Fatal("asset must be a zip")
+	}
+}
+
+func TestResolveUninstallMode_ExplicitModes(t *testing.T) {
+	cmd := &cobra.Command{}
+	cases := map[string]string{
+		"1": "containers", "containers": "containers", "container": "containers", "keep": "containers",
+		"2": "backup", "backup": "backup",
+		"3": "remove", "remove": "remove", "delete": "remove",
+		"4": "complete", "complete": "complete", "full": "complete", "everything": "complete",
+		" Complete ": "complete", "KEEP": "containers",
+	}
+	for in, want := range cases {
+		got, err := resolveUninstallMode(cmd, in)
+		if err != nil || got != want {
+			t.Fatalf("resolveUninstallMode(%q) = %q, %v; want %q", in, got, err, want)
+		}
+	}
+	if _, err := resolveUninstallMode(cmd, "5"); err == nil {
+		t.Fatal("invalid mode must error")
+	}
+	if _, err := resolveUninstallMode(cmd, "nuke"); err == nil {
+		t.Fatal("invalid mode must error")
+	}
+}

--- a/tools/mineos-cli/internal/presentation/cli/commands/release_select_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/release_select_test.go
@@ -1,0 +1,87 @@
+package commands
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// withGithubStub points release fetching at a stub server for one test.
+func withGithubStub(t *testing.T, handler http.Handler) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	orig := githubAPIBase
+	githubAPIBase = srv.URL
+	t.Cleanup(func() {
+		githubAPIBase = orig
+		srv.Close()
+	})
+}
+
+func TestFetchBestRelease_StableUsesLatestEndpoint(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/freeman412/mineos-sveltekit/releases/latest", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"tag_name":"v1.2.0","prerelease":false,"assets":[]}`)
+	})
+	mux.HandleFunc("/repos/freeman412/mineos-sveltekit/releases", func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("stable check must not hit the all-releases endpoint")
+	})
+	withGithubStub(t, mux)
+
+	release, err := fetchBestRelease(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if release.TagName != "v1.2.0" || release.Prerelease {
+		t.Fatalf("wrong release: %+v", release)
+	}
+}
+
+func TestFetchBestRelease_PrereleasePicksNewestOfAll(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/freeman412/mineos-sveltekit/releases", func(w http.ResponseWriter, _ *http.Request) {
+		// GitHub sorts newest-first; the newest here is a beta.
+		_, _ = io.WriteString(w, `[
+			{"tag_name":"v1.2.0-beta.5","prerelease":true,"assets":[]},
+			{"tag_name":"v1.1.0","prerelease":false,"assets":[]}
+		]`)
+	})
+	withGithubStub(t, mux)
+
+	release, err := fetchBestRelease(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if release.TagName != "v1.2.0-beta.5" || !release.Prerelease {
+		t.Fatalf("newest (pre-)release not selected: %+v", release)
+	}
+}
+
+func TestFetchBestRelease_NoReleases(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/freeman412/mineos-sveltekit/releases/latest", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	mux.HandleFunc("/repos/freeman412/mineos-sveltekit/releases", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `[]`)
+	})
+	withGithubStub(t, mux)
+
+	if _, err := fetchBestRelease(false); !errors.Is(err, errNoReleases) {
+		t.Fatalf("404 must map to errNoReleases, got %v", err)
+	}
+	if _, err := fetchBestRelease(true); !errors.Is(err, errNoReleases) {
+		t.Fatalf("empty list must map to errNoReleases, got %v", err)
+	}
+}
+
+func TestFetchBestRelease_ServerErrorSurfaces(t *testing.T) {
+	withGithubStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	if _, err := fetchBestRelease(false); err == nil {
+		t.Fatal("500 must surface as an error")
+	}
+}

--- a/tools/mineos-cli/internal/presentation/cli/commands/stack.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/stack.go
@@ -460,7 +460,13 @@ func NewStackLogsCommand(loadConfig *usecases.LoadConfigUseCase) *cobra.Command 
 	return cmd
 }
 
-func gracefulStop(ctx context.Context, loadConfig *usecases.LoadConfigUseCase, compose composeRunner, cfg config.Config, timeoutSeconds int, force bool, out io.Writer) error {
+// stackRunner is the seam gracefulStop needs from docker compose — satisfied
+// by composeRunner in production and by fakes in tests.
+type stackRunner interface {
+	run(args []string) error
+}
+
+func gracefulStop(ctx context.Context, loadConfig *usecases.LoadConfigUseCase, compose stackRunner, cfg config.Config, timeoutSeconds int, force bool, out io.Writer) error {
 	if force {
 		fmt.Fprintln(out, "Force stop enabled; killing servers and stopping containers immediately.")
 		if err := stopMinecraftServers(ctx, loadConfig, out, true, timeoutSeconds); err != nil {

--- a/tools/mineos-cli/internal/presentation/cli/commands/stack_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/stack_test.go
@@ -1,0 +1,84 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/application/usecases"
+	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/domain/config"
+	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/infrastructure/env"
+)
+
+// fakeRunner records compose invocations instead of exec'ing docker.
+type fakeRunner struct {
+	calls [][]string
+	err   error
+}
+
+func (f *fakeRunner) run(args []string) error {
+	f.calls = append(f.calls, args)
+	return f.err
+}
+
+// unreachableLoadConfig returns a use case whose API is unreachable, so the
+// stop-servers step degrades to a warning and compose is still invoked.
+func unreachableLoadConfig(t *testing.T) *usecases.LoadConfigUseCase {
+	t.Helper()
+	repo := env.NewDotenvRepository(filepath.Join(t.TempDir(), "missing.env"))
+	return usecases.NewLoadConfigUseCase(repo)
+}
+
+func TestGracefulStop_ForceStopsImmediately(t *testing.T) {
+	fake := &fakeRunner{}
+	var out bytes.Buffer
+
+	err := gracefulStop(context.Background(), unreachableLoadConfig(t), fake, config.Config{}, 60, true, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("want 1 compose call, got %v", fake.calls)
+	}
+	got := fake.calls[0]
+	if got[0] != "stop" || got[1] != "-t" || got[2] != "0" {
+		t.Fatalf("force stop must use -t 0, got %v", got)
+	}
+	if !bytes.Contains(out.Bytes(), []byte("Warning:")) {
+		t.Fatal("unreachable API must surface as a warning, not an error")
+	}
+}
+
+func TestGracefulStop_GracefulUsesShortDockerTimeout(t *testing.T) {
+	fake := &fakeRunner{}
+	var out bytes.Buffer
+
+	err := gracefulStop(context.Background(), unreachableLoadConfig(t), fake, config.Config{}, 120, false, &out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("want 1 compose call, got %v", fake.calls)
+	}
+	got := fake.calls[0]
+	// Minecraft servers are stopped via the API; containers get a short SIGTERM window.
+	if got[0] != "stop" || got[1] != "-t" || got[2] != "30" {
+		t.Fatalf("graceful stop must use -t 30, got %v", got)
+	}
+}
+
+func TestGracefulStop_ComposeErrorPropagates(t *testing.T) {
+	fake := &fakeRunner{err: errBoom}
+	var out bytes.Buffer
+
+	if err := gracefulStop(context.Background(), unreachableLoadConfig(t), fake, config.Config{}, 60, true, &out); err == nil {
+		t.Fatal("compose failure must propagate")
+	}
+}
+
+var errBoom = &boomError{}
+
+type boomError struct{}
+
+func (*boomError) Error() string { return "boom" }

--- a/tools/mineos-cli/internal/presentation/cli/commands/upgrade.go
+++ b/tools/mineos-cli/internal/presentation/cli/commands/upgrade.go
@@ -22,12 +22,21 @@ import (
 )
 
 const (
-	githubRepo       = "freeman412/mineos-sveltekit"
-	githubAPIBase    = "https://api.github.com"
-	latestReleaseURL = githubAPIBase + "/repos/" + githubRepo + "/releases/latest"
-	allReleasesURL   = githubAPIBase + "/repos/" + githubRepo + "/releases"
-	checksumsAsset   = "checksums.txt"
+	githubRepo     = "freeman412/mineos-sveltekit"
+	checksumsAsset = "checksums.txt"
 )
+
+// githubAPIBase is a variable so tests can point release fetching at an
+// httptest server.
+var githubAPIBase = "https://api.github.com"
+
+func latestReleaseURL() string {
+	return githubAPIBase + "/repos/" + githubRepo + "/releases/latest"
+}
+
+func allReleasesURL() string {
+	return githubAPIBase + "/repos/" + githubRepo + "/releases"
+}
 
 var (
 	// metadataHTTPClient is for the small GitHub API JSON calls.
@@ -299,7 +308,7 @@ func verifyChecksum(out io.Writer, filePath, assetName string, release *githubRe
 }
 
 func fetchLatestRelease() (*githubRelease, error) {
-	resp, err := metadataHTTPClient.Get(latestReleaseURL)
+	resp, err := metadataHTTPClient.Get(latestReleaseURL())
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +338,7 @@ func fetchBestRelease(includePrerelease bool) (*githubRelease, error) {
 	}
 
 	// Otherwise, fetch all releases and find the newest (including pre-releases)
-	resp, err := metadataHTTPClient.Get(allReleasesURL)
+	resp, err := metadataHTTPClient.Get(allReleasesURL())
 	if err != nil {
 		return nil, err
 	}

--- a/tools/mineos-cli/internal/presentation/cli/tui/transitions_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/transitions_test.go
@@ -1,0 +1,96 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func navIndexOf(t *testing.T, items []NavItem, label string) int {
+	t.Helper()
+	for i, item := range items {
+		if item.Label == label {
+			return i
+		}
+	}
+	t.Fatalf("nav item %q not found", label)
+	return -1
+}
+
+func TestNavSelect_SwitchesToView(t *testing.T) {
+	items := BuildNavItems()
+	m := TuiModel{NavItems: items, CurrentView: ViewDashboard}
+	m.NavIndex = navIndexOf(t, items, "Health & Alerts")
+
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := out.(TuiModel)
+	if got.CurrentView != ViewHealth {
+		t.Fatalf("want ViewHealth, got %v", got.CurrentView)
+	}
+	if got.PreviousView != ViewDashboard {
+		t.Fatal("previous view not recorded")
+	}
+}
+
+func TestNavSelect_EnterOnServerOpensActions(t *testing.T) {
+	m := TuiModel{CurrentView: ViewServers, Servers: serverList("lobby", "survival"), Selected: 1}
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := out.(TuiModel)
+	if !got.ServerActions || got.ActionIndex != 0 {
+		t.Fatalf("server actions not opened: %+v", got)
+	}
+}
+
+func TestNavBack_LeavesServerActionsAndClearsPerfState(t *testing.T) {
+	m := TuiModel{
+		CurrentView:   ViewServers,
+		Servers:       serverList("lobby"),
+		ServerActions: true,
+		ActionIndex:   2,
+		PerfServer:    "lobby",
+	}
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	got := out.(TuiModel)
+	if got.ServerActions || got.ActionIndex != 0 {
+		t.Fatal("Esc must leave server-actions mode")
+	}
+	if got.PerfServer != "" || got.PerfHistory != nil {
+		t.Fatal("perf stream state must be cleared on exit")
+	}
+}
+
+func TestNavBack_OutputReturnsToPreviousView(t *testing.T) {
+	m := TuiModel{CurrentView: ViewOutput, PreviousView: ViewServers}
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if out.(TuiModel).CurrentView != ViewServers {
+		t.Fatal("Esc from output must return to the previous view")
+	}
+}
+
+func TestServersNavigation_MovesSelectionAndRetargetsLogs(t *testing.T) {
+	m := TuiModel{CurrentView: ViewServers, Servers: serverList("alpha", "beta"), Selected: 0, MinecraftSource: "alpha"}
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	got := out.(TuiModel)
+	if got.Selected != 1 || got.MinecraftSource != "beta" {
+		t.Fatalf("selection/log source wrong: %+v", got)
+	}
+
+	out, _ = got.Update(tea.KeyMsg{Type: tea.KeyUp})
+	got = out.(TuiModel)
+	if got.Selected != 0 || got.MinecraftSource != "alpha" {
+		t.Fatalf("selection did not move back: %+v", got)
+	}
+}
+
+func TestQuitKeys(t *testing.T) {
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyCtrlC},
+		{Type: tea.KeyRunes, Runes: []rune("q")},
+	} {
+		m := TuiModel{}
+		out, cmd := m.Update(key)
+		if !out.(TuiModel).Quitting || cmd == nil {
+			t.Fatalf("%v must quit", key)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Implements #135. The suite now runs **84 tests** (green under `go test -race`), covering items 1–6 from the issue:

- **Seams**: `githubAPIBase` is now an overridable var (functions build the URLs), and `gracefulStop` takes a one-method `stackRunner` interface — `composeRunner` satisfies it, tests use a recording fake.
- **Pure helpers**: `EffectiveApiKey` precedence, `IsPreReleaseEnabled`/`IsTelemetryEnabled`, `isValidRelativePath`, `parseEnvInt/Bool`, `isPreviewTag`, `getAssetName`, `resolveUninstallMode`.
- **`DotenvRepository.Load`** table tests: missing file, full key mapping, `WEB_ORIGIN_PROD`→`ORIGIN` fallback.
- **`api.Client`**: 401/403 → `ErrApiKeyInvalid`, console-SSE parsing (skips comments/junk frames).
- **compose**: `composeWithConfig` overlays (host/build), env-file wiring, base-args non-mutation; `gracefulStop` force (`stop -t 0`) vs graceful (`stop -t 30`) vs compose-error propagation, with unreachable API degrading to a warning.
- **`fetchBestRelease`**: stable path must hit only `/releases/latest`; prerelease path picks newest from `/releases`; 404/empty → `errNoReleases`; 500 surfaces.
- **TUI transitions**: view switching, server-actions enter/leave (perf-state cleanup), output-view Esc, selection retargeting logs, quit keys.

## Review stack
PR 6 of the #119 stack — based on `refactor/cli-env-consolidation` (#148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)