### PR TITLE
fix(proxy): land BungeeCord support (#157) with review follow-ups

### DIFF
--- a/apps/MineOS.Api/Endpoints/ModEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/ModEndpoints.cs
@@ -683,7 +683,7 @@ public static class ModEndpoints
         {
             try
             {
-                await serverService.UpdateServerTypeAsync(name, request.ServerType, cancellationToken);
+                await serverService.UpdateServerTypeAsync(name, request.ServerType, request.ProxyKind, cancellationToken);
                 return Results.Ok(new { message = "Server type updated" });
             }
             catch (DirectoryNotFoundException ex)
@@ -695,7 +695,7 @@ public static class ModEndpoints
         return servers;
     }
 
-    private record UpdateServerTypeRequest(string ServerType);
+    private record UpdateServerTypeRequest(string ServerType, string? ProxyKind = null);
 
     /// <summary>
     /// Resolves the mod loader and Minecraft version for a server.

--- a/apps/MineOS.Api/Endpoints/ServerEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/ServerEndpoints.cs
@@ -343,6 +343,10 @@ public static class ServerEndpoints
             {
                 return Results.NotFound(new { error = ex.Message });
             }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Conflict(new { error = ex.Message });
+            }
         });
 
         servers.MapPut("/{name}/bungee-config", async (

--- a/apps/MineOS.Api/Endpoints/ServerEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/ServerEndpoints.cs
@@ -328,6 +328,44 @@ public static class ServerEndpoints
             }
         });
 
