### PR TITLE
refactor(cli): decompose TUI god-model + unify execution paths (#133)

### DIFF
--- a/tools/mineos-cli/internal/presentation/cli/tui/actions.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/actions.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -11,8 +12,30 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/application/usecases"
 	"github.com/freemancraft/mineos-sveltekit/tools/mineos-cli/internal/infrastructure/env"
 )
+
+// ServerActionCmd runs a server action (start/stop/restart/kill) in-process
+// through the API client — the unified boundary for stateful calls; only
+// process orchestration (stack ops, install/reconfigure/uninstall) shells out.
+func (m TuiModel) ServerActionCmd(name, action string) tea.Cmd {
+	client := m.Client
+	ctx := m.Ctx
+	if client == nil || !m.ConfigReady {
+		return func() tea.Msg {
+			return ServerActionDoneMsg{Server: name, Action: action, Err: errors.New("API not connected")}
+		}
+	}
+	return func() tea.Msg {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		uc := usecases.NewServerActionUseCase(client)
+		err := uc.Execute(ctx, name, action)
+		return ServerActionDoneMsg{Server: name, Action: action, Err: err}
+	}
+}
 
 func (m TuiModel) ConsoleCommandCmd(command string) tea.Cmd {
 	server := m.SelectedServer()

--- a/tools/mineos-cli/internal/presentation/cli/tui/health_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/health_test.go
@@ -26,7 +26,7 @@ func TestUpdate_HealthDataMsgPopulatesModel(t *testing.T) {
 }
 
 func TestUpdate_HealthDataMsgErrorKeepsOldData(t *testing.T) {
-	m := TuiModel{HealthDataLoaded: true, Crashes: []api.CrashEvent{{ServerName: "lobby"}}}
+	m := TuiModel{HealthState: HealthState{HealthDataLoaded: true, Crashes: []api.CrashEvent{{ServerName: "lobby"}}}}
 	out, _ := m.Update(HealthDataMsg{Err: errFake})
 	got := out.(TuiModel)
 	if got.HealthDataErr == "" {

--- a/tools/mineos-cli/internal/presentation/cli/tui/input.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/input.go
@@ -343,30 +343,20 @@ func (m TuiModel) executeServerAction() (tea.Model, tea.Cmd) {
 		return m, textinput.Blink
 	}
 
-	// Handle destructive actions
+	// Destructive server actions confirm first, then run in-process.
 	if action.Destructive {
-		menuItem := &MenuItem{
-			Label:       action.Label,
-			Args:        []string{"servers", serverName, action.Action},
-			Destructive: true,
-		}
-		m.ConfirmAction = menuItem
+		m.ConfirmServerName = serverName
+		m.ConfirmServerAction = action.Action
+		m.ConfirmAction = nil
 		m.ConfirmMessage = "This action may cause data loss. Continue?"
 		m.Mode = ModeConfirm
 		return m, nil
 	}
 
-	// Execute the server action
-	m.PreviousView = m.CurrentView
-	m.CurrentView = ViewOutput
-	m.OutputTitle = action.Label + ": " + serverName
-	m.OutputLines = []string{"Executing " + action.Label + " on " + serverName + "..."}
-
-	menuItem := MenuItem{
-		Label: action.Label,
-		Args:  []string{"servers", serverName, action.Action},
-	}
-	return m, m.ExecMenuItem(menuItem)
+	// Server actions run in-process through the API — no subprocess, no
+	// output-view detour. The status line and server list reflect the result.
+	m.StatusMsg = action.Label + ": " + serverName + "..."
+	return m, m.ServerActionCmd(serverName, action.Action)
 }
 
 // navBack handles Esc key - goes back to previous view or exits
@@ -486,55 +476,59 @@ func (m TuiModel) HandleInteractiveInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m TuiModel) HandleConfirmInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.Type {
 	case tea.KeyEsc:
-		m.Mode = ModeNormal
-		m.ConfirmAction = nil
-		m.ConfirmMessage = ""
-		return m, nil
-
+		return m.confirmCancel()
 	case tea.KeyEnter:
-		if m.ConfirmAction != nil {
-			action := m.ConfirmAction
-			m.Mode = ModeNormal
-			m.ConfirmAction = nil
-			m.ConfirmMessage = ""
-
-			// Switch to output view for all commands
-			m.PreviousView = m.CurrentView
-			m.CurrentView = ViewOutput
-			m.OutputTitle = action.Label
-			m.OutputLines = []string{"Executing " + action.Label + "..."}
-
-			return m, m.ExecMenuItem(*action)
-		}
-		m.Mode = ModeNormal
-		return m, nil
+		return m.confirmAccept()
 	}
 
 	switch msg.String() {
 	case "y", "Y":
-		if m.ConfirmAction != nil {
-			action := m.ConfirmAction
-			m.Mode = ModeNormal
-			m.ConfirmAction = nil
-			m.ConfirmMessage = ""
-
-			// Switch to output view for all commands
-			m.PreviousView = m.CurrentView
-			m.CurrentView = ViewOutput
-			m.OutputTitle = action.Label
-			m.OutputLines = []string{"Executing " + action.Label + "..."}
-
-			return m, m.ExecMenuItem(*action)
-		}
-		return m, nil
-
+		return m.confirmAccept()
 	case "n", "N":
-		m.Mode = ModeNormal
-		m.ConfirmAction = nil
-		m.ConfirmMessage = ""
-		return m, nil
+		return m.confirmCancel()
 	}
 
+	return m, nil
+}
+
+// clearConfirm resets all pending-confirmation state.
+func (m *TuiModel) clearConfirm() {
+	m.Mode = ModeNormal
+	m.ConfirmAction = nil
+	m.ConfirmMessage = ""
+	m.ConfirmServerName = ""
+	m.ConfirmServerAction = ""
+}
+
+func (m TuiModel) confirmCancel() (tea.Model, tea.Cmd) {
+	m.clearConfirm()
+	return m, nil
+}
+
+// confirmAccept executes whichever pending action was confirmed: an
+// in-process server action, or a subprocess command shown in the output view.
+func (m TuiModel) confirmAccept() (tea.Model, tea.Cmd) {
+	if m.ConfirmServerAction != "" {
+		name, action := m.ConfirmServerName, m.ConfirmServerAction
+		m.clearConfirm()
+		m.StatusMsg = action + ": " + name + "..."
+		return m, m.ServerActionCmd(name, action)
+	}
+
+	if m.ConfirmAction != nil {
+		action := m.ConfirmAction
+		m.clearConfirm()
+
+		// Switch to output view for subprocess commands
+		m.PreviousView = m.CurrentView
+		m.CurrentView = ViewOutput
+		m.OutputTitle = action.Label
+		m.OutputLines = []string{"Executing " + action.Label + "..."}
+
+		return m, m.ExecMenuItem(*action)
+	}
+
+	m.clearConfirm()
 	return m, nil
 }
 

