### PR TITLE
feat(users): admin ability to rename users (#47)

### DIFF
--- a/apps/MineOS.Api/Endpoints/AuthEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/AuthEndpoints.cs
@@ -131,6 +131,10 @@ public static class AuthEndpoints
             {
                 return Results.NotFound(new { error = ex.Message });
             }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Conflict(new { error = ex.Message });
+            }
         }).RequireAuthorization(new AuthorizeAttribute { Roles = "admin" });
 
         auth.MapDelete("/users/{id:int}", async (

--- a/apps/MineOS.Application/Dtos/UserDtos.cs
+++ b/apps/MineOS.Application/Dtos/UserDtos.cs
@@ -22,7 +22,8 @@ public record UpdateUserRequestDto(
     string? Role,
     bool? IsActive,
     string? MinecraftUsername,
-    IReadOnlyList<ServerAccessRequestDto>? ServerAccesses);
+    IReadOnlyList<ServerAccessRequestDto>? ServerAccesses,
+    string? Username = null);
 
 public record UpdateSelfRequestDto(string? Username, string? Password);
 

--- a/apps/MineOS.Infrastructure/Services/UserService.cs
+++ b/apps/MineOS.Infrastructure/Services/UserService.cs
@@ -105,6 +105,29 @@ public sealed class UserService : IUserService
             throw new ArgumentException("User not found");
         }
 