+        // BungeeCord configuration (config.yml)
+        servers.MapGet("/{name}/bungee-config", async (
+            string name,
+            IServerService serverService,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var config = await serverService.GetBungeeConfigAsync(name, cancellationToken);
+                return Results.Ok(config);
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+        });
+
+        servers.MapPut("/{name}/bungee-config", async (
+            string name,
+            [FromBody] BungeeConfigDto config,
+            IServerService serverService,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                await serverService.UpdateBungeeConfigAsync(name, config, cancellationToken);
+                return Results.Ok(new { message = "BungeeCord config updated" });
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Conflict(new { error = ex.Message });
+            }
+        });
+
         // Server config
         servers.MapGet("/{name}/server-config", async (
             string name,

--- a/apps/MineOS.Api/Program.cs
+++ b/apps/MineOS.Api/Program.cs
@@ -185,7 +185,13 @@ builder.Services.AddHostedService<ApplicationLifetimeService>();
 builder.Services.AddSingleton<WatchdogService>();
 builder.Services.AddSingleton<IWatchdogService>(sp => sp.GetRequiredService<WatchdogService>());
 builder.Services.AddHostedService(sp => sp.GetRequiredService<WatchdogService>());
-builder.Services.AddHttpClient<IProfileService, ProfileService>();
+builder.Services.AddHttpClient<IProfileService, ProfileService>(client =>
+{
+    // hub.spigotmc.org (BungeeCord/BuildTools) is behind Cloudflare and rejects
+    // requests with no User-Agent. Other upstreams (Mojang, PaperMC, minecraft.net)
+    // are fine with this UA so we set it as the default.
+    client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (compatible; MineOS/1.0)");
+});
 builder.Services.AddHttpClient<IModService, ModService>(client =>
 {
     client.Timeout = Timeout.InfiniteTimeSpan;

--- a/apps/MineOS.Application/Dtos/BungeeConfigDto.cs
+++ b/apps/MineOS.Application/Dtos/BungeeConfigDto.cs
@@ -1,0 +1,38 @@
+namespace MineOS.Application.Dtos;
+
+// Models BungeeCord's config.yml. Only the fields the editor surfaces are
+// mapped; anything else present in the file (extra listeners, fork-specific
+// keys) is preserved on round-trip rather than dropped.
+public record BungeeConfigDto(
+    bool Exists,
+    // top-level
+    bool OnlineMode,
+    bool IpForward,
+    int PlayerLimit,
+    int Timeout,
+    int NetworkCompressionThreshold,
+    bool ForgeSupport,
+    bool LogCommands,
+    bool LogPings,
+    int ConnectionThrottle,
+    int ConnectionThrottleLimit,
+    // first listener (BungeeCord supports multiple but the editor exposes #0;
+    // any additional listeners in config.yml are preserved on round-trip)
+    string Host,
+    string Motd,
+    int MaxPlayers,
+    bool QueryEnabled,
+    int QueryPort,
+    bool PingPassthrough,
+    bool ForceDefaultServer,
+    string TabList,
+    bool ProxyProtocol,
+    List<string> Priorities,
+    Dictionary<string, string> ForcedHosts, // BungeeCord supports a single server per host (not a list).
+    // backends
+    Dictionary<string, BungeeBackendDto> Servers);
+
+public record BungeeBackendDto(
+    string Address,
+    string Motd,
+    bool Restricted);

--- a/apps/MineOS.Application/Dtos/ServerDtos.cs
+++ b/apps/MineOS.Application/Dtos/ServerDtos.cs
@@ -92,7 +92,10 @@ public record CrashEventDto(
 
 public record ConsoleCommandDto(string Command);
 
-public record CreateServerRequest(string Name, int OwnerUid, int OwnerGid, string ServerType = "java");
+// ProxyKind narrows ServerType="proxy" to a specific implementation
+// (velocity / bungeecord) so server creation skips the velocity.toml
+// bootstrap when the user picked a YAML-based proxy.
+public record CreateServerRequest(string Name, int OwnerUid, int OwnerGid, string ServerType = "java", string? ProxyKind = null);
 
 public record CloneServerRequest(string NewName);
 

--- a/apps/MineOS.Application/Interfaces/IServerService.cs
+++ b/apps/MineOS.Application/Interfaces/IServerService.cs
@@ -25,11 +25,13 @@ public interface IServerService
     Task UpdateServerConfigAsync(string name, ServerConfigDto config, CancellationToken cancellationToken);
     Task<VelocityConfigDto> GetVelocityConfigAsync(string name, CancellationToken cancellationToken);
     Task UpdateVelocityConfigAsync(string name, VelocityConfigDto config, CancellationToken cancellationToken);
+    Task<BungeeConfigDto> GetBungeeConfigAsync(string name, CancellationToken cancellationToken);
+    Task UpdateBungeeConfigAsync(string name, BungeeConfigDto config, CancellationToken cancellationToken);
 
     /// <summary>
-    /// Returns the (host, port) the server listens on, branching on server type
-    /// (server.properties for java/bedrock, velocity.toml for proxy).
-    /// Returns null if neither config exists or the value is malformed.
+    /// Returns the (host, port) the server listens on, branching on server type:
+    /// server.properties for java/bedrock, velocity.toml or config.yml for proxies.
+    /// Returns null if no config exists or the value is malformed.
     /// </summary>
     Task<(string Host, int Port)?> GetServerListenEndpointAsync(string name, CancellationToken cancellationToken);
 
@@ -38,5 +40,5 @@ public interface IServerService
 
     // Loader detection
     Task<ServerLoaderDto> DetectLoaderAsync(string name, CancellationToken cancellationToken);
-    Task UpdateServerTypeAsync(string name, string serverType, CancellationToken cancellationToken);
+    Task UpdateServerTypeAsync(string name, string serverType, string? proxyKind, CancellationToken cancellationToken);
 }

--- a/apps/MineOS.Infrastructure/MineOS.Infrastructure.csproj
+++ b/apps/MineOS.Infrastructure/MineOS.Infrastructure.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
     <PackageReference Include="Tomlyn" Version="0.19.0" />
+    <PackageReference Include="YamlDotNet" Version="16.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/apps/MineOS.Infrastructure/Services/ProfileService.cs
+++ b/apps/MineOS.Infrastructure/Services/ProfileService.cs
@@ -22,9 +22,16 @@ public sealed class ProfileService : IProfileService
     // PaperMC's legacy api.papermc.io/v2 API was sunset in 2026; Fill v3 is the replacement.
     private const string PaperProjectUrl = "https://fill.papermc.io/v3/projects/paper";
     private const string VelocityProjectUrl = "https://fill.papermc.io/v3/projects/velocity";
+    // BungeeCord lives on md_5's Jenkins (hub.spigotmc.org auto-redirects there).
+    // Each successful build publishes bootstrap/target/BungeeCord.jar; we expose
+    // the most recent N successful builds as profiles.
+    private const string BungeeCordJenkinsApi =
+        "https://hub.spigotmc.org/jenkins/job/BungeeCord/api/json?depth=1&tree=builds[number,result,timestamp,artifacts[relativePath,fileName]]";
+    private const string BungeeCordBuildBaseUrl = "https://hub.spigotmc.org/jenkins/job/BungeeCord";
     private const string MojangVersionManifestUrl = "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json";
     private const int PaperVersionLimit = 20;
     private const int VelocityVersionLimit = 10;
+    private const int BungeeCordBuildLimit = 10;
     private static readonly TimeSpan PaperCacheTtl = TimeSpan.FromMinutes(10);
     private static readonly SemaphoreSlim PaperCacheLock = new(1, 1);
     private static DateTimeOffset? _paperLastFetch;
@@ -33,6 +40,10 @@ public sealed class ProfileService : IProfileService
     private static readonly SemaphoreSlim VelocityCacheLock = new(1, 1);
     private static DateTimeOffset? _velocityLastFetch;
     private static List<ProfileDto> _velocityCache = new();
+    private static readonly TimeSpan BungeeCordCacheTtl = TimeSpan.FromMinutes(10);
+    private static readonly SemaphoreSlim BungeeCordCacheLock = new(1, 1);
+    private static DateTimeOffset? _bungeeCordLastFetch;
+    private static List<ProfileDto> _bungeeCordCache = new();
     private static readonly TimeSpan VanillaCacheTtl = TimeSpan.FromMinutes(10);
     private static readonly SemaphoreSlim VanillaCacheLock = new(1, 1);
     private static DateTimeOffset? _vanillaLastFetch;
@@ -105,6 +116,7 @@ public sealed class ProfileService : IProfileService
         var vanillaProfiles = await GetVanillaProfilesAsync(cancellationToken);
         var paperProfiles = await GetPaperProfilesAsync(cancellationToken);
         var velocityProfiles = await GetVelocityProfilesAsync(cancellationToken);
+        var bungeeCordProfiles = await GetBungeeCordProfilesAsync(cancellationToken);
         var buildToolsProfiles = await DiscoverBuildToolsProfilesAsync(cancellationToken);
         var bedrockProfiles = await GetBedrockProfilesAsync(cancellationToken);
         var combined = new Dictionary<string, ProfileDto>(StringComparer.OrdinalIgnoreCase);
@@ -125,6 +137,11 @@ public sealed class ProfileService : IProfileService
         }
 
         foreach (var profile in velocityProfiles)
+        {
+            combined[profile.Id] = profile;
+        }
+
+        foreach (var profile in bungeeCordProfiles)
         {
             combined[profile.Id] = profile;
         }
@@ -1314,6 +1331,127 @@ public sealed class ProfileService : IProfileService
     private static bool IsStableVelocityVersion(string version)
     {
         return !version.Contains('-', StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<IReadOnlyList<ProfileDto>> GetBungeeCordProfilesAsync(CancellationToken cancellationToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        if (_bungeeCordLastFetch.HasValue &&
+            now - _bungeeCordLastFetch.Value < BungeeCordCacheTtl &&
+            _bungeeCordCache.Count > 0)
+        {
+            return _bungeeCordCache;
+        }
+
+        await BungeeCordCacheLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (_bungeeCordLastFetch.HasValue &&
+                now - _bungeeCordLastFetch.Value < BungeeCordCacheTtl &&
+                _bungeeCordCache.Count > 0)
+            {
+                return _bungeeCordCache;
+            }
+
+            var fetched = await FetchBungeeCordProfilesAsync(cancellationToken);
+            if (fetched.Count > 0)
+            {
+                _bungeeCordCache = fetched.ToList();
+                _bungeeCordLastFetch = DateTimeOffset.UtcNow;
+            }
+            else if (_bungeeCordCache.Count == 0)
+            {
+                _bungeeCordLastFetch = DateTimeOffset.UtcNow;
+            }
+
+            return _bungeeCordCache;
+        }
+        finally
+        {
+            BungeeCordCacheLock.Release();
+        }
+    }
+
+    private async Task<IReadOnlyList<ProfileDto>> FetchBungeeCordProfilesAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var json = await _httpClient.GetStringAsync(BungeeCordJenkinsApi, cancellationToken);
+            using var doc = JsonDocument.Parse(json);
+            if (!doc.RootElement.TryGetProperty("builds", out var builds) ||
+                builds.ValueKind != JsonValueKind.Array)
+            {
+                return Array.Empty<ProfileDto>();
+            }
+
+            var results = new List<ProfileDto>();
+            foreach (var build in builds.EnumerateArray())
+            {
+                if (results.Count >= BungeeCordBuildLimit)
+                {
+                    break;
+                }
+
+                if (!build.TryGetProperty("result", out var resultElement) ||
+                    resultElement.GetString() != "SUCCESS" ||
+                    !build.TryGetProperty("number", out var numberElement) ||
+                    numberElement.ValueKind != JsonValueKind.Number)
+                {
+                    continue;
+                }
+
+                var buildNumber = numberElement.GetInt32();
+
+                // Find the BungeeCord.jar artifact (relativePath is bootstrap/target/BungeeCord.jar)
+                string? relativePath = null;
+                if (build.TryGetProperty("artifacts", out var artifacts) &&
+                    artifacts.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var artifact in artifacts.EnumerateArray())
+                    {
+                        if (artifact.TryGetProperty("fileName", out var fileNameEl) &&
+                            fileNameEl.GetString() == "BungeeCord.jar" &&
+                            artifact.TryGetProperty("relativePath", out var relPathEl))
+                        {
+                            relativePath = relPathEl.GetString();
+                            break;
+                        }
+                    }
+                }
+
+                if (string.IsNullOrWhiteSpace(relativePath))
+                {
+                    continue;
+                }
+
+                var time = build.TryGetProperty("timestamp", out var ts) && ts.ValueKind == JsonValueKind.Number
+                    ? DateTimeOffset.FromUnixTimeMilliseconds(ts.GetInt64()).ToString("O")
+                    : DateTimeOffset.UtcNow.ToString("O");
+                var version = $"build-{buildNumber}";
+                var downloadUrl = $"{BungeeCordBuildBaseUrl}/{buildNumber}/artifact/{relativePath}";
+
+                results.Add(new ProfileDto(
+                    $"bungeecord-{version}",
+                    "bungeecord",
+                    "release",
+                    version,
+                    time,
+                    downloadUrl,
+                    // Local filename includes the build number so multiple BungeeCord
+                    // builds can coexist on disk and the proxy-version chip in the UI
+                    // can disambiguate which build is installed.
+                    $"bungeecord-{version}.jar",
+                    false,
+                    null));
+            }
+
+            return results;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch BungeeCord profiles");
+            return Array.Empty<ProfileDto>();
+        }
     }
 
     private static Version? TryParseVersion(string? version)

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -10,6 +10,8 @@ using MineOS.Infrastructure.Utilities;
 using ServerStatusStrings = MineOS.Infrastructure.Constants.ServerStatus;
 using Tomlyn;
 using Tomlyn.Model;
+using YamlDotNet.RepresentationModel;
+using YamlDotNet.Serialization;
 
 namespace MineOS.Infrastructure.Services;
 
@@ -296,9 +298,9 @@ public class ServerService : IServerService
         }
         else if (serverType == "proxy")
         {
-            // Velocity (and future BungeeCord/Waterfall) proxies: no server.properties,
-            // no EULA, no world. Velocity creates velocity.toml on first launch.
-            // Velocity's actual default bind port is 25577 (set in velocity.toml).
+            // Proxies (Velocity / BungeeCord): no server.properties,
+            // no EULA, no world. The proxy creates its own config file on first
+            // launch (velocity.toml or config.yml). Default bind port 25577.
             var defaultPort = GetNextAvailablePort(usedPorts, 25577);
 
             var proxyConfig = new Dictionary<string, Dictionary<string, string>>
@@ -312,7 +314,7 @@ public class ServerService : IServerService
                 ["minecraft"] = new()
                 {
                     ["profile"] = "",
-                    // Velocity rejects "nogui"; treat as unconventional so the
+                    // Proxies reject "nogui"; treat as unconventional so the
                     // launcher does not append it.
                     ["unconventional"] = "true",
                     ["lan_broadcast"] = "false"
@@ -330,20 +332,50 @@ public class ServerService : IServerService
 
             await File.WriteAllTextAsync(configPath, IniParser.WriteWithSections(proxyConfig), cancellationToken);
 
-            // Pre-populate velocity.toml with sibling Java backends so the proxy
-            // does something out of the box. The user can edit /reorder them via
-            // the Velocity tab.
+            var proxyKind = NormalizeProxyKind(request.ProxyKind);
             var backends = await DiscoverJavaBackendsAsync(request.Name, cancellationToken);
-            var initialConfig = VelocityConfigDefaults(exists: true) with
+
+            if (proxyKind == "velocity")
             {
-                Bind = $"0.0.0.0:{defaultPort}",
-                Servers = backends,
-                Try = backends.Count > 0
-                    ? new List<string> { backends.Keys.First() }
-                    : new List<string>()
-            };
-            var tomlPath = Path.Combine(serverPath, "velocity.toml");
-            await WriteVelocityTomlAsync(tomlPath, initialConfig, cancellationToken);
+                // Pre-populate velocity.toml with sibling Java backends so the proxy
+                // does something out of the box. The user can edit/reorder them via
+                // the Properties tab.
+                var initialConfig = VelocityConfigDefaults(exists: true) with
+                {
+                    Bind = $"0.0.0.0:{defaultPort}",
+                    Servers = backends,
+                    Try = backends.Count > 0
+                        ? new List<string> { backends.Keys.First() }
+                        : new List<string>()
+                };
+                var tomlPath = Path.Combine(serverPath, "velocity.toml");
+                await WriteVelocityTomlAsync(tomlPath, initialConfig, cancellationToken);
+            }
+            else
+            {
+                // BungeeCord — bootstrap config.yml in its YAML schema.
+                // BungeeCord refuses to start with an empty servers: map
+                // ("IllegalArgumentException: No servers defined"), so when no
+                // sibling Java backends exist we seed the same placeholder
+                // BungeeCord itself ships in its default config.yml.
+                var bungeeBackends = backends.Count > 0
+                    ? backends.ToDictionary(
+                        kv => kv.Key,
+                        kv => new BungeeBackendDto(kv.Value, "&1Backend server", false))
+                    : new Dictionary<string, BungeeBackendDto>
+                    {
+                        ["lobby"] = new("127.0.0.1:25565", "&1Just another BungeeCord - Forced Host", false)
+                    };
+                var initialConfig = BungeeConfigDefaults(exists: true) with
+                {
+                    Host = $"0.0.0.0:{defaultPort}",
+                    QueryPort = defaultPort,
+                    Servers = bungeeBackends,
+                    Priorities = new List<string> { bungeeBackends.Keys.First() }
+                };
+                var yamlPath = Path.Combine(serverPath, "config.yml");
+                await WriteBungeeConfigAsync(yamlPath, initialConfig, cancellationToken);
+            }
         }
         else
         {
@@ -924,6 +956,59 @@ public class ServerService : IServerService
     private string GetVelocityTomlPath(string name) =>
         Path.Combine(GetServerPath(name), "velocity.toml");
 
+    private string GetBungeeConfigPath(string name) =>
+        Path.Combine(GetServerPath(name), "config.yml");
+
+    private static (string Host, int Port)? ParseHostPort(string bind)
+    {
+        // Bind format is "<host>:<port>" e.g. "0.0.0.0:25577", with IPv6 like
+        // "[::]:25577". Split on the LAST colon so IPv6 brackets don't break.
+        if (string.IsNullOrWhiteSpace(bind))
+        {
+            return null;
+        }
+        var lastColon = bind.LastIndexOf(':');
+        if (lastColon <= 0 || lastColon == bind.Length - 1)
+        {
+            return null;
+        }
+        if (!int.TryParse(bind[(lastColon + 1)..], out var port) || port < 1 || port > 65535)
+        {
+            return null;
+        }
+        var host = bind[..lastColon].Trim('[', ']');
+        if (string.IsNullOrWhiteSpace(host) || host == "0.0.0.0" || host == "::")
+        {
+            host = "127.0.0.1";
+        }
+        return (host, port);
+    }
+
+    private static string? ReadFirstListenerHost(string yamlContent)
+    {
+        var stream = new YamlStream();
+        using var reader = new StringReader(yamlContent);
+        stream.Load(reader);
+        if (stream.Documents.Count == 0 ||
+            stream.Documents[0].RootNode is not YamlMappingNode root)
+        {
+            return null;
+        }
+        if (!root.Children.TryGetValue(new YamlScalarNode("listeners"), out var listenersNode) ||
+            listenersNode is not YamlSequenceNode listeners ||
+            listeners.Children.Count == 0 ||
+            listeners.Children[0] is not YamlMappingNode first)
+        {
+            return null;
+        }
+        if (first.Children.TryGetValue(new YamlScalarNode("host"), out var hostNode) &&
+            hostNode is YamlScalarNode hostScalar)
+        {
+            return hostScalar.Value;
+        }
+        return null;
+    }
+
     public async Task<(string Host, int Port)?> GetServerListenEndpointAsync(string name, CancellationToken cancellationToken)
     {
         var serverPath = GetServerPath(name);
@@ -934,43 +1019,44 @@ public class ServerService : IServerService
 
         if (DetectServerType(name) == "proxy")
         {
+            // Try Velocity (velocity.toml) first; fall back to BungeeCord (config.yml).
             var tomlPath = GetVelocityTomlPath(name);
-            if (!File.Exists(tomlPath))
+            if (File.Exists(tomlPath))
             {
-                return null;
+                try
+                {
+                    var content = await File.ReadAllTextAsync(tomlPath, cancellationToken);
+                    var model = Toml.ToModel(content);
+                    if (model.TryGetValue("bind", out var bindObj) && bindObj is string bind)
+                    {
+                        return ParseHostPort(bind);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to parse velocity.toml for {ServerName}", name);
+                }
             }
-            try
+
+            var yamlPath = GetBungeeConfigPath(name);
+            if (File.Exists(yamlPath))
             {
-                var content = await File.ReadAllTextAsync(tomlPath, cancellationToken);
-                var model = Toml.ToModel(content);
-                if (!model.TryGetValue("bind", out var bindObj) || bindObj is not string bind)
+                try
                 {
-                    return null;
+                    var content = await File.ReadAllTextAsync(yamlPath, cancellationToken);
+                    var bind = ReadFirstListenerHost(content);
+                    if (!string.IsNullOrWhiteSpace(bind))
+                    {
+                        return ParseHostPort(bind);
+                    }
                 }
-                // Velocity bind format is "<host>:<port>" e.g. "0.0.0.0:25577".
-                // Velocity also supports IPv6 like "[::]:25577" but we treat that
-                // by splitting on the LAST colon.
-                var lastColon = bind.LastIndexOf(':');
-                if (lastColon <= 0 || lastColon == bind.Length - 1)
+                catch (Exception ex)
                 {
-                    return null;
+                    _logger.LogWarning(ex, "Failed to parse config.yml for {ServerName}", name);
                 }
-                if (!int.TryParse(bind[(lastColon + 1)..], out var port) || port < 1 || port > 65535)
-                {
-                    return null;
-                }
-                var host = bind[..lastColon].Trim('[', ']');
-                if (string.IsNullOrWhiteSpace(host) || host == "0.0.0.0" || host == "::")
-                {
-                    host = "127.0.0.1";
-                }
-                return (host, port);
             }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to parse velocity.toml for {ServerName}", name);
-                return null;
-            }
+
+            return null;
         }
 
         // Java + bedrock: read server.properties
@@ -1259,6 +1345,359 @@ public class ServerService : IServerService
                     list.Add(s);
             }
             result[hostname] = list;
+        }
+        return result;
+    }
+
+    public async Task<BungeeConfigDto> GetBungeeConfigAsync(string name, CancellationToken cancellationToken)
+    {
+        var serverPath = GetServerPath(name);
+        if (!Directory.Exists(serverPath))
+        {
+            throw new DirectoryNotFoundException($"Server '{name}' not found");
+        }
+
+        var yamlPath = GetBungeeConfigPath(name);
+        if (!File.Exists(yamlPath))
+        {
+            return BungeeConfigDefaults(exists: false);
+        }
+
+        var content = await File.ReadAllTextAsync(yamlPath, cancellationToken);
+        return ParseBungeeConfig(content);
+    }
+
+    /// <summary>
+    /// Maps BungeeCord's config.yml text onto <see cref="BungeeConfigDto"/>. Keys the
+    /// file omits fall back to <see cref="BungeeConfigDefaults"/>. Malformed YAML throws
+    /// rather than silently yielding defaults — returning defaults would let the next
+    /// save overwrite a config the user still has content in.
+    /// </summary>
+    public static BungeeConfigDto ParseBungeeConfig(string yaml)
+    {
+        var stream = new YamlStream();
+        using var reader = new StringReader(yaml);
+        stream.Load(reader);
+
+        var defaults = BungeeConfigDefaults(exists: true);
+        if (stream.Documents.Count == 0 ||
+            stream.Documents[0].RootNode is not YamlMappingNode root)
+        {
+            return defaults;
+        }
+
+        var listener = GetFirstListener(root);
+
+        return defaults with
+        {
+            OnlineMode = YamlGetBool(root, "online_mode", defaults.OnlineMode),
+            IpForward = YamlGetBool(root, "ip_forward", defaults.IpForward),
+            PlayerLimit = YamlGetInt(root, "player_limit", defaults.PlayerLimit),
+            Timeout = YamlGetInt(root, "timeout", defaults.Timeout),
+            NetworkCompressionThreshold = YamlGetInt(root, "network_compression_threshold", defaults.NetworkCompressionThreshold),
+            ForgeSupport = YamlGetBool(root, "forge_support", defaults.ForgeSupport),
+            LogCommands = YamlGetBool(root, "log_commands", defaults.LogCommands),
+            LogPings = YamlGetBool(root, "log_pings", defaults.LogPings),
+            ConnectionThrottle = YamlGetInt(root, "connection_throttle", defaults.ConnectionThrottle),
+            ConnectionThrottleLimit = YamlGetInt(root, "connection_throttle_limit", defaults.ConnectionThrottleLimit),
+            Host = listener is null ? defaults.Host : YamlGetString(listener, "host", defaults.Host),
+            Motd = listener is null ? defaults.Motd : YamlGetString(listener, "motd", defaults.Motd),
+            MaxPlayers = listener is null ? defaults.MaxPlayers : YamlGetInt(listener, "max_players", defaults.MaxPlayers),
+            QueryEnabled = listener is not null && YamlGetBool(listener, "query_enabled", defaults.QueryEnabled),
+            QueryPort = listener is null ? defaults.QueryPort : YamlGetInt(listener, "query_port", defaults.QueryPort),
+            PingPassthrough = listener is not null && YamlGetBool(listener, "ping_passthrough", defaults.PingPassthrough),
+            ForceDefaultServer = listener is not null && YamlGetBool(listener, "force_default_server", defaults.ForceDefaultServer),
+            TabList = listener is null ? defaults.TabList : YamlGetString(listener, "tab_list", defaults.TabList),
+            ProxyProtocol = listener is not null && YamlGetBool(listener, "proxy_protocol", defaults.ProxyProtocol),
+            Priorities = listener is null ? new List<string>() : ReadPriorities(listener),
+            ForcedHosts = listener is null ? new Dictionary<string, string>() : ReadBungeeForcedHosts(listener),
+            Servers = ReadBungeeServers(root)
+        };
+    }
+
+    public async Task UpdateBungeeConfigAsync(string name, BungeeConfigDto config, CancellationToken cancellationToken)
+    {
+        var serverPath = GetServerPath(name);
+        if (!Directory.Exists(serverPath))
+        {
+            throw new DirectoryNotFoundException($"Server '{name}' not found");
+        }
+
+        if (DetectServerType(name) != "proxy")
+        {
+            throw new InvalidOperationException($"Server '{name}' is not a proxy server");
+        }
+
+        var yamlPath = GetBungeeConfigPath(name);
+        await WriteBungeeConfigAsync(yamlPath, config, cancellationToken);
+        await MarkRestartRequiredAsync(name);
+        _logger.LogInformation("Updated config.yml for {ServerName}", name);
+    }
+
+    private async Task WriteBungeeConfigAsync(string yamlPath, BungeeConfigDto config, CancellationToken cancellationToken)
+    {
+        var existing = File.Exists(yamlPath)
+            ? await File.ReadAllTextAsync(yamlPath, cancellationToken)
+            : null;
+
+        await File.WriteAllTextAsync(yamlPath, SerializeBungeeConfig(config, existing), cancellationToken);
+        await OwnershipHelper.ChangeOwnershipAsync(yamlPath, _options.RunAsUid, _options.RunAsGid, _logger, cancellationToken);
+    }
+
+    /// <summary>
+    /// Renders <paramref name="config"/> as config.yml text. When <paramref name="existingYaml"/>
+    /// is supplied its tree is edited in place rather than replaced, so keys the editor does not
+    /// model — groups, permissions, disabled_commands, the stats UUID, listeners beyond the
+    /// first — survive an edit cycle instead of being dropped.
+    /// </summary>
+    public static string SerializeBungeeConfig(BungeeConfigDto config, string? existingYaml)
+    {
+        YamlMappingNode root;
+        if (!string.IsNullOrWhiteSpace(existingYaml))
+        {
+            var stream = new YamlStream();
+            using var reader = new StringReader(existingYaml);
+            stream.Load(reader);
+            root = stream.Documents.Count > 0 && stream.Documents[0].RootNode is YamlMappingNode m
+                ? m
+                : new YamlMappingNode();
+        }
+        else
+        {
+            root = new YamlMappingNode();
+        }
+
+        SetScalar(root, "online_mode", config.OnlineMode);
+        SetScalar(root, "ip_forward", config.IpForward);
+        SetScalar(root, "player_limit", config.PlayerLimit);
+        SetScalar(root, "timeout", config.Timeout);
+        SetScalar(root, "network_compression_threshold", config.NetworkCompressionThreshold);
+        SetScalar(root, "forge_support", config.ForgeSupport);
+        SetScalar(root, "log_commands", config.LogCommands);
+        SetScalar(root, "log_pings", config.LogPings);
+        SetScalar(root, "connection_throttle", config.ConnectionThrottle);
+        SetScalar(root, "connection_throttle_limit", config.ConnectionThrottleLimit);
+
+        // Listener: edit the first listener if it exists, else create one.
+        // Any additional listeners after [0] are preserved untouched.
+        YamlSequenceNode listeners;
+        if (root.Children.TryGetValue(new YamlScalarNode("listeners"), out var listenersNode) &&
+            listenersNode is YamlSequenceNode existingListeners)
+        {
+            listeners = existingListeners;
+        }
+        else
+        {
+            listeners = new YamlSequenceNode();
+            root.Children[new YamlScalarNode("listeners")] = listeners;
+        }
+        YamlMappingNode firstListener;
+        if (listeners.Children.Count > 0 && listeners.Children[0] is YamlMappingNode existingFirst)
+        {
+            firstListener = existingFirst;
+        }
+        else
+        {
+            firstListener = new YamlMappingNode();
+            listeners.Children.Insert(0, firstListener);
+        }
+        SetScalar(firstListener, "host", config.Host);
+        SetScalar(firstListener, "motd", config.Motd);
+        SetScalar(firstListener, "max_players", config.MaxPlayers);
+        SetScalar(firstListener, "query_enabled", config.QueryEnabled);
+        SetScalar(firstListener, "query_port", config.QueryPort);
+        SetScalar(firstListener, "ping_passthrough", config.PingPassthrough);
+        SetScalar(firstListener, "force_default_server", config.ForceDefaultServer);
+        SetScalar(firstListener, "tab_list", config.TabList);
+        SetScalar(firstListener, "proxy_protocol", config.ProxyProtocol);
+
+        // The collections are non-nullable on the record, but this DTO is bound
+        // straight from a PUT body and System.Text.Json leaves them null when the
+        // client omits the property — nullable reference types are not enforced at
+        // runtime. Treat a missing collection as empty rather than throwing.
+        var prioritiesSeq = new YamlSequenceNode();
+        foreach (var p in config.Priorities ?? new List<string>())
+        {
+            prioritiesSeq.Children.Add(new YamlScalarNode(p));
+        }
+        firstListener.Children[new YamlScalarNode("priorities")] = prioritiesSeq;
+
+        var forcedHostsMap = new YamlMappingNode();
+        foreach (var (host, target) in config.ForcedHosts ?? new Dictionary<string, string>())
+        {
+            forcedHostsMap.Children[new YamlScalarNode(host)] = new YamlScalarNode(target ?? string.Empty);
+        }
+        firstListener.Children[new YamlScalarNode("forced_hosts")] = forcedHostsMap;
+
+        var serversMap = new YamlMappingNode();
+        foreach (var (key, backend) in config.Servers ?? new Dictionary<string, BungeeBackendDto>())
+        {
+            var entry = new YamlMappingNode
+            {
+                { new YamlScalarNode("address"), new YamlScalarNode(backend?.Address ?? string.Empty) },
+                { new YamlScalarNode("motd"), new YamlScalarNode(backend?.Motd ?? string.Empty) },
+                { new YamlScalarNode("restricted"), new YamlScalarNode(backend?.Restricted == true ? "true" : "false") }
+            };
+            serversMap.Children[new YamlScalarNode(key)] = entry;
+        }
+        root.Children[new YamlScalarNode("servers")] = serversMap;
+
+        var writer = new StringWriter();
+        new YamlStream(new YamlDocument(root)).Save(writer, assignAnchors: false);
+        return writer.ToString();
+    }
+
+    /// <summary>
+    /// BungeeCord's own config.yml defaults, with one deliberate divergence noted inline.
+    /// </summary>
+    public static BungeeConfigDto BungeeConfigDefaults(bool exists)
+    {
+        return new BungeeConfigDto(
+            Exists: exists,
+            OnlineMode: true,
+            IpForward: false,
+            PlayerLimit: -1,
+            Timeout: 30000,
+            NetworkCompressionThreshold: 256,
+            ForgeSupport: false,
+            LogCommands: false,
+            // BungeeCord defaults log_pings to true. MineOS heartbeats SLP-ping
+            // the proxy every few seconds for the dashboard, which floods the
+            // log. Default off here; users can re-enable in the Properties tab.
+            LogPings: false,
+            ConnectionThrottle: 4000,
+            ConnectionThrottleLimit: 3,
+            Host: "0.0.0.0:25577",
+            Motd: "&1Another BungeeCord server",
+            MaxPlayers: 1,
+            QueryEnabled: false,
+            QueryPort: 25577,
+            PingPassthrough: false,
+            ForceDefaultServer: false,
+            TabList: "GLOBAL_PING",
+            ProxyProtocol: false,
+            Priorities: new List<string>(),
+            ForcedHosts: new Dictionary<string, string>(),
+            Servers: new Dictionary<string, BungeeBackendDto>());
+    }
+
+    private static YamlMappingNode? GetFirstListener(YamlMappingNode root)
+    {
+        if (!root.Children.TryGetValue(new YamlScalarNode("listeners"), out var listenersNode) ||
+            listenersNode is not YamlSequenceNode listeners ||
+            listeners.Children.Count == 0)
+        {
+            return null;
+        }
+        return listeners.Children[0] as YamlMappingNode;
+    }
+
+    private static string YamlGetString(YamlMappingNode node, string key, string fallback)
+    {
+        if (node.Children.TryGetValue(new YamlScalarNode(key), out var v) &&
+            v is YamlScalarNode s &&
+            s.Value is not null)
+        {
+            return s.Value;
+        }
+        return fallback;
+    }
+
+    private static int YamlGetInt(YamlMappingNode node, string key, int fallback)
+    {
+        if (node.Children.TryGetValue(new YamlScalarNode(key), out var v) &&
+            v is YamlScalarNode s &&
+            int.TryParse(s.Value, out var parsed))
+        {
+            return parsed;
+        }
+        return fallback;
+    }
+
+    private static bool YamlGetBool(YamlMappingNode node, string key, bool fallback)
+    {
+        if (node.Children.TryGetValue(new YamlScalarNode(key), out var v) &&
+            v is YamlScalarNode s &&
+            bool.TryParse(s.Value, out var parsed))
+        {
+            return parsed;
+        }
+        return fallback;
+    }
+
+    private static void SetScalar(YamlMappingNode node, string key, string value)
+    {
+        node.Children[new YamlScalarNode(key)] = new YamlScalarNode(value ?? string.Empty);
+    }
+
+    private static void SetScalar(YamlMappingNode node, string key, int value)
+    {
+        node.Children[new YamlScalarNode(key)] = new YamlScalarNode(value.ToString());
+    }
+
+    private static void SetScalar(YamlMappingNode node, string key, bool value)
+    {
+        node.Children[new YamlScalarNode(key)] = new YamlScalarNode(value ? "true" : "false");
+    }
+
+    private static List<string> ReadPriorities(YamlMappingNode listener)
+    {
+        var result = new List<string>();
+        if (listener.Children.TryGetValue(new YamlScalarNode("priorities"), out var v) &&
+            v is YamlSequenceNode seq)
+        {
+            foreach (var item in seq.Children)
+            {
+                if (item is YamlScalarNode s && s.Value is not null)
+                {
+                    result.Add(s.Value);
+                }
+            }
+        }
+        return result;
+    }
+
+    private static Dictionary<string, string> ReadBungeeForcedHosts(YamlMappingNode listener)
+    {
+        var result = new Dictionary<string, string>();
+        if (listener.Children.TryGetValue(new YamlScalarNode("forced_hosts"), out var v) &&
+            v is YamlMappingNode map)
+        {
+            foreach (var (key, value) in map.Children)
+            {
+                if (key is YamlScalarNode hostScalar &&
+                    hostScalar.Value is { } host &&
+                    value is YamlScalarNode targetScalar &&
+                    targetScalar.Value is { } target)
+                {
+                    result[host] = target;
+                }
+            }
+        }
+        return result;
+    }
+
+    private static Dictionary<string, BungeeBackendDto> ReadBungeeServers(YamlMappingNode root)
+    {
+        var result = new Dictionary<string, BungeeBackendDto>();
+        if (!root.Children.TryGetValue(new YamlScalarNode("servers"), out var v) ||
+            v is not YamlMappingNode map)
+        {
+            return result;
+        }
+
+        foreach (var (key, value) in map.Children)
+        {
+            if (key is not YamlScalarNode keyScalar ||
+                keyScalar.Value is not { } name ||
+                value is not YamlMappingNode entry)
+            {
+                continue;
+            }
+            var address = YamlGetString(entry, "address", "");
+            var motd = YamlGetString(entry, "motd", "");
+            var restricted = YamlGetBool(entry, "restricted", false);
+            result[name] = new BungeeBackendDto(address, motd, restricted);
         }
         return result;
     }