--- a/tools/mineos-cli/internal/presentation/cli/tui/logs_retry_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/logs_retry_test.go
@@ -10,7 +10,7 @@ func TestListenLogs_BatchesBufferedLines(t *testing.T) {
 	for _, l := range []string{"a", "b", "c"} {
 		logs <- l
 	}
-	m := TuiModel{LogsChan: logs, LogErrsChan: errs}
+	m := TuiModel{LogState: LogState{LogsChan: logs, LogErrsChan: errs}}
 
 	msg := m.ListenLogsCmd()()
 	batch, ok := msg.(LogLinesMsg)
@@ -26,7 +26,7 @@ func TestListenLogs_ClosedChannelSignalsClose(t *testing.T) {
 	logs := make(chan string)
 	errs := make(chan error, 1)
 	close(logs)
-	m := TuiModel{LogsChan: logs, LogErrsChan: errs}
+	m := TuiModel{LogState: LogState{LogsChan: logs, LogErrsChan: errs}}
 
 	if _, ok := m.ListenLogsCmd()().(LogStreamClosedMsg); !ok {
 		t.Fatal("closed channel must yield LogStreamClosedMsg")
@@ -38,7 +38,7 @@ func TestListenLogs_CloseDuringDrainDeliversCollectedLines(t *testing.T) {
 	errs := make(chan error, 1)
 	logs <- "last"
 	close(logs)
-	m := TuiModel{LogsChan: logs, LogErrsChan: errs}
+	m := TuiModel{LogState: LogState{LogsChan: logs, LogErrsChan: errs}}
 
 	msg := m.ListenLogsCmd()()
 	batch, ok := msg.(LogLinesMsg)
@@ -56,7 +56,7 @@ func TestListenLogs_CloseDuringDrainDeliversCollectedLines(t *testing.T) {
 }
 
 func TestUpdate_CleanCloseRetriesWithDelayAndCap(t *testing.T) {
-	m := TuiModel{LogsActive: true}
+	m := TuiModel{LogState: LogState{LogsActive: true}}
 
 	// First MaxLogRetries closes schedule a delayed retry.
 	for i := 0; i < MaxLogRetries; i++ {
@@ -90,9 +90,9 @@ func TestUpdate_CleanCloseRetriesWithDelayAndCap(t *testing.T) {
 
 func TestUpdate_CleanCloseDoesNotRetryWhenStopped(t *testing.T) {
 	for _, m := range []TuiModel{
-		{LogsActive: true, ContainersStopped: true},
-		{LogsActive: false},
-		{LogsActive: true, Quitting: true},
+		{LogState: LogState{LogsActive: true}, ConnectionState: ConnectionState{ContainersStopped: true}},
+		{LogState: LogState{LogsActive: false}},
+		{LogState: LogState{LogsActive: true}, Quitting: true},
 	} {
 		if _, cmd := m.Update(LogStreamClosedMsg{}); cmd != nil {
 			t.Fatalf("no retry expected for %+v", m)

--- a/tools/mineos-cli/internal/presentation/cli/tui/model.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/model.go
@@ -134,9 +134,13 @@ type TuiModel struct {
 	Input    textinput.Model
 	Quitting bool
 
-	// Confirmation dialog state
-	ConfirmAction  *MenuItem
-	ConfirmMessage string
+	// Confirmation dialog state. ConfirmAction is a pending subprocess command
+	// (stack ops); ConfirmServerName/Action is a pending in-process server
+	// action (kill) — exactly one is set while confirming.
+	ConfirmAction       *MenuItem
+	ConfirmMessage      string
+	ConfirmServerName   string
+	ConfirmServerAction string
 
 	// Interactive command state
 	InteractiveStdin   io.WriteCloser
@@ -251,6 +255,13 @@ type LogErrorMsg struct {
 
 // LogRetryMsg is sent to trigger log stream retry
 type LogRetryMsg struct{}
+
+// ServerActionDoneMsg reports an in-process server action (start/stop/restart/kill)
+type ServerActionDoneMsg struct {
+	Server string
+	Action string
+	Err    error
+}
 
 // ActionResultMsg is sent when an action completes
 type ActionResultMsg struct {

--- a/tools/mineos-cli/internal/presentation/cli/tui/model.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/model.go
@@ -62,17 +62,8 @@ type NavItem struct {
 	Destructive bool
 }
 
-// TuiModel is the main model for the TUI application
-type TuiModel struct {
-	LoadConfig *usecases.LoadConfigUseCase
-	Ctx        context.Context
-
-	// Version is the mineos-cli version (usually from the git tag at build time).
-	Version string
-
-	Width  int
-	Height int
-
+// ConnectionState holds API/compose connectivity and configuration.
+type ConnectionState struct {
 	Client *api.Client
 	Cfg    config.Config
 
@@ -83,12 +74,21 @@ type TuiModel struct {
 	ComposeError    string
 	ComposeServices []string
 
-	Servers       []ports.Server
-	Selected      int  // Selected server in servers view
-	ServerActions bool // Whether we're in server actions mode
-	ActionIndex   int  // Selected action in server actions
+	ContainersStopped bool // True when user intentionally stopped containers
+	RetryCount        int  // Config-load retry state
+}
 
-	// Log state
+// ServerListState holds the servers table and its selection.
+type ServerListState struct {
+	Servers           []ports.Server
+	Selected          int  // Selected server in servers view
+	ServerActions     bool // Whether we're in server actions mode
+	ActionIndex       int  // Selected action in server actions
+	ServersLoadedOnce bool // Distinguishes "still loading" from "genuinely empty"
+}
+
+// LogState holds both log subsystems (docker + minecraft) and log-view UI state.
+type LogState struct {
 	Logs            []string
 	LogsActive      bool
 	LogType         LogType
@@ -99,7 +99,14 @@ type TuiModel struct {
 	LogErrsChan     <-chan error
 	LogCancel       context.CancelFunc
 
-	// Live per-server performance stream (server-actions view)
+	LogScroll      int    // Scroll offset for logs view
+	LogSearchQuery string // Search query for logs
+	LogSearchMode  bool   // Whether in search mode
+	LogRetries     int    // Consecutive clean-close reconnects without data (resets on receipt)
+}
+
+// PerfState holds the live per-server performance stream and its history buffer.
+type PerfState struct {
 	PerfSample *api.PerfSample
 	PerfChan   <-chan api.PerfSample
 	PerfErrs   <-chan error
@@ -109,76 +116,97 @@ type TuiModel struct {
 	// Sample history backing the sparkline: history-endpoint backfill plus
 	// live samples appended as they stream in. Cleared with the stream.
 	PerfHistory []api.PerfSample
+}
 
-	LogScroll      int    // Scroll offset for logs view
-	LogSearchQuery string // Search query for logs
-	LogSearchMode  bool   // Whether in search mode
-	LogRetries     int    // Consecutive clean-close reconnects without data (resets on receipt)
+// HealthState holds the watchdog/crash/alert roll-up for the health view.
+type HealthState struct {
+	Watchdog         map[string]api.WatchdogServerStatus
+	Crashes          []api.CrashEvent
+	Alerts           []api.Notification
+	HealthDataLoaded bool   // First fetch completed (distinguishes loading from empty)
+	HealthDataErr    string // Last fetch error, if any
+}
 
-	StatusMsg string
-	ErrMsg    string
+// OutputState holds the output view plus streaming/interactive subprocess state.
+type OutputState struct {
+	OutputLines []string
+	OutputTitle string
 
-	// Navigation
+	StreamingOutput  <-chan string
+	StreamingRunning bool
+	StreamingLabel   string
+	StreamingEffect  ContainerEffect
+
+	InteractiveStdin   io.WriteCloser
+	InteractiveOutput  <-chan string
+	InteractiveRunning bool
+}
+
+// NavState holds the sidebar menu and current/previous view.
+type NavState struct {
 	NavItems  []NavItem // Full navigation menu
 	NavIndex  int       // Currently selected nav item
 	NavScroll int       // Scroll offset for nav menu
 
 	CurrentView  TuiView
 	PreviousView TuiView
+}
 
-	// Command output display
-	OutputLines []string
-	OutputTitle string
+// DialogState holds modal state: input mode, text input, confirmations, help.
+type DialogState struct {
+	Mode  TuiMode
+	Input textinput.Model
 
-	Mode     TuiMode
-	Input    textinput.Model
-	Quitting bool
-
-	// Confirmation dialog state. ConfirmAction is a pending subprocess command
-	// (stack ops); ConfirmServerName/Action is a pending in-process server
-	// action (kill) — exactly one is set while confirming.
+	// ConfirmAction is a pending subprocess command (stack ops);
+	// ConfirmServerName/Action is a pending in-process server action (kill) —
+	// exactly one is set while confirming.
 	ConfirmAction       *MenuItem
 	ConfirmMessage      string
 	ConfirmServerName   string
 	ConfirmServerAction string
 
-	// Interactive command state
-	InteractiveStdin   io.WriteCloser
-	InteractiveOutput  <-chan string
-	InteractiveRunning bool
+	ShowHelp bool // Help overlay visibility (toggled with '?')
+}
 
-	// Streaming command state (output-only, no input)
-	StreamingOutput  <-chan string
-	StreamingRunning bool
-	StreamingLabel   string
-	StreamingEffect  ContainerEffect
-
-	// Spinner shown while work is in flight (connecting, streaming, interactive)
-	Spinner spinner.Model
-
-	// Help overlay visibility (toggled with '?')
-	ShowHelp bool
-
-	// ServersLoadedOnce distinguishes "still loading" from "genuinely empty"
-	ServersLoadedOnce bool
+// StatusState holds the transient status/error lines and their TTL bookkeeping.
+type StatusState struct {
+	StatusMsg string
+	ErrMsg    string
 
 	// Last status/error seen by the TTL sweep: a message that survives one full
 	// poll interval unchanged is cleared (persistent conditions re-set theirs).
 	StatusSeenAtTick string
 	ErrSeenAtTick    string
+}
 
-	// Health & alert roll-up (health view; refreshed on the health tick)
-	Watchdog         map[string]api.WatchdogServerStatus
-	Crashes          []api.CrashEvent
-	Alerts           []api.Notification
-	HealthDataLoaded bool   // First fetch completed (distinguishes loading from empty)
-	HealthDataErr    string // Last fetch error, if any
+// TuiModel is the main model for the TUI application. State is grouped into
+// embedded sub-models per domain; Go field promotion keeps accessors flat
+// (m.Servers, m.CurrentView, ...), while each group can be reasoned about —
+// and reset — as a unit.
+type TuiModel struct {
+	LoadConfig *usecases.LoadConfigUseCase
+	Ctx        context.Context
 
-	// Retry state for error recovery
-	RetryCount int
+	// Version is the mineos-cli version (usually from the git tag at build time).
+	Version string
 
-	// Container state tracking
-	ContainersStopped bool // True when user intentionally stopped containers
+	Width  int
+	Height int
+
+	ConnectionState
+	ServerListState
+	LogState
+	PerfState
+	HealthState
+	OutputState
+	NavState
+	DialogState
+	StatusState
+
+	// Spinner shown while work is in flight (connecting, streaming, interactive)
+	Spinner spinner.Model
+
+	Quitting bool
 }
 
 // ContainerEffect declares how a finished command changed container state,

--- a/tools/mineos-cli/internal/presentation/cli/tui/server_actions_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/server_actions_test.go
@@ -1,0 +1,108 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func actionIndexOf(t *testing.T, action string) int {
+	t.Helper()
+	for i, a := range GetServerActions() {
+		if a.Action == action {
+			return i
+		}
+	}
+	t.Fatalf("action %q not found", action)
+	return -1
+}
+
+func serversActionModel(action string, t *testing.T) TuiModel {
+	return TuiModel{
+		CurrentView:   ViewServers,
+		Servers:       serverList("lobby"),
+		ServerActions: true,
+		ActionIndex:   actionIndexOf(t, action),
+	}
+}
+
+func TestServerAction_RunsInProcessWithoutOutputView(t *testing.T) {
+	m := serversActionModel("start", t)
+	out, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := out.(TuiModel)
+
+	if got.CurrentView != ViewServers {
+		t.Fatal("server actions must not detour through the output view")
+	}
+	if cmd == nil {
+		t.Fatal("expected an in-process action command")
+	}
+	if got.StatusMsg == "" {
+		t.Fatal("dispatch must set a status line")
+	}
+
+	// With no client connected the command reports a clean error message.
+	msg := cmd()
+	done, ok := msg.(ServerActionDoneMsg)
+	if !ok {
+		t.Fatalf("want ServerActionDoneMsg, got %T", msg)
+	}
+	if done.Server != "lobby" || done.Action != "start" || done.Err == nil {
+		t.Fatalf("unexpected result: %+v", done)
+	}
+}
+
+func TestServerAction_KillRequiresConfirmThenRunsInProcess(t *testing.T) {
+	m := serversActionModel("kill", t)
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := out.(TuiModel)
+
+	if got.Mode != ModeConfirm || got.ConfirmServerAction != "kill" || got.ConfirmServerName != "lobby" {
+		t.Fatalf("kill must confirm first: %+v", got)
+	}
+	if got.ConfirmAction != nil {
+		t.Fatal("in-process confirmation must not carry a subprocess MenuItem")
+	}
+
+	// Confirming dispatches the in-process action and clears confirm state.
+	out, cmd := got.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	got = out.(TuiModel)
+	if cmd == nil {
+		t.Fatal("confirm must dispatch the action")
+	}
+	if got.Mode != ModeNormal || got.ConfirmServerAction != "" {
+		t.Fatal("confirm state must be cleared")
+	}
+	if done, ok := cmd().(ServerActionDoneMsg); !ok || done.Action != "kill" {
+		t.Fatalf("expected in-process kill, got %v", cmd())
+	}
+}
+
+func TestServerAction_ConfirmCancelClearsState(t *testing.T) {
+	m := serversActionModel("kill", t)
+	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := out.(TuiModel)
+
+	out, cmd := got.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	got = out.(TuiModel)
+	if cmd != nil || got.Mode != ModeNormal || got.ConfirmServerAction != "" || got.ConfirmServerName != "" {
+		t.Fatalf("cancel must clear pending action: %+v", got)
+	}
+}
+
+func TestUpdate_ServerActionDone(t *testing.T) {
+	m := TuiModel{}
+	out, cmd := m.Update(ServerActionDoneMsg{Server: "lobby", Action: "start"})
+	got := out.(TuiModel)
+	if got.StatusMsg == "" || got.ErrMsg != "" {
+		t.Fatalf("success must set status: %+v", got)
+	}
+	if cmd == nil {
+		t.Fatal("completion must refresh the server list")
+	}
+
+	out, _ = m.Update(ServerActionDoneMsg{Server: "lobby", Action: "stop", Err: errFake})
+	if out.(TuiModel).ErrMsg == "" {
+		t.Fatal("failure must surface the error")
+	}
+}

--- a/tools/mineos-cli/internal/presentation/cli/tui/server_actions_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/server_actions_test.go
@@ -18,12 +18,7 @@ func actionIndexOf(t *testing.T, action string) int {
 }
 
 func serversActionModel(action string, t *testing.T) TuiModel {
-	return TuiModel{
-		CurrentView:   ViewServers,
-		Servers:       serverList("lobby"),
-		ServerActions: true,
-		ActionIndex:   actionIndexOf(t, action),
-	}
+	return TuiModel{ServerListState: ServerListState{Servers: serverList("lobby"), ServerActions: true, ActionIndex: actionIndexOf(t, action)}, NavState: NavState{CurrentView: ViewServers}}
 }
 
 func TestServerAction_RunsInProcessWithoutOutputView(t *testing.T) {

--- a/tools/mineos-cli/internal/presentation/cli/tui/sparkline_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/sparkline_test.go
@@ -56,10 +56,7 @@ func TestSeriesStats(t *testing.T) {
 
 func TestUpdate_PerfHistoryBackfillsAndGuardsServer(t *testing.T) {
 	tps := 19.5
-	m := TuiModel{
-		Servers:  serverList("lobby"),
-		Selected: 0,
-	}
+	m := TuiModel{ServerListState: ServerListState{Servers: serverList("lobby"), Selected: 0}}
 	// Live sample arrived first
 	out, _ := m.Update(PerfSampleMsg{Sample: api.PerfSample{CpuPercent: 50}})
 	m = out.(TuiModel)
@@ -90,7 +87,7 @@ func TestAppendCapped_DropsOldest(t *testing.T) {
 }
 
 func TestRenderSparklines_NeedsTwoSamples(t *testing.T) {
-	m := TuiModel{PerfHistory: []api.PerfSample{{CpuPercent: 10}}}
+	m := TuiModel{PerfState: PerfState{PerfHistory: []api.PerfSample{{CpuPercent: 10}}}}
 	if lines := m.renderSparklines(); lines != nil {
 		t.Fatal("one sample must not render a sparkline")
 	}

--- a/tools/mineos-cli/internal/presentation/cli/tui/transitions_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/transitions_test.go
@@ -19,7 +19,7 @@ func navIndexOf(t *testing.T, items []NavItem, label string) int {
 
 func TestNavSelect_SwitchesToView(t *testing.T) {
 	items := BuildNavItems()
-	m := TuiModel{NavItems: items, CurrentView: ViewDashboard}
+	m := TuiModel{NavState: NavState{NavItems: items, CurrentView: ViewDashboard}}
 	m.NavIndex = navIndexOf(t, items, "Health & Alerts")
 
 	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
@@ -33,7 +33,7 @@ func TestNavSelect_SwitchesToView(t *testing.T) {
 }
 
 func TestNavSelect_EnterOnServerOpensActions(t *testing.T) {
-	m := TuiModel{CurrentView: ViewServers, Servers: serverList("lobby", "survival"), Selected: 1}
+	m := TuiModel{ServerListState: ServerListState{Servers: serverList("lobby", "survival"), Selected: 1}, NavState: NavState{CurrentView: ViewServers}}
 	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	got := out.(TuiModel)
 	if !got.ServerActions || got.ActionIndex != 0 {
@@ -42,13 +42,7 @@ func TestNavSelect_EnterOnServerOpensActions(t *testing.T) {
 }
 
 func TestNavBack_LeavesServerActionsAndClearsPerfState(t *testing.T) {
-	m := TuiModel{
-		CurrentView:   ViewServers,
-		Servers:       serverList("lobby"),
-		ServerActions: true,
-		ActionIndex:   2,
-		PerfServer:    "lobby",
-	}
+	m := TuiModel{ServerListState: ServerListState{Servers: serverList("lobby"), ServerActions: true, ActionIndex: 2}, PerfState: PerfState{PerfServer: "lobby"}, NavState: NavState{CurrentView: ViewServers}}
 	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	got := out.(TuiModel)
 	if got.ServerActions || got.ActionIndex != 0 {
@@ -60,7 +54,7 @@ func TestNavBack_LeavesServerActionsAndClearsPerfState(t *testing.T) {
 }
 
 func TestNavBack_OutputReturnsToPreviousView(t *testing.T) {
-	m := TuiModel{CurrentView: ViewOutput, PreviousView: ViewServers}
+	m := TuiModel{NavState: NavState{CurrentView: ViewOutput, PreviousView: ViewServers}}
 	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	if out.(TuiModel).CurrentView != ViewServers {
 		t.Fatal("Esc from output must return to the previous view")
@@ -68,7 +62,7 @@ func TestNavBack_OutputReturnsToPreviousView(t *testing.T) {
 }
 
 func TestServersNavigation_MovesSelectionAndRetargetsLogs(t *testing.T) {
-	m := TuiModel{CurrentView: ViewServers, Servers: serverList("alpha", "beta"), Selected: 0, MinecraftSource: "alpha"}
+	m := TuiModel{ServerListState: ServerListState{Servers: serverList("alpha", "beta"), Selected: 0}, LogState: LogState{MinecraftSource: "alpha"}, NavState: NavState{CurrentView: ViewServers}}
 	out, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
 	got := out.(TuiModel)
 	if got.Selected != 1 || got.MinecraftSource != "beta" {

--- a/tools/mineos-cli/internal/presentation/cli/tui/update.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/update.go
@@ -29,19 +29,25 @@ func NewTuiModel(loadConfig *usecases.LoadConfigUseCase, ctx context.Context, ve
 	navItems := BuildNavItems()
 
 	return TuiModel{
-		Spinner: spin,
-		LoadConfig:    loadConfig,
-		Ctx:           ctx,
-		Version:       version,
-		LogsActive:    true,
-		LogType:       LogTypeDocker,
-		LogSource:     DefaultDockerLogSource,
-		MinecraftType: "combined",
-		Mode:          ModeNormal,
-		CurrentView:   ViewDashboard,
-		Input:         input,
-		NavItems:      navItems,
-		NavIndex:      FirstSelectableIndex(navItems),
+		Spinner:    spin,
+		LoadConfig: loadConfig,
+		Ctx:        ctx,
+		Version:    version,
+		LogState: LogState{
+			LogsActive:    true,
+			LogType:       LogTypeDocker,
+			LogSource:     DefaultDockerLogSource,
+			MinecraftType: "combined",
+		},
+		DialogState: DialogState{
+			Mode:  ModeNormal,
+			Input: input,
+		},
+		NavState: NavState{
+			CurrentView: ViewDashboard,
+			NavItems:    navItems,
+			NavIndex:    FirstSelectableIndex(navItems),
+		},
 	}
 }
 

--- a/tools/mineos-cli/internal/presentation/cli/tui/update.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/update.go
@@ -176,6 +176,15 @@ func (m TuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case LogRetryMsg:
 		return m, m.StartLogStreamCmd()
 
+	case ServerActionDoneMsg:
+		if msg.Err != nil {
+			m.ErrMsg = msg.Action + " " + msg.Server + ": " + msg.Err.Error()
+		} else {
+			m.StatusMsg = msg.Action + " " + msg.Server + ": done"
+			m.ErrMsg = ""
+		}
+		return m, m.LoadServersCmd()
+
 	case ActionResultMsg:
 		return m.handleActionResult(msg)
 

--- a/tools/mineos-cli/internal/presentation/cli/tui/update_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/update_test.go
@@ -17,7 +17,7 @@ func TestUpdate_HealthCheckedSetsHealthy(t *testing.T) {
 
 // The refresh loop must keep re-arming (non-nil cmd) and stopped != healthy.
 func TestUpdate_HealthTickReschedulesAndStoppedIsUnhealthy(t *testing.T) {
-	m := TuiModel{ContainersStopped: true, Healthy: true}
+	m := TuiModel{ConnectionState: ConnectionState{ContainersStopped: true, Healthy: true}}
 	out, cmd := m.Update(HealthTickMsg{})
 	if out.(TuiModel).Healthy {
 		t.Fatal("stopped containers must not report healthy")
@@ -29,7 +29,7 @@ func TestUpdate_HealthTickReschedulesAndStoppedIsUnhealthy(t *testing.T) {
 
 // While ready, a tick issues refresh work (and still re-arms).
 func TestUpdate_HealthTickWhileReadyRefreshes(t *testing.T) {
-	m := TuiModel{ConfigReady: true}
+	m := TuiModel{ConnectionState: ConnectionState{ConfigReady: true}}
 	_, cmd := m.Update(HealthTickMsg{})
 	if cmd == nil {
 		t.Fatal("expected refresh commands while ready")

--- a/tools/mineos-cli/internal/presentation/cli/tui/ux_test.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/ux_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUpdate_StatusAndErrTTLSweep(t *testing.T) {
-	m := TuiModel{StatusMsg: "Restart complete", ErrMsg: "boom", ConfigReady: true}
+	m := TuiModel{ConnectionState: ConnectionState{ConfigReady: true}, StatusState: StatusState{StatusMsg: "Restart complete", ErrMsg: "boom"}}
 
 	// First tick: messages survive (just seen).
 	out, _ := m.Update(HealthTickMsg{})
@@ -26,7 +26,7 @@ func TestUpdate_StatusAndErrTTLSweep(t *testing.T) {
 }
 
 func TestUpdate_TTLSweepKeepsRefreshedMessages(t *testing.T) {
-	m := TuiModel{ErrMsg: "invalid API key", ConfigReady: true}
+	m := TuiModel{ConnectionState: ConnectionState{ConfigReady: true}, StatusState: StatusState{ErrMsg: "invalid API key"}}
 	out, _ := m.Update(HealthTickMsg{})
 	m = out.(TuiModel)
 
@@ -41,7 +41,7 @@ func TestUpdate_TTLSweepKeepsRefreshedMessages(t *testing.T) {
 
 func TestUpdate_StreamingFinishedUsesDeclaredEffect(t *testing.T) {
 	// A stop effect marks containers stopped regardless of label wording.
-	m := TuiModel{ConfigReady: true, Servers: serverList("lobby")}
+	m := TuiModel{ConnectionState: ConnectionState{ConfigReady: true}, ServerListState: ServerListState{Servers: serverList("lobby")}}
 	out, _ := m.Update(StreamingFinishedMsg{Label: "Anything", Effect: EffectStopsContainers})
 	got := out.(TuiModel)
 	if !got.ContainersStopped || got.ConfigReady || got.Servers != nil {
@@ -55,7 +55,7 @@ func TestUpdate_StreamingFinishedUsesDeclaredEffect(t *testing.T) {
 	}
 
 	// A failed command applies no effect.
-	m = TuiModel{ConfigReady: true}
+	m = TuiModel{ConnectionState: ConnectionState{ConfigReady: true}}
 	out, _ = m.Update(StreamingFinishedMsg{Effect: EffectStopsContainers, Err: errFake})
 	if out.(TuiModel).ContainersStopped {
 		t.Fatal("a failed command must not change container state")
@@ -107,25 +107,25 @@ func TestRenderServersTable_DistinguishesStates(t *testing.T) {
 	}
 
 	// Connected, list not loaded yet
-	m = TuiModel{ConfigReady: true}
+	m = TuiModel{ConnectionState: ConnectionState{ConfigReady: true}}
 	if !containsLine(m.RenderServersTable(width, height), "Loading servers") {
 		t.Fatal("expected loading state")
 	}
 
 	// Unreachable (error set)
-	m = TuiModel{ConfigReady: true, ErrMsg: "connection refused"}
+	m = TuiModel{ConnectionState: ConnectionState{ConfigReady: true}, StatusState: StatusState{ErrMsg: "connection refused"}}
 	if !containsLine(m.RenderServersTable(width, height), "Server list unavailable") {
 		t.Fatal("expected unavailable state")
 	}
 
 	// Containers intentionally stopped
-	m = TuiModel{ContainersStopped: true}
+	m = TuiModel{ConnectionState: ConnectionState{ContainersStopped: true}}
 	if !containsLine(m.RenderServersTable(width, height), "Containers are stopped") {
 		t.Fatal("expected stopped state")
 	}
 
 	// Genuinely empty
-	m = TuiModel{ConfigReady: true, ServersLoadedOnce: true}
+	m = TuiModel{ConnectionState: ConnectionState{ConfigReady: true}, ServerListState: ServerListState{ServersLoadedOnce: true}}
 	if !containsLine(m.RenderServersTable(width, height), "No servers found") {
 		t.Fatal("expected empty state")
 	}

--- a/tools/mineos-cli/internal/presentation/cli/tui/view.go
+++ b/tools/mineos-cli/internal/presentation/cli/tui/view.go
@@ -261,8 +261,14 @@ func (m TuiModel) RenderConfirmDialog(width, height int) []string {
 	lines = append(lines, StyleError.Render("  │"+strings.Repeat(" ", boxWidth)+"│"))
 
 	// Action name
+	actionLabel := ""
 	if m.ConfirmAction != nil {
-		actionLine := centerText(m.ConfirmAction.Label, boxWidth)
+		actionLabel = m.ConfirmAction.Label
+	} else if m.ConfirmServerAction != "" {
+		actionLabel = m.ConfirmServerAction + " " + m.ConfirmServerName
+	}
+	if actionLabel != "" {
+		actionLine := centerText(actionLabel, boxWidth)
 		lines = append(lines, StyleError.Render("  │")+StyleSelected.Render(actionLine)+StyleError.Render("│"))
 	}
 


### PR DESCRIPTION
## Summary
Implements the two halves of #133 in two commits:

**1. Unified execution boundary** — server start/stop/restart/kill now run **in-process** through `ServerActionUseCase` (a `tea.Cmd` returning `ServerActionDoneMsg`) instead of re-exec'ing the mineos binary and detouring through the output view; the status line + live-refreshed table show the result. Kill still confirms, via new in-process confirmation state; the confirm dialog's triplicated accept logic is deduplicated into `confirmAccept`/`confirmCancel`. Subprocesses remain only for streaming stack ops and truly-interactive commands (install/reconfigure/uninstall) — exactly the boundary the issue proposed.

**2. God-model decomposed** — the ~40 flat fields are grouped into embedded sub-structs (`ConnectionState`, `ServerListState`, `LogState`, `PerfState`, `HealthState`, `OutputState`, `NavState`, `DialogState`, `StatusState`). Field promotion keeps all accessors flat, so handlers/views are untouched — only composite literals changed. Each domain's state + invariants now live in one block.

**Scope note**: this delivers grouped state + a single execution boundary; it deliberately stops short of giving every sub-model its own `Update`/`View` dispatch (the per-domain files already own their handlers). If you want the full nested-dispatch rewrite, say the word and I'll stack it — I kept the final PR of the night reviewable instead.

## Review stack
PR 7 (last) of the #119 stack — based on `test/cli-test-wave` (#149). The 84-test wave below it was the safety net for this refactor.

## Testing
`go build ./... && go vet ./... && go test -race ./...` green (90+ tests), including new tests: in-process dispatch without output-view detour, kill confirm→dispatch→state-cleared, confirm cancel, done-msg success/error handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)