+        if (!string.IsNullOrWhiteSpace(request.Username))
+        {
+            var normalized = request.Username.Trim();
+            if (!string.Equals(user.Username, normalized, StringComparison.Ordinal))
+            {
+                // Only a rename to a *different* name (beyond casing) can collide.
+                if (!string.Equals(user.Username, normalized, StringComparison.OrdinalIgnoreCase))
+                {
+                    var exists = await _db.Users.AnyAsync(
+                        u => u.Username.ToLower() == normalized.ToLower() && u.Id != id,
+                        cancellationToken);
+
+                    if (exists)
+                    {
+                        throw new InvalidOperationException("Username already exists");
+                    }
+                }
+
+                _logger.LogInformation("Renaming user {OldUsername} to {NewUsername}", user.Username, normalized);
+                user.Username = normalized;
+            }
+        }
+
         if (request.MinecraftUsername != null)
         {
             var minecraftLink = await ResolveMinecraftProfileAsync(request.MinecraftUsername, cancellationToken);

--- a/apps/web/src/routes/(app)/admin/access/+page.svelte
+++ b/apps/web/src/routes/(app)/admin/access/+page.svelte
@@ -38,6 +38,7 @@
 
 	let editingUser = $state<User | null>(null);
 	let editPassword = $state('');
+	let editUsername = $state('');
 	let editRole = $state('');
 	let editActive = $state(true);
 	let editMinecraftUsername = $state('');
@@ -110,6 +111,7 @@
 
 	function startEdit(user: User) {
 		editingUser = user;
+		editUsername = user.username;
 		editPassword = '';
 		editRole = user.role;
 		editActive = user.isActive;
@@ -119,6 +121,7 @@
 
 	function cancelEdit() {
 		editingUser = null;
+		editUsername = '';
 		editPassword = '';
 		editRole = '';
 		editActive = true;
@@ -132,6 +135,7 @@
 		saving = true;
 		try {
 			const payload: {
+				username?: string;
 				password?: string;
 				role?: string;
 				isActive?: boolean;
@@ -139,6 +143,10 @@
 				serverAccesses?: ServerAccess[];
 			} = {};
 
+			const trimmedUsername = editUsername.trim();
+			if (trimmedUsername && trimmedUsername !== editingUser.username) {
+				payload.username = trimmedUsername;
+			}
 			if (editPassword.trim()) {
 				payload.password = editPassword.trim();
 			}
@@ -314,6 +322,15 @@
 									<span class="edit-badge">Editing</span>
 								</div>
 
+								<label>
+									<span class="label-text">Username</span>
+									<input
+										type="text"
+										bind:value={editUsername}
+										placeholder="Username"
+										autocomplete="off"
+									/>
+								</label>
 								<label>
 									<span class="label-text">New Password</span>
 									<input

--- a/test/MineOS.Tests/UserServiceTests.cs
+++ b/test/MineOS.Tests/UserServiceTests.cs
@@ -54,6 +54,83 @@ public sealed class UserServiceTests
         Assert.True(updated.ServerAccesses[0].CanView);
     }
 
+    [Fact]
+    public async Task UpdateUserAsync_RenamesUser()
+    {
+        await using var db = await CreateDbContextAsync();
+        var service = CreateUserService(db, new FakeMojangApiService());
+
+        var created = await service.CreateUserAsync(
+            new CreateUserRequestDto("oldname", "password", "user", null, null),
+            CancellationToken.None);
+
+        var updated = await service.UpdateUserAsync(
+            created.Id,
+            new UpdateUserRequestDto(null, null, null, null, null, Username: "  newname  "),
+            CancellationToken.None);
+
+        Assert.Equal("newname", updated.Username);
+
+        var stored = await db.Users.SingleAsync(u => u.Id == created.Id);
+        Assert.Equal("newname", stored.Username);
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_RenameToExistingUsernameThrows()
+    {
+        await using var db = await CreateDbContextAsync();
+        var service = CreateUserService(db, new FakeMojangApiService());
+
+        await service.CreateUserAsync(
+            new CreateUserRequestDto("taken", "password", "user", null, null),
+            CancellationToken.None);
+        var victim = await service.CreateUserAsync(
+            new CreateUserRequestDto("someone", "password", "user", null, null),
+            CancellationToken.None);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.UpdateUserAsync(
+            victim.Id,
+            new UpdateUserRequestDto(null, null, null, null, null, Username: "TAKEN"),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_AllowsCaseOnlyRename()
+    {
+        await using var db = await CreateDbContextAsync();
+        var service = CreateUserService(db, new FakeMojangApiService());
+
+        var created = await service.CreateUserAsync(
+            new CreateUserRequestDto("miner", "password", "user", null, null),
+            CancellationToken.None);
+
+        var updated = await service.UpdateUserAsync(
+            created.Id,
+            new UpdateUserRequestDto(null, null, null, null, null, Username: "Miner"),
+            CancellationToken.None);
+
+        Assert.Equal("Miner", updated.Username);
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync_OmittedUsernameLeavesNameUnchanged()
+    {
+        await using var db = await CreateDbContextAsync();
+        var service = CreateUserService(db, new FakeMojangApiService());
+
+        var created = await service.CreateUserAsync(
+            new CreateUserRequestDto("stable", "password", "user", null, null),
+            CancellationToken.None);
+
+        var updated = await service.UpdateUserAsync(
+            created.Id,
+            new UpdateUserRequestDto(null, "manager", null, null, null),
+            CancellationToken.None);
+
+        Assert.Equal("stable", updated.Username);
+        Assert.Equal("manager", updated.Role);
+    }
+
     private static async Task<AppDbContext> CreateDbContextAsync()
     {
         var connection = new SqliteConnection("Filename=:memory:");


### PR DESCRIPTION
## Summary
Implements #47. Self-rename already existed (`PATCH /auth/me`); this adds the missing **admin rename of any user**.

- `UpdateUserRequestDto.Username` (optional, appended with a default so existing positional constructions still compile).
- `UserService.UpdateUserAsync` mirrors the self-rename logic: trim, case-insensitive uniqueness excluding self, and explicitly allows case-only renames (`miner` → `Miner`).
- **Endpoint fix**: `PATCH /auth/users/{id}` now returns 409 on `InvalidOperationException` — a collision would previously have been a 500 (the POST endpoint already handled this).
- Admin UI (`admin/access`): Username input in the edit form, included in the PATCH payload only when changed.

**Safety**: every relationship (server access, notifications, audit log, favorites, API keys) keys on the integer user id — no migration, no referential risk. Issued JWTs embed the id; the stale name claim in existing tokens is never security-checked and self-heals via `/auth/me`.

## Testing
- `test/MineOS.Tests`: 6/6 (4 new: rename+trim, collision throws, case-only rename, omitted username untouched while role updates).
- `apps/MineOS.Tests`: 59/59.
- `npm run check`: no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)