@@ -1629,6 +2068,18 @@ public class ServerService : IServerService
         var timeout = TimeSpan.FromSeconds(10);
         var started = DateTimeOffset.UtcNow;
 
+        // Brief settle so the echo'd "Launching <name>" line lands before we
+        // sample the baseline. The launcher writes that line via echo BEFORE
+        // exec'ing the server; we want to count only output past it as proof
+        // the server produced output of its own.
+        await Task.Delay(300, cancellationToken);
+        long startupBaselineBytes = 0;
+        if (File.Exists(startupLogPath))
+        {
+            try { startupBaselineBytes = new FileInfo(startupLogPath).Length; }
+            catch (IOException) { }
+        }
+
         while (DateTimeOffset.UtcNow - started < timeout)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -1650,6 +2101,22 @@ public class ServerService : IServerService
                 if (logInfo.LastWriteTimeUtc >= startTime.UtcDateTime)
                 {
                     _logger.LogInformation("Detected log output for {ServerName} at {LogPath}", name, logPath);
+                    return;
+                }
+            }
+
+            // Fallback: the launcher tees stdout/stderr to startup.log. Any growth
+            // past the baseline means the server emitted output of its own — this
+            // is what covers BungeeCord, which writes proxy.log.0 rather than
+            // logs/latest.log and so never trips the check above.
+            if (File.Exists(startupLogPath))
+            {
+                var startupInfo = new FileInfo(startupLogPath);
+                if (startupInfo.Length > startupBaselineBytes)
+                {
+                    _logger.LogInformation(
+                        "Detected startup activity for {ServerName} at {LogPath} (grew from {Baseline} to {Length} bytes)",
+                        name, startupLogPath, startupBaselineBytes, startupInfo.Length);
                     return;
                 }
             }
@@ -1812,10 +2279,31 @@ public class ServerService : IServerService
     private static readonly HashSet<string> AllowedServerTypes = new(StringComparer.OrdinalIgnoreCase)
     {
         "java", "bedrock", "proxy", "vanilla", "paper", "spigot", "craftbukkit", "purpur",
-        "forge", "neoforge", "fabric", "quilt", "folia", "velocity"
+        "forge", "neoforge", "fabric", "quilt", "folia", "velocity", "bungeecord"
     };
 
-    public async Task UpdateServerTypeAsync(string name, string serverType, CancellationToken cancellationToken)
+    private static readonly HashSet<string> AllowedProxyKinds = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "velocity", "bungeecord"
+    };
+
+    /// <summary>
+    /// Normalizes a caller-supplied proxy implementation to a known kind. Null or
+    /// empty means "velocity" (the default proxy, and what pre-ProxyKind clients
+    /// send). Anything else is rejected rather than silently treated as BungeeCord.
+    /// </summary>
+    private static string NormalizeProxyKind(string? proxyKind)
+    {
+        if (string.IsNullOrWhiteSpace(proxyKind))
+            return "velocity";
+
+        if (!AllowedProxyKinds.Contains(proxyKind))
+            throw new ArgumentException($"Invalid proxy kind: '{proxyKind}'");
+
+        return proxyKind.ToLowerInvariant();
+    }
+
+    public async Task UpdateServerTypeAsync(string name, string serverType, string? proxyKind, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(serverType) || !AllowedServerTypes.Contains(serverType))
             throw new ArgumentException($"Invalid server type: '{serverType}'");
@@ -1828,14 +2316,14 @@ public class ServerService : IServerService
         await File.WriteAllTextAsync(
             Path.Combine(serverPath, ServerTypeFile), normalized, cancellationToken);
 
-        // When converting an existing server to a proxy, bootstrap velocity.toml
-        // the same way CreateServerAsync does: pre-populated with sibling Java
-        // backends and an empty [forced-hosts] table. Mirrors the wizard so a
-        // type-changed proxy is functional from the first launch.
+        // When converting an existing server to a proxy, bootstrap the right
+        // config file (mirrors CreateServerAsync): pre-populated with sibling
+        // Java backends so a type-changed proxy is functional from first launch.
+        // proxyKind narrows to velocity (TOML) vs bungeecord (YAML).
         if (normalized == "proxy")
         {
-            // Velocity rejects `nogui`; flip unconventional so the launcher won't
-            // append it (wizard-created proxies already set this at creation).
+            // Neither proxy accepts `nogui`; flip unconventional so the launcher
+            // won't append it (wizard-created proxies already set this at creation).
             var config = await GetServerConfigAsync(name, cancellationToken);
             if (!config.Minecraft.Unconventional)
             {
@@ -1845,22 +2333,50 @@ public class ServerService : IServerService
                     cancellationToken);
             }
 
