### PR TITLE
fix(tests): isolate integration tests to a temp server root

### DIFF
--- a/apps/MineOS.Tests/Integration/MineOsWebApplicationFactory.cs
+++ b/apps/MineOS.Tests/Integration/MineOsWebApplicationFactory.cs
@@ -17,6 +17,16 @@ public class MineOsWebApplicationFactory : WebApplicationFactory<Program>
     private readonly string _dbName = $"TestDb_{Guid.NewGuid():N}";
     private const string TestSigningKey = "test-signing-key-at-least-32-characters-long!!";
 
+    /// <summary>
+    /// Every instance gets its own throwaway server root. Without this the tests
+    /// inherit HostOptions' production default of /var/games/minecraft and operate
+    /// on the real host directory: they fail outright where that path is not
+    /// writable, and where it *is* writable they silently create and delete
+    /// servers belonging to whoever is running them.
+    /// </summary>
+    private readonly string _hostRoot =
+        Path.Combine(Path.GetTempPath(), $"mineos-tests-{Guid.NewGuid():N}");
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
@@ -33,6 +43,11 @@ public class MineOsWebApplicationFactory : WebApplicationFactory<Program>
                 ["Auth:Jwt:ExpiresMinutes"] = "60",
                 ["ApiKey:StaticKey"] = "dev-static-api-key-change-me",
                 ["ConnectionStrings:Default"] = "DataSource=:memory:",
+                ["Host:BaseDirectory"] = _hostRoot,
+                ["Host:ServersPathSegment"] = "servers",
+                ["Host:ProfilesPathSegment"] = "profiles",
+                ["Host:BackupsPathSegment"] = "backups",
+                ["Host:ImportPathSegment"] = "import",
             });
         });
 
@@ -85,5 +100,30 @@ public class MineOsWebApplicationFactory : WebApplicationFactory<Program>
                 };
             });
         });
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+
+        if (!disposing)
+        {
+            return;
+        }
+
+        try
+        {
+            if (Directory.Exists(_hostRoot))
+            {
+                Directory.Delete(_hostRoot, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not worth failing a test run over.
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
     }
 }


### PR DESCRIPTION
`MineOsWebApplicationFactory` overrode the database but never `HostOptions`, so every integration test inherited the production default of `/var/games/minecraft` and operated on the **real host directory**.

Two consequences, and the second is the one that matters:

- Where that path isn't writable, the tests just fail. That's the "known failing" set the suite has carried for a while — **6** failures in a `dotnet/sdk:8.0` container, **11** on @CutFlame's machine during #157. Different numbers, same cause.
- Where the path *is* writable, they pass by creating and deleting servers under `/var/games/minecraft` — i.e. on a real MineOS install, the test suite operates on the user's actual servers.

Each factory instance now gets its own `mineos-tests-<guid>` root under the temp directory and removes it on dispose.

## Testing

| | before | after |
|---|---|---|
| `dotnet test` | 67 passed, **6 failed**, 73 total | **73 passed, 0 failed**, 73 total |

No production code changed — the fix is entirely in the test factory. Worth noting this makes the suite trustworthy for the first time in a while: "green" now actually means green, so future PRs can be measured against zero rather than against a remembered baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