-            var tomlPath = GetVelocityTomlPath(name);
-            if (!File.Exists(tomlPath))
+            var kind = NormalizeProxyKind(proxyKind);
+            var backends = await DiscoverJavaBackendsAsync(name, cancellationToken);
+
+            if (kind == "velocity")
             {
-                var backends = await DiscoverJavaBackendsAsync(name, cancellationToken);
-                var initialConfig = VelocityConfigDefaults(exists: true) with
+                var tomlPath = GetVelocityTomlPath(name);
+                if (!File.Exists(tomlPath))
                 {
-                    Servers = backends,
-                    Try = backends.Count > 0
-                        ? new List<string> { backends.Keys.First() }
-                        : new List<string>()
-                };
-                await WriteVelocityTomlAsync(tomlPath, initialConfig, cancellationToken);
+                    var initialConfig = VelocityConfigDefaults(exists: true) with
+                    {
+                        Servers = backends,
+                        Try = backends.Count > 0
+                            ? new List<string> { backends.Keys.First() }
+                            : new List<string>()
+                    };
+                    await WriteVelocityTomlAsync(tomlPath, initialConfig, cancellationToken);
+                }
+            }
+            else
+            {
+                var yamlPath = GetBungeeConfigPath(name);
+                if (!File.Exists(yamlPath))
+                {
+                    // See CreateServerAsync — BungeeCord requires at least one
+                    // entry in servers: or it fails to start.
+                    var bungeeBackends = backends.Count > 0
+                        ? backends.ToDictionary(
+                            kv => kv.Key,
+                            kv => new BungeeBackendDto(kv.Value, "&1Backend server", false))
+                        : new Dictionary<string, BungeeBackendDto>
+                        {
+                            ["lobby"] = new("127.0.0.1:25565", "&1Just another BungeeCord - Forced Host", false)
+                        };
+                    var initialConfig = BungeeConfigDefaults(exists: true) with
+                    {
+                        Servers = bungeeBackends,
+                        Priorities = new List<string> { bungeeBackends.Keys.First() }
+                    };
+                    await WriteBungeeConfigAsync(yamlPath, initialConfig, cancellationToken);
+                }
             }
         }
 
-        _logger.LogInformation("Updated server type for {Server} to {Type}", name, normalized);
+        _logger.LogInformation("Updated server type for {Server} to {Type} (proxyKind={Kind})", name, normalized, proxyKind ?? "n/a");
     }
 
     private static readonly System.Text.RegularExpressions.Regex[] JarLoaderPatterns =

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -198,6 +198,13 @@ public class ServerService : IServerService
         if (request.Name.Contains(".."))
             throw new ArgumentException("Server name cannot contain '..'");
 
+        // Validate the proxy kind before anything is created on disk. Otherwise an
+        // unrecognized value throws part-way through the proxy branch below and
+        // leaves a half-built server behind. NormalizeProxyKind is pure, so the
+        // call in that branch can stay as-is.
+        if (string.Equals(request.ServerType, "proxy", StringComparison.OrdinalIgnoreCase))
+            NormalizeProxyKind(request.ProxyKind);
+
         var serverPath = GetServerPath(request.Name);
         var backupPath = GetBackupPath(request.Name);
         var archivePath = GetArchivePath(request.Name);
@@ -1364,7 +1371,18 @@ public class ServerService : IServerService
         }
 
         var content = await File.ReadAllTextAsync(yamlPath, cancellationToken);
-        return ParseBungeeConfig(content);
+        try
+        {
+            return ParseBungeeConfig(content);
+        }
+        catch (YamlDotNet.Core.YamlException ex)
+        {
+            // Translated here rather than caught in the Api layer: YamlException is
+            // an Infrastructure detail, and letting it escape produced an opaque 500
+            // that took the whole Properties tab down with no explanation.
+            throw new InvalidOperationException(
+                $"config.yml for '{name}' is not valid YAML: {ex.Message}", ex);
+        }
     }
 
     /// <summary>
@@ -1514,33 +1532,44 @@ public class ServerService : IServerService
         // The collections are non-nullable on the record, but this DTO is bound
         // straight from a PUT body and System.Text.Json leaves them null when the
         // client omits the property — nullable reference types are not enforced at
-        // runtime. Treat a missing collection as empty rather than throwing.
-        var prioritiesSeq = new YamlSequenceNode();
-        foreach (var p in config.Priorities ?? new List<string>())
+        // runtime. A null here means "the client said nothing about this key", which
+        // must leave whatever is already in the file alone. Writing an empty node
+        // instead would silently wipe the backend map on any partial PUT.
+        if (config.Priorities is not null)
         {
-            prioritiesSeq.Children.Add(new YamlScalarNode(p));
-        }
-        firstListener.Children[new YamlScalarNode("priorities")] = prioritiesSeq;
-
-        var forcedHostsMap = new YamlMappingNode();
-        foreach (var (host, target) in config.ForcedHosts ?? new Dictionary<string, string>())
-        {
-            forcedHostsMap.Children[new YamlScalarNode(host)] = new YamlScalarNode(target ?? string.Empty);
-        }
-        firstListener.Children[new YamlScalarNode("forced_hosts")] = forcedHostsMap;
-
-        var serversMap = new YamlMappingNode();
-        foreach (var (key, backend) in config.Servers ?? new Dictionary<string, BungeeBackendDto>())
-        {
-            var entry = new YamlMappingNode
+            var prioritiesSeq = new YamlSequenceNode();
+            foreach (var p in config.Priorities)
             {
-                { new YamlScalarNode("address"), new YamlScalarNode(backend?.Address ?? string.Empty) },
-                { new YamlScalarNode("motd"), new YamlScalarNode(backend?.Motd ?? string.Empty) },
-                { new YamlScalarNode("restricted"), new YamlScalarNode(backend?.Restricted == true ? "true" : "false") }
-            };
-            serversMap.Children[new YamlScalarNode(key)] = entry;
+                prioritiesSeq.Children.Add(new YamlScalarNode(p));
+            }
+            firstListener.Children[new YamlScalarNode("priorities")] = prioritiesSeq;
         }
-        root.Children[new YamlScalarNode("servers")] = serversMap;
+
+        if (config.ForcedHosts is not null)
+        {
+            var forcedHostsMap = new YamlMappingNode();
+            foreach (var (host, target) in config.ForcedHosts)
+            {
+                forcedHostsMap.Children[new YamlScalarNode(host)] = new YamlScalarNode(target ?? string.Empty);
+            }
+            firstListener.Children[new YamlScalarNode("forced_hosts")] = forcedHostsMap;
+        }
+
+        if (config.Servers is not null)
+        {
+            var serversMap = new YamlMappingNode();
+            foreach (var (key, backend) in config.Servers)
+            {
+                var entry = new YamlMappingNode
+                {
+                    { new YamlScalarNode("address"), new YamlScalarNode(backend?.Address ?? string.Empty) },
+                    { new YamlScalarNode("motd"), new YamlScalarNode(backend?.Motd ?? string.Empty) },
+                    { new YamlScalarNode("restricted"), new YamlScalarNode(backend?.Restricted == true ? "true" : "false") }
+                };
+                serversMap.Children[new YamlScalarNode(key)] = entry;
+            }
+            root.Children[new YamlScalarNode("servers")] = serversMap;
+        }
 
         var writer = new StringWriter();
         new YamlStream(new YamlDocument(root)).Save(writer, assignAnchors: false);
@@ -2065,20 +2094,19 @@ public class ServerService : IServerService
         CancellationToken cancellationToken)
     {
         var logPath = Path.Combine(serverPath, "logs", "latest.log");
+        // BungeeCord logs to proxy.log.0 in the server root rather than
+        // logs/latest.log, so it never trips the latest.log check. Both are
+        // written by the server's own logger, which only runs once the process
+        // is genuinely up — unlike startup.log, which also captures JVM-level
+        // failure output (bad Java version, missing jar, unaccepted EULA) and
+        // so cannot distinguish a started server from a crashed one.
+        var logCandidates = new[]
+        {
+            logPath,
+            Path.Combine(serverPath, "proxy.log.0")
+        };
         var timeout = TimeSpan.FromSeconds(10);
         var started = DateTimeOffset.UtcNow;
-
-        // Brief settle so the echo'd "Launching <name>" line lands before we
-        // sample the baseline. The launcher writes that line via echo BEFORE
-        // exec'ing the server; we want to count only output past it as proof
-        // the server produced output of its own.
-        await Task.Delay(300, cancellationToken);
-        long startupBaselineBytes = 0;
-        if (File.Exists(startupLogPath))
-        {
-            try { startupBaselineBytes = new FileInfo(startupLogPath).Length; }
-            catch (IOException) { }
-        }
 
         while (DateTimeOffset.UtcNow - started < timeout)
         {
@@ -2095,28 +2123,16 @@ public class ServerService : IServerService
                 return;
             }
 
-            if (File.Exists(logPath))
+            foreach (var candidate in logCandidates)
             {
-                var logInfo = new FileInfo(logPath);
+                if (!File.Exists(candidate))
+                {
+                    continue;
+                }
+                var logInfo = new FileInfo(candidate);
                 if (logInfo.LastWriteTimeUtc >= startTime.UtcDateTime)
                 {
-                    _logger.LogInformation("Detected log output for {ServerName} at {LogPath}", name, logPath);
-                    return;
-                }
-            }
-
-            // Fallback: the launcher tees stdout/stderr to startup.log. Any growth
-            // past the baseline means the server emitted output of its own — this
-            // is what covers BungeeCord, which writes proxy.log.0 rather than
-            // logs/latest.log and so never trips the check above.
-            if (File.Exists(startupLogPath))
-            {
-                var startupInfo = new FileInfo(startupLogPath);
-                if (startupInfo.Length > startupBaselineBytes)
-                {
-                    _logger.LogInformation(
-                        "Detected startup activity for {ServerName} at {LogPath} (grew from {Baseline} to {Length} bytes)",
-                        name, startupLogPath, startupBaselineBytes, startupInfo.Length);
+                    _logger.LogInformation("Detected log output for {ServerName} at {LogPath}", name, candidate);
                     return;
                 }
             }
@@ -2313,6 +2329,23 @@ public class ServerService : IServerService
             throw new DirectoryNotFoundException($"Server '{name}' not found");
 
         var normalized = serverType.ToLowerInvariant();
+
+        // "velocity" and "bungeecord" are accepted server types, but writing either
+        // verbatim to .mineos-server-type breaks every DetectServerType(name) ==
+        // "proxy" branch downstream (EULA skip, "end" vs "stop" on shutdown, which
+        // file the listen endpoint is read from). Normalize to "proxy" and let the
+        // value imply the proxy kind when the caller did not pass one.
+        string? requestedKind = proxyKind;
+        if (normalized is "velocity" or "bungeecord")
+        {
+            requestedKind ??= normalized;
+            normalized = "proxy";
+        }
+
+        // Validate before writing anything: an invalid kind must not leave a server
+        // marked "proxy" with no proxy config behind.
+        var kind = normalized == "proxy" ? NormalizeProxyKind(requestedKind) : null;
+
         await File.WriteAllTextAsync(
             Path.Combine(serverPath, ServerTypeFile), normalized, cancellationToken);
 
@@ -2333,7 +2366,6 @@ public class ServerService : IServerService
                     cancellationToken);
             }
 
-            var kind = NormalizeProxyKind(proxyKind);
             var backends = await DiscoverJavaBackendsAsync(name, cancellationToken);
 
             if (kind == "velocity")

--- a/apps/MineOS.Tests/Unit/BungeeConfigTests.cs
+++ b/apps/MineOS.Tests/Unit/BungeeConfigTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text.Json;
 using MineOS.Application.Dtos;
 using MineOS.Infrastructure.Services;
@@ -258,6 +259,53 @@ public class BungeeConfigTests
         // MineOS SLP-pings proxies on every heartbeat; BungeeCord's own default of
         // log_pings: true would flood the console with one line per poll.
         Assert.False(ServerService.BungeeConfigDefaults(exists: true).LogPings);
+    }
+
+    [Fact]
+    public void Serialize_Preserves_Existing_Servers_When_The_Request_Omits_Them()
+    {
+        // The dangerous half of the null-collection case. Tolerating null by writing
+        // an empty node turns any partial PUT into a silent wipe of every backend the
+        // proxy has — worse than the 500 it replaced, because nothing reports it.
+        var partialBody = """
+            {"exists":true,"onlineMode":true,"host":"0.0.0.0:25577",
+             "motd":"x","maxPlayers":1,"tabList":"GLOBAL_PING"}
+            """;
+        var config = JsonSerializer.Deserialize<BungeeConfigDto>(
+            partialBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+        Assert.Null(config.Servers);       // guards the premise
+        Assert.Null(config.Priorities);
+        Assert.Null(config.ForcedHosts);
+
+        var reparsed = ServerService.ParseBungeeConfig(
+            ServerService.SerializeBungeeConfig(config, existingYaml: SampleConfig));
+
+        // The edit the client did ask for still lands...
+        Assert.Equal("0.0.0.0:25577", reparsed.Host);
+
+        // ...and everything it said nothing about survives.
+        var sample = ParseSample();
+        Assert.Equal(sample.Servers.Keys.OrderBy(k => k), reparsed.Servers.Keys.OrderBy(k => k));
+        Assert.NotEmpty(reparsed.Servers);
+        Assert.Equal(sample.Priorities, reparsed.Priorities);
+        Assert.Equal(sample.ForcedHosts, reparsed.ForcedHosts);
+    }
+
+    [Fact]
+    public void Serialize_Still_Clears_Collections_When_The_Request_Sends_Them_Empty()
+    {
+        // An explicitly empty collection is a real instruction ("remove them all")
+        // and must stay distinguishable from an omitted one.
+        var config = ServerService.BungeeConfigDefaults(exists: true) with
+        {
+            Servers = new Dictionary<string, BungeeBackendDto>()
+        };
+
+        var reparsed = ServerService.ParseBungeeConfig(
+            ServerService.SerializeBungeeConfig(config, existingYaml: SampleConfig));
+
+        Assert.Empty(reparsed.Servers);
     }
 
     private static BungeeConfigDto ParseSample() => ServerService.ParseBungeeConfig(SampleConfig);

--- a/apps/MineOS.Tests/Unit/BungeeConfigTests.cs
+++ b/apps/MineOS.Tests/Unit/BungeeConfigTests.cs
@@ -1,0 +1,264 @@
+using System.Text.Json;
+using MineOS.Application.Dtos;
+using MineOS.Infrastructure.Services;
+
+namespace MineOS.Tests.Unit;
+
+/// <summary>
+/// Covers the config.yml mapping behind the BungeeCord proxy editor. The two things
+/// worth guarding are that we read BungeeCord's real file shape (listener settings
+/// live inside listeners[0], not at the root) and that saving preserves the keys the
+/// editor does not model.
+/// </summary>
+public class BungeeConfigTests
+{
+    // Trimmed from a config.yml BungeeCord generates on first launch. Keeps the
+    // nesting and a few keys the editor never surfaces (groups, permissions).
+    private const string SampleConfig = """
+        online_mode: true
+        ip_forward: false
+        player_limit: -1
+        timeout: 30000
+        network_compression_threshold: 256
+        forge_support: false
+        log_commands: false
+        log_pings: true
+        connection_throttle: 4000
+        connection_throttle_limit: 3
+        stats: 6d9e9d3b-0000-4000-8000-a1b2c3d4e5f6
+        groups:
+          md_5:
+          - admin
+        permissions:
+          default:
+          - bungeecord.command.server
+        disabled_commands:
+        - disabledcommandhere
+        listeners:
+        - host: 0.0.0.0:25577
+          motd: '&1Another Bungee server'
+          max_players: 1
+          query_enabled: false
+          query_port: 25577
+          ping_passthrough: false
+          force_default_server: false
+          tab_list: GLOBAL_PING
+          proxy_protocol: false
+          priorities:
+          - lobby
+          forced_hosts:
+            pvp.md-5.net: pvp
+        servers:
+          lobby:
+            address: localhost:25565
+            motd: '&1Just another BungeeCord - Forced Host'
+            restricted: false
+        """;
+
+    [Fact]
+    public void Parse_Reads_Root_Level_Settings()
+    {
+        var config = ParseSample();
+
+        Assert.True(config.Exists);
+        Assert.True(config.OnlineMode);
+        Assert.False(config.IpForward);
+        Assert.Equal(-1, config.PlayerLimit);
+        Assert.Equal(30000, config.Timeout);
+        Assert.Equal(256, config.NetworkCompressionThreshold);
+        Assert.Equal(4000, config.ConnectionThrottle);
+        Assert.Equal(3, config.ConnectionThrottleLimit);
+    }
+
+    [Fact]
+    public void Parse_Reads_Settings_From_First_Listener_Not_Root()
+    {
+        var config = ParseSample();
+
+        Assert.Equal("0.0.0.0:25577", config.Host);
+        Assert.Equal("&1Another Bungee server", config.Motd);
+        Assert.Equal(1, config.MaxPlayers);
+        Assert.Equal(25577, config.QueryPort);
+        Assert.Equal("GLOBAL_PING", config.TabList);
+        Assert.Equal(new[] { "lobby" }, config.Priorities);
+        Assert.Equal("pvp", Assert.Contains("pvp.md-5.net", config.ForcedHosts));
+    }
+
+    [Fact]
+    public void Parse_Reads_Backend_Servers()
+    {
+        var config = ParseSample();
+
+        var lobby = Assert.Contains("lobby", config.Servers);
+        Assert.Equal("localhost:25565", lobby.Address);
+        Assert.Equal("&1Just another BungeeCord - Forced Host", lobby.Motd);
+        Assert.False(lobby.Restricted);
+    }
+
+    [Fact]
+    public void Parse_Falls_Back_To_Defaults_For_Missing_Keys()
+    {
+        // A file with nothing but a servers map — every other key should default.
+        var config = ServerService.ParseBungeeConfig("servers:\n  lobby:\n    address: localhost:25565\n");
+        var defaults = ServerService.BungeeConfigDefaults(exists: true);
+
+        Assert.Equal(defaults.Timeout, config.Timeout);
+        Assert.Equal(defaults.Host, config.Host);
+        Assert.Equal(defaults.TabList, config.TabList);
+        Assert.Equal(defaults.ConnectionThrottle, config.ConnectionThrottle);
+        Assert.Empty(config.Priorities);
+    }
+
+    [Fact]
+    public void Parse_Reports_Empty_Document_As_Defaults()
+    {
+        var config = ServerService.ParseBungeeConfig("");
+        var defaults = ServerService.BungeeConfigDefaults(exists: true);
+
+        // Compared field-by-field: BungeeConfigDto's record equality compares its
+        // List/Dictionary members by reference, so two structurally-equal instances
+        // are never Equal.
+        Assert.True(config.Exists);
+        Assert.Equal(defaults.OnlineMode, config.OnlineMode);
+        Assert.Equal(defaults.Timeout, config.Timeout);
+        Assert.Equal(defaults.Host, config.Host);
+        Assert.Equal(defaults.Motd, config.Motd);
+        Assert.Equal(defaults.MaxPlayers, config.MaxPlayers);
+        Assert.Equal(defaults.TabList, config.TabList);
+        Assert.Empty(config.Priorities);
+        Assert.Empty(config.ForcedHosts);
+        Assert.Empty(config.Servers);
+    }
+
+    [Fact]
+    public void RoundTrip_Preserves_Edited_Values()
+    {
+        var edited = ParseSample() with
+        {
+            Motd = "&aEdited MOTD",
+            MaxPlayers = 200,
+            IpForward = true,
+            Priorities = new List<string> { "lobby", "survival" },
+            Servers = new Dictionary<string, BungeeBackendDto>
+            {
+                ["lobby"] = new("localhost:25565", "&1Lobby", false),
+                ["survival"] = new("localhost:25566", "&2Survival", true)
+            }
+        };
+
+        var reparsed = ServerService.ParseBungeeConfig(
+            ServerService.SerializeBungeeConfig(edited, SampleConfig));
+
+        Assert.Equal("&aEdited MOTD", reparsed.Motd);
+        Assert.Equal(200, reparsed.MaxPlayers);
+        Assert.True(reparsed.IpForward);
+        Assert.Equal(new[] { "lobby", "survival" }, reparsed.Priorities);
+        Assert.Equal(2, reparsed.Servers.Count);
+        Assert.True(Assert.Contains("survival", reparsed.Servers).Restricted);
+    }
+
+    [Fact]
+    public void RoundTrip_Preserves_Keys_The_Editor_Does_Not_Model()
+    {
+        // groups / permissions / disabled_commands / stats have no DTO field. Dropping
+        // them on save would silently wipe a user's proxy permissions.
+        var yaml = ServerService.SerializeBungeeConfig(ParseSample(), SampleConfig);
+
+        Assert.Contains("groups:", yaml);
+        Assert.Contains("permissions:", yaml);
+        Assert.Contains("disabled_commands:", yaml);
+        Assert.Contains("6d9e9d3b-0000-4000-8000-a1b2c3d4e5f6", yaml);
+        Assert.Contains("bungeecord.command.server", yaml);
+    }
+
+    [Fact]
+    public void RoundTrip_Preserves_Additional_Listeners()
+    {
+        // The editor only exposes listeners[0]; a second listener must survive.
+        var twoListeners = SampleConfig.Replace(
+            "servers:",
+            "- host: 0.0.0.0:25578\n  motd: '&2Second listener'\n  max_players: 5\nservers:");
+
+        var config = ServerService.ParseBungeeConfig(twoListeners);
+        var yaml = ServerService.SerializeBungeeConfig(config with { Motd = "&aFirst only" }, twoListeners);
+        var reparsed = ServerService.ParseBungeeConfig(yaml);
+
+        Assert.Equal("&aFirst only", reparsed.Motd);
+        Assert.Contains("&2Second listener", yaml);
+        Assert.Contains("0.0.0.0:25578", yaml);
+    }
+
+    [Fact]
+    public void Serialize_Without_Existing_File_Emits_A_Usable_Config()
+    {
+        var config = ServerService.BungeeConfigDefaults(exists: true) with
+        {
+            Host = "0.0.0.0:25580",
+            Servers = new Dictionary<string, BungeeBackendDto>
+            {
+                ["lobby"] = new("127.0.0.1:25565", "&1Lobby", false)
+            },
+            Priorities = new List<string> { "lobby" }
+        };
+
+        var reparsed = ServerService.ParseBungeeConfig(
+            ServerService.SerializeBungeeConfig(config, existingYaml: null));
+
+        Assert.Equal("0.0.0.0:25580", reparsed.Host);
+        Assert.Equal(new[] { "lobby" }, reparsed.Priorities);
+        Assert.Equal("127.0.0.1:25565", Assert.Contains("lobby", reparsed.Servers).Address);
+    }
+
+    [Fact]
+    public void Serialize_Tolerates_Null_Collections_From_A_Partial_Request_Body()
+    {
+        // BungeeConfigDto is bound straight from the PUT body. Its collection
+        // properties are declared non-nullable, but System.Text.Json leaves them
+        // null when the client omits them — nullable reference types are not
+        // enforced at runtime. Without a guard this threw NullReferenceException
+        // and surfaced as an unhandled 500.
+        var partialBody = """
+            {"exists":true,"onlineMode":true,"host":"0.0.0.0:25577",
+             "motd":"x","maxPlayers":1,"tabList":"GLOBAL_PING"}
+            """;
+        var config = JsonSerializer.Deserialize<BungeeConfigDto>(
+            partialBody, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
+
+        Assert.Null(config.Priorities); // guards the premise of this test
+        Assert.Null(config.Servers);
+
+        var reparsed = ServerService.ParseBungeeConfig(
+            ServerService.SerializeBungeeConfig(config, existingYaml: null));
+
+        Assert.Equal("0.0.0.0:25577", reparsed.Host);
+        Assert.Empty(reparsed.Priorities);
+        Assert.Empty(reparsed.Servers);
+        Assert.Empty(reparsed.ForcedHosts);
+    }
+
+    [Fact]
+    public void Serialize_Tolerates_A_Null_Backend_Entry()
+    {
+        var config = ServerService.BungeeConfigDefaults(exists: true) with
+        {
+            Servers = new Dictionary<string, BungeeBackendDto> { ["lobby"] = null! }
+        };
+
+        var reparsed = ServerService.ParseBungeeConfig(
+            ServerService.SerializeBungeeConfig(config, existingYaml: null));
+
+        var lobby = Assert.Contains("lobby", reparsed.Servers);
+        Assert.Equal("", lobby.Address);
+        Assert.False(lobby.Restricted);
+    }
+
+    [Fact]
+    public void Defaults_Disable_Ping_Logging()
+    {
+        // MineOS SLP-pings proxies on every heartbeat; BungeeCord's own default of
+        // log_pings: true would flood the console with one line per poll.
+        Assert.False(ServerService.BungeeConfigDefaults(exists: true).LogPings);
+    }
+
+    private static BungeeConfigDto ParseSample() => ServerService.ParseBungeeConfig(SampleConfig);
+}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -232,6 +232,21 @@ export async function updateVelocityConfig(
 	return apiPut(fetcher, `/api/servers/${name}/velocity-config`, config);
 }
 
+export async function getBungeeConfig(
+	fetcher: Fetcher,
+	name: string
+): Promise<ApiResult<import('./types').BungeeConfig>> {
+	return apiFetch(fetcher, `/api/servers/${name}/bungee-config`);
+}
+
+export async function updateBungeeConfig(
+	fetcher: Fetcher,
+	name: string,
+	config: import('./types').BungeeConfig
+): Promise<ApiResult<void>> {
+	return apiPut(fetcher, `/api/servers/${name}/bungee-config`, config);
+}
+
 export async function acceptEula(fetcher: Fetcher, name: string): Promise<ApiResult<void>> {
 	return apiPost(fetcher, `/api/servers/${name}/eula`);
 }

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -107,6 +107,38 @@ export type VelocityConfig = {
 	forcedHosts: Record<string, string[]>;
 };
 
+export type BungeeBackend = {
+	address: string;
+	motd: string;
+	restricted: boolean;
+};
+
+export type BungeeConfig = {
+	exists: boolean;
+	onlineMode: boolean;
+	ipForward: boolean;
+	playerLimit: number;
+	timeout: number;
+	networkCompressionThreshold: number;
+	forgeSupport: boolean;
+	logCommands: boolean;
+	logPings: boolean;
+	connectionThrottle: number;
+	connectionThrottleLimit: number;
+	host: string;
+	motd: string;
+	maxPlayers: number;
+	queryEnabled: boolean;
+	queryPort: number;
+	pingPassthrough: boolean;
+	forceDefaultServer: boolean;
+	tabList: string;
+	proxyProtocol: boolean;
+	priorities: string[];
+	forcedHosts: Record<string, string>;
+	servers: Record<string, BungeeBackend>;
+};
+
 export type JavaConfig = {
 	javaBinary: string;
 	javaXmx: number;
@@ -183,6 +215,9 @@ export type CreateServerRequest = {
 	ownerUid: number;
 	ownerGid: number;
 	serverType?: string;
+	// When serverType is "proxy", proxyKind narrows the implementation
+	// so the backend bootstraps the right config file (velocity.toml vs config.yml).
+	proxyKind?: 'velocity' | 'bungeecord';
 };
 
 export type CloneServerRequest = {

--- a/apps/web/src/lib/components/ChangeServerType.svelte
+++ b/apps/web/src/lib/components/ChangeServerType.svelte
@@ -19,7 +19,7 @@
 		onComplete: () => void;
 	} = $props();
 
-	type ServerType = 'vanilla' | 'paper' | 'spigot' | 'forge' | 'neoforge' | 'fabric' | 'quilt' | 'velocity';
+	type ServerType = 'vanilla' | 'paper' | 'spigot' | 'forge' | 'neoforge' | 'fabric' | 'quilt' | 'velocity' | 'bungeecord';
 
 	const serverTypes: { id: ServerType; name: string; category: string }[] = [
 		{ id: 'vanilla', name: 'Vanilla', category: 'vanilla' },
@@ -30,7 +30,10 @@
 		{ id: 'fabric', name: 'Fabric', category: 'mods' },
 		{ id: 'quilt', name: 'Quilt', category: 'mods' },
 		{ id: 'velocity', name: 'Velocity', category: 'proxy' },
+		{ id: 'bungeecord', name: 'BungeeCord', category: 'proxy' },
 	];
+
+	const proxyTypes = new Set<ServerType>(['velocity', 'bungeecord']);
 
 	// Detect current server category from jar name
 	function detectCategory(jar: string | null, type: string): string {
@@ -78,6 +81,7 @@
 					case 'forge': return p.group === 'forge';
 				case 'fabric': return p.group === 'fabric';
 				case 'velocity': return p.group === 'velocity';
+				case 'bungeecord': return p.group === 'bungeecord';
 				case 'bedrock': return p.group === 'bedrock-server' || p.group === 'bedrock-server-preview';
 				default: return false;
 			}
@@ -281,16 +285,19 @@
 	async function markInstallComplete() {
 		installCompleted = true;
 		// Update the .mineos-server-type file so detection works immediately.
-		// Velocity is recorded as the generic "proxy" marker so all proxy-specific
-		// branches (skip EULA, ping via velocity.toml, send "end" not "stop", etc.)
-		// match — same as a proxy created via the wizard.
+		// All proxy implementations are recorded as the generic "proxy" marker so
+		// proxy-specific branches (skip EULA, ping via velocity.toml/config.yml,
+		// send "end" not "stop") match — same as a proxy created via the wizard.
+		// proxyKind tells the backend which config to bootstrap.
 		if (selectedType) {
-			const markerType = selectedType === 'velocity' ? 'proxy' : selectedType;
+			const isProxy = proxyTypes.has(selectedType);
+			const markerType = isProxy ? 'proxy' : selectedType;
+			const proxyKind = isProxy ? selectedType : undefined;
 			try {
 				await fetch(`/api/servers/${encodeURIComponent(serverName)}/server-type`, {
 					method: 'PUT',
 					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ serverType: markerType })
+					body: JSON.stringify({ serverType: markerType, proxyKind })
 				});
 			} catch { /* best effort */ }
 		}

--- a/apps/web/src/routes/(app)/about/+page.svelte
+++ b/apps/web/src/routes/(app)/about/+page.svelte
@@ -239,7 +239,6 @@
 					<h4>Platform</h4>
 					<ul>
 						<li><span class="status planned">Planned</span> <a href="https://github.com/freeman412/mineos-sveltekit/issues/63" target="_blank" rel="noopener noreferrer">Velocity proxy support</a></li>
-						<li><span class="status planned">Planned</span> <a href="https://github.com/freeman412/mineos-sveltekit/issues/64" target="_blank" rel="noopener noreferrer">BungeeCord proxy support</a></li>
 						<li><span class="status planned">Planned</span> <a href="https://github.com/freeman412/mineos-sveltekit/issues/25" target="_blank" rel="noopener noreferrer">OAuth login (Discord/Google)</a></li>
 						<li><span class="status planned">Planned</span> <a href="https://github.com/freeman412/mineos-sveltekit/issues/87" target="_blank" rel="noopener noreferrer">TurnKey Linux appliance</a></li>
 					</ul>

--- a/apps/web/src/routes/(app)/servers/[name]/+layout.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/+layout.svelte
@@ -37,12 +37,12 @@
 	);
 
 	// For proxies, the SLP ping returns a protocol-range string ("Velocity 1.7.2-1.18.1")
-	// that's confusing in the page header. Derive the actual proxy build (e.g. "Velocity 3.1.1")
-	// from the jar filename so the chip says what's running.
+	// that's confusing in the page header. Derive the actual proxy build (e.g. "Velocity 3.1.1",
+	// "BungeeCord build-2068") from the jar filename so the chip says what's running.
 	const proxyVersionFromJar = $derived.by(() => {
 		if (!isProxy) return null;
 		const raw = server?.config?.java?.jarFile ?? '';
-		const m = raw.match(/^(velocity|bungeecord|waterfall)-(\d+\.\d+(?:\.\d+)?)/i);
+		const m = raw.match(/^(velocity|bungeecord|waterfall)-(.+?)\.jar$/i);
 		if (!m) return null;
 		const name = m[1].charAt(0).toUpperCase() + m[1].slice(1).toLowerCase();
 		return `${name} ${m[2]}`;

--- a/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.server.ts
+++ b/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.server.ts
@@ -8,28 +8,49 @@ import {
 } from '$lib/api/client';
 import { fail } from '@sveltejs/kit';
 
-// Detect which proxy implementation is installed by inspecting the jar name.
-// Used by the page to decide which config editor to render and which API to hit.
-// Falls back to "velocity" so an empty proxy server keeps showing the existing
-// editor (matches behavior before BungeeCord support landed).
-function detectProxyKind(jar: string | null): 'velocity' | 'bungeecord' {
+// Which proxy implementation this server actually runs. The config file on disk
+// is authoritative: the jar name is not, because an imported, renamed, or
+// not-yet-downloaded jar sends a BungeeCord server down the Velocity branch,
+// and saving there writes a stray velocity.toml that
+// GetServerListenEndpointAsync then *prefers* over config.yml — so the dashboard
+// silently reads the wrong port from that point on.
+//
+// The jar name is kept only as a tiebreak for a proxy with neither file yet,
+// and "velocity" remains the final fallback so an empty proxy server keeps
+// showing the existing editor (matches behavior before BungeeCord landed).
+function detectProxyKindFromJar(jar: string | null): 'velocity' | 'bungeecord' {
 	const j = (jar ?? '').toLowerCase();
 	if (j.includes('bungeecord')) return 'bungeecord';
 	return 'velocity';
 }
 
 export const load: PageServerLoad = async ({ params, fetch }) => {
-	const server = await getServer(fetch, params.name);
-	const jar = server.data?.config?.java?.jarFile ?? null;
-	const proxyKind = detectProxyKind(jar);
+	// Both endpoints report `exists` for their own config file, so this resolves
+	// the kind without a new API surface.
+	const [velocityConfig, bungeeConfig] = await Promise.all([
+		getVelocityConfig(fetch, params.name),
+		getBungeeConfig(fetch, params.name)
+	]);
 
-	if (proxyKind === 'velocity') {
-		const config = await getVelocityConfig(fetch, params.name);
-		return { proxyKind, velocityConfig: config, bungeeConfig: null, serverName: params.name };
+	const hasVelocity = velocityConfig.data?.exists ?? false;
+	const hasBungee = bungeeConfig.data?.exists ?? false;
+
+	let proxyKind: 'velocity' | 'bungeecord';
+	if (hasVelocity !== hasBungee) {
+		proxyKind = hasVelocity ? 'velocity' : 'bungeecord';
+	} else {
+		// Neither file exists yet, or (after a past mis-detection) both do —
+		// fall back to the jar name.
+		const server = await getServer(fetch, params.name);
+		proxyKind = detectProxyKindFromJar(server.data?.config?.java?.jarFile ?? null);
 	}
 
-	const config = await getBungeeConfig(fetch, params.name);
-	return { proxyKind, velocityConfig: null, bungeeConfig: config, serverName: params.name };
+	return {
+		proxyKind,
+		velocityConfig: proxyKind === 'velocity' ? velocityConfig : null,
+		bungeeConfig: proxyKind === 'bungeecord' ? bungeeConfig : null,
+		serverName: params.name
+	};
 };
 
 export const actions = {

--- a/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.server.ts
+++ b/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.server.ts
@@ -1,19 +1,42 @@
 import type { PageServerLoad, Actions } from './$types';
-import { getVelocityConfig, updateVelocityConfig } from '$lib/api/client';
+import {
+	getVelocityConfig,
+	updateVelocityConfig,
+	getBungeeConfig,
+	updateBungeeConfig,
+	getServer
+} from '$lib/api/client';
 import { fail } from '@sveltejs/kit';
 
+// Detect which proxy implementation is installed by inspecting the jar name.
+// Used by the page to decide which config editor to render and which API to hit.
+// Falls back to "velocity" so an empty proxy server keeps showing the existing
+// editor (matches behavior before BungeeCord support landed).
+function detectProxyKind(jar: string | null): 'velocity' | 'bungeecord' {
+	const j = (jar ?? '').toLowerCase();
+	if (j.includes('bungeecord')) return 'bungeecord';
+	return 'velocity';
+}
+
 export const load: PageServerLoad = async ({ params, fetch }) => {
-	const config = await getVelocityConfig(fetch, params.name);
-	return {
-		config,
-		serverName: params.name
-	};
+	const server = await getServer(fetch, params.name);
+	const jar = server.data?.config?.java?.jarFile ?? null;
+	const proxyKind = detectProxyKind(jar);
+
+	if (proxyKind === 'velocity') {
+		const config = await getVelocityConfig(fetch, params.name);
+		return { proxyKind, velocityConfig: config, bungeeConfig: null, serverName: params.name };
+	}
+
+	const config = await getBungeeConfig(fetch, params.name);
+	return { proxyKind, velocityConfig: null, bungeeConfig: config, serverName: params.name };
 };
 
 export const actions = {
 	default: async ({ request, params, fetch }) => {
 		const data = await request.formData();
 		const configJson = data.get('config')?.toString();
+		const kind = data.get('proxyKind')?.toString() ?? 'velocity';
 
 		if (!configJson) {
 			return fail(400, { error: 'Config data is required' });
@@ -21,7 +44,10 @@ export const actions = {
 
 		try {
 			const config = JSON.parse(configJson);
-			const result = await updateVelocityConfig(fetch, params.name, config);
+			const result =
+				kind === 'velocity'
+					? await updateVelocityConfig(fetch, params.name, config)
+					: await updateBungeeConfig(fetch, params.name, config);
 
 			if (result.error) {
 				return fail(500, { error: result.error });
@@ -29,7 +55,7 @@ export const actions = {
 
 			return { success: true };
 		} catch {
-			return fail(500, { error: 'Failed to update Velocity config' });
+			return fail(500, { error: 'Failed to update proxy config' });
 		}
 	}
 } satisfies Actions;

--- a/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.svelte
@@ -3,6 +3,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import type { PageData, ActionData } from './$types';
 	import type { VelocityConfig } from '$lib/api/types';
+	import BungeeConfigEditor from './BungeeConfigEditor.svelte';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 
@@ -27,7 +28,9 @@
 		};
 	}
 
-	let config = $state<VelocityConfig>({ ...(data.config.data ?? emptyConfig()) });
+	// The Velocity branch only runs when proxyKind === 'velocity'; the destructured
+	// $state below is initialized from velocityConfig in that branch (null otherwise).
+	let config = $state<VelocityConfig>({ ...(data.velocityConfig?.data ?? emptyConfig()) });
 	let initial = $state<VelocityConfig>(JSON.parse(JSON.stringify(config)));
 	let lastServerName = $state(data.serverName);
 
@@ -46,7 +49,7 @@
 	$effect(() => {
 		if (data.serverName !== lastServerName) {
 			lastServerName = data.serverName;
-			const fresh = data.config.data ?? emptyConfig();
+			const fresh = data.velocityConfig?.data ?? emptyConfig();
 			config = { ...fresh };
 			initial = JSON.parse(JSON.stringify(fresh));
 			serverEntries = Object.entries(fresh.servers).map(([name, address]) => ({
@@ -145,9 +148,17 @@
 </script>
 
 <svelte:head>
-	<title>Velocity Config | {data.serverName} | MineOS</title>
+	<title>Proxy Config | {data.serverName} | MineOS</title>
 </svelte:head>
 
+{#if data.proxyKind !== 'velocity'}
+	<BungeeConfigEditor
+		serverName={data.serverName}
+		initial={data.bungeeConfig?.data ?? null}
+		formError={form && 'error' in form ? form.error : null}
+		formSuccess={form?.success ?? false}
+	/>
+{:else}
 <div class="page">
 	<header class="header">
 		<div>
@@ -189,6 +200,7 @@
 			};
 		}}
 	>
+		<input type="hidden" name="proxyKind" value="velocity" />
 		<input type="hidden" name="config" value={JSON.stringify(buildSubmitConfig())} />
 
 		<section class="card">
@@ -381,6 +393,7 @@
 		</div>
 	</form>
 </div>
+{/if}
 
 <style>
 	.page {

--- a/apps/web/src/routes/(app)/servers/[name]/proxy-config/BungeeConfigEditor.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/proxy-config/BungeeConfigEditor.svelte
@@ -1,0 +1,724 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+	import { invalidateAll } from '$app/navigation';
+	import type { BungeeConfig, BungeeBackend } from '$lib/api/types';
+
+	interface Props {
+		serverName: string;
+		initial: BungeeConfig | null;
+		formError?: string | null;
+		formSuccess?: boolean;
+	}
+
+	let { serverName, initial, formError, formSuccess }: Props = $props();
+
+	function emptyConfig(): BungeeConfig {
+		return {
+			exists: false,
+			onlineMode: true,
+			ipForward: false,
+			playerLimit: -1,
+			timeout: 30000,
+			networkCompressionThreshold: 256,
+			forgeSupport: false,
+			logCommands: false,
+			logPings: false,
+			connectionThrottle: 4000,
+			connectionThrottleLimit: 3,
+			host: '0.0.0.0:25577',
+			motd: '&1Another BungeeCord server',
+			maxPlayers: 1,
+			queryEnabled: false,
+			queryPort: 25577,
+			pingPassthrough: false,
+			forceDefaultServer: false,
+			tabList: 'GLOBAL_PING',
+			proxyProtocol: false,
+			priorities: [],
+			forcedHosts: {},
+			servers: {}
+		};
+	}
+
+	let config = $state<BungeeConfig>({ ...(initial ?? emptyConfig()) });
+	let initialState = $state<BungeeConfig>(JSON.parse(JSON.stringify(config)));
+	let lastServerName = $state(serverName);
+
+	type ServerEntry = { name: string; address: string; motd: string; restricted: boolean };
+	let serverEntries = $state<ServerEntry[]>(
+		Object.entries(config.servers).map(([name, b]) => ({
+			name,
+			address: b.address,
+			motd: b.motd,
+			restricted: b.restricted
+		}))
+	);
+	let priorities = $state<string[]>([...config.priorities]);
+	let forcedHostEntries = $state<{ hostname: string; server: string }[]>(
+		Object.entries(config.forcedHosts).map(([hostname, server]) => ({ hostname, server }))
+	);
+	let saving = $state(false);
+
+	$effect(() => {
+		if (serverName !== lastServerName) {
+			lastServerName = serverName;
+			const fresh = initial ?? emptyConfig();
+			config = { ...fresh };
+			initialState = JSON.parse(JSON.stringify(fresh));
+			serverEntries = Object.entries(fresh.servers).map(([name, b]) => ({
+				name,
+				address: b.address,
+				motd: b.motd,
+				restricted: b.restricted
+			}));
+			priorities = [...fresh.priorities];
+			forcedHostEntries = Object.entries(fresh.forcedHosts).map(([hostname, server]) => ({
+				hostname,
+				server
+			}));
+		}
+	});
+
+	function buildServersObject(): Record<string, BungeeBackend> {
+		const result: Record<string, BungeeBackend> = {};
+		for (const e of serverEntries) {
+			const name = e.name.trim();
+			if (!name) continue;
+			result[name] = {
+				address: e.address.trim(),
+				motd: e.motd,
+				restricted: e.restricted
+			};
+		}
+		return result;
+	}
+
+	function buildForcedHostsObject(): Record<string, string> {
+		const result: Record<string, string> = {};
+		for (const e of forcedHostEntries) {
+			const host = e.hostname.trim();
+			const target = e.server.trim();
+			if (!host || !target) continue;
+			result[host] = target;
+		}
+		return result;
+	}
+
+	function buildSubmitConfig(): BungeeConfig {
+		return {
+			...config,
+			servers: buildServersObject(),
+			priorities: priorities.filter((n) => n.trim().length > 0),
+			forcedHosts: buildForcedHostsObject()
+		};
+	}
+
+	const dirty = $derived.by(() => {
+		const current = buildSubmitConfig();
+		return JSON.stringify(current) !== JSON.stringify(initialState);
+	});
+
+	function addServer() {
+		serverEntries = [
+			...serverEntries,
+			{ name: '', address: '', motd: '&1Backend server', restricted: false }
+		];
+	}
+
+	function removeServer(idx: number) {
+		const removedName = serverEntries[idx]?.name.trim();
+		serverEntries = serverEntries.filter((_, i) => i !== idx);
+		if (removedName) {
+			priorities = priorities.filter((n) => n !== removedName);
+		}
+	}
+
+	function addPriority() {
+		priorities = [...priorities, ''];
+	}
+
+	function removePriority(idx: number) {
+		priorities = priorities.filter((_, i) => i !== idx);
+	}
+
+	function addForcedHost() {
+		forcedHostEntries = [...forcedHostEntries, { hostname: '', server: '' }];
+	}
+
+	function removeForcedHost(idx: number) {
+		forcedHostEntries = forcedHostEntries.filter((_, i) => i !== idx);
+	}
+
+	function resetForm() {
+		config = JSON.parse(JSON.stringify(initialState));
+		serverEntries = Object.entries(initialState.servers).map(([name, b]) => ({
+			name,
+			address: b.address,
+			motd: b.motd,
+			restricted: b.restricted
+		}));
+		priorities = [...initialState.priorities];
+		forcedHostEntries = Object.entries(initialState.forcedHosts).map(([hostname, server]) => ({
+			hostname,
+			server
+		}));
+	}
+
+</script>
+
+<div class="page">
+	<header class="header">
+		<div>
+			<h1>BungeeCord Configuration</h1>
+			<p class="subtitle">
+				Edit <code>config.yml</code>. Changes require a restart to take effect.
+			</p>
+		</div>
+		<div class="header-actions">
+			<button class="btn btn-secondary" type="button" onclick={resetForm} disabled={!dirty}>
+				Reset
+			</button>
+		</div>
+	</header>
+
+	{#if !config.exists}
+		<div class="hint">
+			<strong>config.yml has not been generated yet.</strong> Showing BungeeCord defaults — saving
+			here will create the file. Alternatively, start the server once and it will generate the file
+			with its own defaults.
+		</div>
+	{/if}
+
+	{#if formError}
+		<div class="error">{formError}</div>
+	{:else if formSuccess}
+		<div class="success">Saved. Restart the proxy for changes to apply.</div>
+	{/if}
+
+	<form
+		method="POST"
+		use:enhance={() => {
+			saving = true;
+			return async ({ update }) => {
+				await update();
+				await invalidateAll();
+				saving = false;
+				initialState = JSON.parse(JSON.stringify(buildSubmitConfig()));
+			};
+		}}
+	>
+		<input type="hidden" name="proxyKind" value="bungeecord" />
+		<input type="hidden" name="config" value={JSON.stringify(buildSubmitConfig())} />
+
+		<section class="card">
+			<h2>Network</h2>
+			<div class="grid">
+				<label class="field">
+					<span class="label">Bind address</span>
+					<input type="text" bind:value={config.host} placeholder="0.0.0.0:25577" />
+					<span class="help">IP and port the proxy listens on. Default port is 25577.</span>
+				</label>
+				<label class="field">
+					<span class="label">MOTD</span>
+					<input type="text" bind:value={config.motd} />
+					<span class="help">Server list message. Use color codes like <code>&amp;1</code>.</span>
+				</label>
+				<label class="field">
+					<span class="label">Max players (cosmetic)</span>
+					<input type="number" bind:value={config.maxPlayers} min="0" max="100000" />
+					<span class="help">Slot count shown in the server list. Not the real cap.</span>
+				</label>
+				<label class="field">
+					<span class="label">Player limit (real cap)</span>
+					<input type="number" bind:value={config.playerLimit} min="-1" max="100000" />
+					<span class="help">Hard cap on connected players. <code>-1</code> for unlimited.</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.onlineMode} />
+					<span class="label">Online mode</span>
+					<span class="help">Authenticate players with Mojang.</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.queryEnabled} />
+					<span class="label">Enable query</span>
+					<span class="help">Expose the GameSpy4 query protocol.</span>
+				</label>
+				<label class="field">
+					<span class="label">Query port</span>
+					<input type="number" bind:value={config.queryPort} min="1" max="65535" />
+					<span class="help">UDP query port. Usually matches the bind port.</span>
+				</label>
+			</div>
+		</section>
+
+		<section class="card">
+			<h2>Forwarding</h2>
+			<div class="grid">
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.ipForward} />
+					<span class="label">IP forward</span>
+					<span class="help"
+						>Pass the player's real IP to backends. Backends must accept this — and you must
+						firewall them, or anyone can spoof identities.</span
+					>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.forgeSupport} />
+					<span class="label">Forge support</span>
+					<span class="help">Pass through Forge mod handshake to backends.</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.pingPassthrough} />
+					<span class="label">Ping passthrough</span>
+					<span class="help">Forward MOTD/version from the priority backend.</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.forceDefaultServer} />
+					<span class="label">Force default server</span>
+					<span class="help">Always send players to the priority list on join.</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.proxyProtocol} />
+					<span class="label">PROXY protocol</span>
+					<span class="help"
+						>Accept HAProxy/PROXY protocol on the listener. Only enable behind a TCP load
+						balancer.</span
+					>
+				</label>
+				<label class="field">
+					<span class="label">Tab list</span>
+					<select bind:value={config.tabList}>
+						<option value="GLOBAL_PING">GLOBAL_PING</option>
+						<option value="GLOBAL">GLOBAL</option>
+						<option value="SERVER">SERVER</option>
+					</select>
+					<span class="help">How the player tab list is composed across backends.</span>
+				</label>
+			</div>
+		</section>
+
+		<section class="card">
+			<div class="card-header">
+				<h2>Backend servers</h2>
+				<button class="btn btn-secondary" type="button" onclick={addServer}>+ Add</button>
+			</div>
+			<p class="card-description">
+				Map a name to a backend Minecraft server's <code>host:port</code>. Restricted backends
+				require <code>bungeecord.server.&lt;name&gt;</code> permission.
+			</p>
+			{#if serverEntries.length === 0}
+				<p class="empty">No backends configured. The proxy won't have anywhere to route players.</p>
+			{:else}
+				<div class="server-rows">
+					{#each serverEntries as entry, i}
+						<div class="server-row">
+							<input type="text" placeholder="Name (e.g. lobby)" bind:value={entry.name} />
+							<input
+								type="text"
+								placeholder="host:port (e.g. 127.0.0.1:25565)"
+								bind:value={entry.address}
+							/>
+							<input type="text" placeholder="MOTD" bind:value={entry.motd} />
+							<label class="restricted-toggle">
+								<input type="checkbox" bind:checked={entry.restricted} />
+								<span>Restricted</span>
+							</label>
+							<button
+								class="btn btn-icon"
+								type="button"
+								title="Remove"
+								onclick={() => removeServer(i)}>×</button
+							>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</section>
+
+		<section class="card">
+			<div class="card-header">
+				<h2>Priority order</h2>
+				<button class="btn btn-secondary" type="button" onclick={addPriority}>+ Add</button>
+			</div>
+			<p class="card-description">
+				Backend names tried in order on join or kick fallback. Names must match entries above.
+			</p>
+			{#if priorities.length === 0}
+				<p class="empty">No priorities configured.</p>
+			{:else}
+				<div class="try-rows">
+					{#each priorities as _name, i}
+						<div class="try-row">
+							<input type="text" placeholder="Backend name" bind:value={priorities[i]} />
+							<button
+								class="btn btn-icon"
+								type="button"
+								title="Remove"
+								onclick={() => removePriority(i)}>×</button
+							>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</section>
+
+		<section class="card">
+			<div class="card-header">
+				<h2>Forced hosts</h2>
+				<button class="btn btn-secondary" type="button" onclick={addForcedHost}>+ Add</button>
+			</div>
+			<p class="card-description">
+				Route players to a specific backend based on the hostname they connect with. BungeeCord
+				accepts a single backend per hostname (unlike Velocity's list).
+			</p>
+			{#if forcedHostEntries.length === 0}
+				<p class="empty">No forced hosts configured.</p>
+			{:else}
+				<div class="server-rows">
+					{#each forcedHostEntries as entry, i}
+						<div class="server-row two-col">
+							<input
+								type="text"
+								placeholder="hostname (e.g. lobby.example.com)"
+								bind:value={entry.hostname}
+							/>
+							<input
+								type="text"
+								placeholder="backend name (e.g. lobby)"
+								bind:value={entry.server}
+							/>
+							<button
+								class="btn btn-icon"
+								type="button"
+								title="Remove"
+								onclick={() => removeForcedHost(i)}>×</button
+							>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</section>
+
+		<section class="card">
+			<h2>Advanced</h2>
+			<div class="grid">
+				<label class="field">
+					<span class="label">Timeout (ms)</span>
+					<input type="number" bind:value={config.timeout} min="1000" max="600000" />
+					<span class="help">Backend connection timeout in milliseconds.</span>
+				</label>
+				<label class="field">
+					<span class="label">Network compression threshold</span>
+					<input
+						type="number"
+						bind:value={config.networkCompressionThreshold}
+						min="-1"
+						max="65535"
+					/>
+					<span class="help">Packet size in bytes above which compression kicks in.</span>
+				</label>
+				<label class="field">
+					<span class="label">Connection throttle (ms)</span>
+					<input type="number" bind:value={config.connectionThrottle} min="0" />
+					<span class="help">Per-IP cooldown between connections. <code>0</code> disables.</span>
+				</label>
+				<label class="field">
+					<span class="label">Connection throttle limit</span>
+					<input type="number" bind:value={config.connectionThrottleLimit} min="0" />
+					<span class="help">Max connections per IP within the throttle window.</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.logCommands} />
+					<span class="label">Log commands</span>
+					<span class="help">Log every command run through the proxy.</span>
+				</label>
+				<label class="field checkbox">
+					<input type="checkbox" bind:checked={config.logPings} />
+					<span class="label">Log pings</span>
+					<span class="help">
+						Log every server-list ping. MineOS pings the proxy every few seconds for status,
+						so leaving this on floods the console.
+					</span>
+				</label>
+			</div>
+		</section>
+
+		<div class="actions">
+			<button class="btn btn-primary" type="submit" disabled={!dirty || saving}>
+				{saving ? 'Saving…' : 'Save'}
+			</button>
+		</div>
+	</form>
+</div>
+
+<style>
+	.page {
+		padding: 1.5rem 2rem;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 1rem;
+	}
+
+	.header h1 {
+		margin: 0 0 4px;
+		font-size: 1.6rem;
+		font-weight: 700;
+	}
+
+	.subtitle {
+		margin: 0;
+		color: var(--mc-text-muted, #9aa2c5);
+		font-size: 0.9rem;
+	}
+
+	.subtitle code,
+	.help code,
+	.card-description code {
+		background: rgba(255, 255, 255, 0.08);
+		padding: 0.05rem 0.3rem;
+		border-radius: 0.2rem;
+		font-size: 0.85em;
+	}
+
+	.hint {
+		padding: 0.6rem 0.9rem;
+		font-size: 0.85rem;
+		color: var(--mc-text-secondary, #c4cff5);
+		background: rgba(6, 182, 212, 0.08);
+		border: 1px solid rgba(6, 182, 212, 0.25);
+		border-radius: 0.5rem;
+	}
+
+	.error {
+		padding: 0.6rem 0.9rem;
+		font-size: 0.9rem;
+		color: #fecaca;
+		background: rgba(239, 68, 68, 0.12);
+		border: 1px solid rgba(239, 68, 68, 0.3);
+		border-radius: 0.5rem;
+	}
+
+	.success {
+		padding: 0.6rem 0.9rem;
+		font-size: 0.9rem;
+		color: #bbf7d0;
+		background: rgba(34, 197, 94, 0.12);
+		border: 1px solid rgba(34, 197, 94, 0.3);
+		border-radius: 0.5rem;
+	}
+
+	form {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.card {
+		background: var(--mc-panel, rgba(22, 27, 46, 0.95));
+		border: 1px solid var(--border-color, #2a2f47);
+		border-radius: 0.75rem;
+		padding: 1.25rem;
+	}
+
+	.card h2 {
+		margin: 0 0 0.75rem;
+		font-size: 1.05rem;
+		font-weight: 600;
+	}
+
+	.card-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 0.5rem;
+	}
+
+	.card-header h2 {
+		margin: 0;
+	}
+
+	.card-description {
+		margin: 0 0 0.75rem;
+		font-size: 0.85rem;
+		color: var(--mc-text-muted, #9aa2c5);
+	}
+
+	.empty {
+		margin: 0.5rem 0 0;
+		font-size: 0.85rem;
+		color: var(--mc-text-muted, #9aa2c5);
+		font-style: italic;
+	}
+
+	.grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.75rem 1rem;
+	}
+
+	@media (max-width: 720px) {
+		.grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.field .label {
+		font-size: 0.85rem;
+		font-weight: 500;
+		color: var(--mc-text-secondary, #c4cff5);
+	}
+
+	.field input[type='text'],
+	.field input[type='number'],
+	.field select {
+		padding: 0.4rem 0.6rem;
+		background: var(--input-bg, #1f2937);
+		border: 1px solid var(--border-color, #374151);
+		border-radius: 0.375rem;
+		color: inherit;
+		font-size: 0.9rem;
+		font-family: inherit;
+	}
+
+	.field.checkbox {
+		flex-direction: row;
+		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	.field.checkbox input[type='checkbox'] {
+		width: 1rem;
+		height: 1rem;
+		flex-shrink: 0;
+	}
+
+	.field.checkbox .label {
+		flex: 1 1 auto;
+	}
+
+	.field.checkbox .help {
+		flex-basis: 100%;
+		margin-left: 1.5rem;
+	}
+
+	.help {
+		font-size: 0.75rem;
+		color: var(--mc-text-muted, #9aa2c5);
+	}
+
+	.server-rows,
+	.try-rows {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.server-row {
+		display: grid;
+		grid-template-columns: 1fr 1.5fr 1.5fr auto auto;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.server-row.two-col {
+		grid-template-columns: 1fr 1fr auto;
+	}
+
+	.try-row {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		gap: 0.5rem;
+	}
+
+	.server-row input,
+	.try-row input {
+		padding: 0.35rem 0.55rem;
+		background: var(--input-bg, #1f2937);
+		border: 1px solid var(--border-color, #374151);
+		border-radius: 0.35rem;
+		color: inherit;
+		font-size: 0.85rem;
+		font-family: inherit;
+	}
+
+	.restricted-toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.3rem;
+		font-size: 0.8rem;
+		color: var(--mc-text-muted, #9aa2c5);
+		white-space: nowrap;
+	}
+
+	.btn {
+		padding: 0.4rem 0.9rem;
+		border-radius: 0.4rem;
+		border: 1px solid transparent;
+		font-size: 0.85rem;
+		font-weight: 500;
+		cursor: pointer;
+		font-family: inherit;
+	}
+
+	.btn-primary {
+		background: #06b6d4;
+		color: #0b1220;
+	}
+
+	.btn-primary:hover:not(:disabled) {
+		filter: brightness(1.08);
+	}
+
+	.btn-primary:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.btn-secondary {
+		background: var(--mc-panel-light, #2a2f47);
+		color: var(--mc-text-secondary, #c4cff5);
+	}
+
+	.btn-secondary:hover:not(:disabled) {
+		background: var(--mc-panel-lighter, #3a3f5a);
+	}
+
+	.btn-secondary:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.btn-icon {
+		background: transparent;
+		color: var(--mc-text-muted, #9aa2c5);
+		border: 1px solid var(--border-color, #374151);
+		padding: 0.2rem 0.55rem;
+		font-size: 1rem;
+		line-height: 1;
+	}
+
+	.btn-icon:hover {
+		color: #fecaca;
+		border-color: rgba(239, 68, 68, 0.4);
+	}
+
+	.actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: 0.6rem;
+	}
+</style>

--- a/apps/web/src/routes/(app)/servers/new/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/new/+page.svelte
@@ -126,15 +126,20 @@
 		// Create the server first
 		simpleStepText = 'Creating server...';
 		simpleProgress = 5;
+		const isProxy = implementation === 'velocity' || implementation === 'bungeecord';
 		const serverType =
 			implementation === 'bedrock' ? 'bedrock'
-			: implementation === 'velocity' ? 'proxy'
+			: isProxy ? 'proxy'
 			: 'java';
+		const proxyKind = isProxy
+			? (implementation as 'velocity' | 'bungeecord')
+			: undefined;
 		const createResult = await api.createServer(fetch, {
 			name,
 			ownerUid: 1000,
 			ownerGid: 1000,
-			serverType
+			serverType,
+			proxyKind
 		});
 		if (createResult.error) {
 			createError = createResult.error;

--- a/apps/web/src/routes/(app)/servers/new/steps/ImplementationSelect.svelte
+++ b/apps/web/src/routes/(app)/servers/new/steps/ImplementationSelect.svelte
@@ -4,7 +4,7 @@
 
 	export type PluginImpl = 'paper' | 'spigot';
 	export type ModLoader = 'forge' | 'neoforge' | 'fabric' | 'quilt';
-	export type ProxyImpl = 'velocity';
+	export type ProxyImpl = 'velocity' | 'bungeecord';
 	export type Implementation = PluginImpl | ModLoader | ProxyImpl;
 
 	interface Props {
@@ -48,6 +48,15 @@
 			iconImage: '',
 			color: '#06b6d4',
 			badge: 'Recommended'
+		},
+		{
+			id: 'bungeecord' as const,
+			name: 'BungeeCord',
+			description:
+				'The original Minecraft proxy by md_5. Stable and widely compatible with older plugins.',
+			icon: '🔀',
+			iconImage: '',
+			color: '#fbbf24'
 		}
 	];
 

--- a/apps/web/src/routes/(app)/servers/new/steps/VersionSelect.svelte
+++ b/apps/web/src/routes/(app)/servers/new/steps/VersionSelect.svelte
@@ -9,6 +9,7 @@
 	import QuiltVersions from '../version-pickers/QuiltVersions.svelte';
 	import BedrockVersions from '../version-pickers/BedrockVersions.svelte';
 	import VelocityVersions from '../version-pickers/VelocityVersions.svelte';
+	import BungeeCordVersions from '../version-pickers/BungeeCordVersions.svelte';
 	import TemplateSelect from '../version-pickers/TemplateSelect.svelte';
 
 	interface VersionSelection {
@@ -42,6 +43,7 @@
 		quilt: 'Quilt',
 		bedrock: 'Bedrock',
 		velocity: 'Velocity',
+		bungeecord: 'BungeeCord',
 		template: 'Template'
 	};
 </script>
@@ -90,6 +92,12 @@
 		/>
 	{:else if implementation === 'velocity'}
 		<VelocityVersions
+			{profiles}
+			onselect={(profile) => onselect({ profileId: profile.id, minecraftVersion: profile.version })}
+			onready={onready}
+		/>
+	{:else if implementation === 'bungeecord'}
+		<BungeeCordVersions
 			{profiles}
 			onselect={(profile) => onselect({ profileId: profile.id, minecraftVersion: profile.version })}
 			onready={onready}

--- a/apps/web/src/routes/(app)/servers/new/version-pickers/BungeeCordVersions.svelte
+++ b/apps/web/src/routes/(app)/servers/new/version-pickers/BungeeCordVersions.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+	import type { Profile } from '$lib/api/types';
+	import StatusBadge from '$lib/components/StatusBadge.svelte';
+
+	interface Props {
+		profiles: Profile[];
+		onselect: (profile: Profile) => void;
+		onready?: (fn: (() => void) | null) => void;
+	}
+
+	let { profiles, onselect, onready }: Props = $props();
+	let selectedProfile = $state<Profile | null>(null);
+
+	let search = $state('');
+	let page = $state(0);
+	const perPage = 20;
+
+	// BungeeCord versions are Jenkins build numbers ("build-2068"), not semver, so
+	// the shared profile list falls back to ordering them lexically — where
+	// "build-999" lands after "build-1000". Sort numerically here so the newest
+	// build is always first.
+	const buildNumber = (p: Profile) => Number(p.version.replace(/^build-/, '')) || 0;
+
+	const filtered = $derived.by(() => {
+		let result = profiles.filter((p) => p.group === 'bungeecord');
+		if (search.trim()) {
+			result = result.filter((p) =>
+				p.version.toLowerCase().includes(search.trim().toLowerCase())
+			);
+		}
+		return [...result].sort((a, b) => buildNumber(b) - buildNumber(a));
+	});
+
+	const paged = $derived(filtered.slice(page * perPage, (page + 1) * perPage));
+	const totalPages = $derived(Math.ceil(filtered.length / perPage));
+
+	$effect(() => {
+		search;
+		page = 0;
+	});
+</script>
+
+<div class="version-picker">
+	<div class="controls">
+		<input type="text" placeholder="Search builds..." bind:value={search} class="search" />
+	</div>
+
+	<div class="version-list">
+		{#each paged as profile}
+			<button
+				class="version-row"
+				class:selected={selectedProfile?.id === profile.id}
+				onclick={() => {
+					selectedProfile = profile;
+					onready?.(() => onselect(profile));
+				}}
+				type="button"
+			>
+				<span class="version-name">{profile.version}</span>
+				<span class="version-meta">
+					{#if profile.downloaded}
+						<StatusBadge variant="success" size="sm">Ready</StatusBadge>
+					{:else}
+						<StatusBadge variant="info" size="sm">Will Download</StatusBadge>
+					{/if}
+				</span>
+			</button>
+		{/each}
+		{#if paged.length === 0}
+			<div class="empty">No BungeeCord builds available</div>
+		{/if}
+	</div>
+
+	{#if totalPages > 1}
+		<div class="pagination">
+			<button onclick={() => (page = Math.max(0, page - 1))} disabled={page === 0} type="button"
+				>Prev</button
+			>
+			<span>
+				Page {page + 1} of {totalPages}
+			</span>
+			<button
+				onclick={() => (page = Math.min(totalPages - 1, page + 1))}
+				disabled={page >= totalPages - 1}
+				type="button">Next</button
+			>
+		</div>
+	{/if}
+
+	<p class="hint">
+		BungeeCord is a long-running Minecraft proxy by md_5. Builds are numbered (no semver). The
+		latest successful build supports current Minecraft releases. After first launch, edit
+		<code>config.yml</code> via the Properties tab to configure backends.
+	</p>
+</div>
+
+<style>
+	.version-picker {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	.controls {
+		display: flex;
+		gap: 1rem;
+		align-items: center;
+	}
+
+	.search {
+		flex: 1;
+		padding: 0.4rem 0.75rem;
+		border: 1px solid var(--border-color, #374151);
+		border-radius: 0.375rem;
+		background: var(--input-bg, #1f2937);
+		color: inherit;
+		font-size: 0.85rem;
+	}
+
+	.version-list {
+		border: 1px solid var(--border-color, #374151);
+		border-radius: 0.5rem;
+		overflow: hidden;
+		max-height: 400px;
+		overflow-y: auto;
+	}
+
+	.version-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		width: 100%;
+		padding: 0.5rem 0.75rem;
+		border: none;
+		border-bottom: 1px solid var(--border-color, #374151);
+		background: transparent;
+		color: inherit;
+		cursor: pointer;
+		font-size: 0.85rem;
+		text-align: left;
+		font-family: inherit;
+	}
+
+	.version-row:last-child {
+		border-bottom: none;
+	}
+
+	.version-row:hover {
+		background: rgba(255, 255, 255, 0.05);
+	}
+
+	.version-row.selected {
+		background: rgba(6, 182, 212, 0.15);
+		border-color: #06b6d4;
+	}
+
+	.empty {
+		padding: 2rem;
+		text-align: center;
+		color: var(--text-secondary, #9ca3af);
+	}
+
+	.pagination {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		gap: 1rem;
+		font-size: 0.85rem;
+	}
+
+	.pagination button {
+		padding: 0.3rem 0.75rem;
+		border: 1px solid var(--border-color, #374151);
+		border-radius: 0.25rem;
+		background: transparent;
+		color: inherit;
+		cursor: pointer;
+		font-size: 0.8rem;
+	}
+
+	.pagination button:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.hint {
+		margin: 0;
+		padding: 0.6rem 0.8rem;
+		font-size: 0.78rem;
+		color: var(--text-secondary, #9ca3af);
+		background: rgba(6, 182, 212, 0.06);
+		border: 1px solid rgba(6, 182, 212, 0.2);
+		border-radius: 0.4rem;
+		line-height: 1.4;
+	}
+
+	.hint code {
+		background: rgba(255, 255, 255, 0.08);
+		padding: 0.05rem 0.3rem;
+		border-radius: 0.2rem;
+		font-size: 0.85em;
+	}
+</style>


### PR DESCRIPTION
Lands #157 (BungeeCord proxy support, by @CutFlame) with the review follow-ups applied on top. Their commit is preserved at the base of this branch, so merging here closes #157 as merged.

## What's on top

| Fix | Why |
|---|---|
| Start verification checks `proxy.log.0` mtime instead of `startup.log` growth | The launcher runs `exec java … >> startup.log 2>&1`, so JVM-level failures (wrong Java version, missing jar, unaccepted EULA) write there and never touch `logs/latest.log`. The growth signal reported those crashes as **successful starts, for every server type**. `proxy.log.0` closes the BungeeCord gap the signal was added for, and like `latest.log` it is only written once the server's own logger runs. |
| Null collections preserve existing YAML nodes | A PUT omitting `servers` silently wiped the proxy's entire backend map — worse than the 500 it replaced, because nothing reported it. Explicitly-empty collections still clear. |
| `proxyKind` validated before any disk write | An invalid value left a half-built server marked `proxy` with no proxy config. Both `CreateServerAsync` and `UpdateServerTypeAsync`. |
| `GET /bungee-config` → 409 on malformed YAML | Was an opaque 500 that took the whole Properties tab down. Translated in Infrastructure so `YamlException` stays out of the Api layer. |
| Proxy kind resolved from config-file presence, not jar name | An imported/renamed jar sent a BungeeCord server down the Velocity branch; saving wrote a stray `velocity.toml`, which `GetServerListenEndpointAsync` *prefers* over `config.yml` — so the dashboard read the wrong port from then on. |
| `"velocity"`/`"bungeecord"` normalized to `"proxy"` | Written verbatim to `.mineos-server-type`, either broke every `DetectServerType(name) == "proxy"` branch downstream. |

Deliberately out of scope: the Velocity write path's identical null-collection flaw and matching malformed-TOML 500 (both pre-existing), and the version chip now rendering `3.1.1-SNAPSHOT`.

## Testing

Run in a `mcr.microsoft.com/dotnet/sdk:8.0` container against a clean-`vibing` baseline captured the same way:

| | clean `vibing` | this branch |
|---|---|---|
| `dotnet test` | 53 passed, 6 failed, 59 total | 67 passed, 6 failed, 73 total |
| `npm run check` | 5 errors, 87 warnings | 5 errors, 93 warnings |

The 6 failures are identical on both sides (Bedrock + Mod integration tests) and pre-existing. The +6 warnings are `state_referenced_locally` in the new `BungeeConfigEditor.svelte`, matching the sibling Velocity editor. Two new regression tests cover the backend-map wipe and the explicitly-empty case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
