### PR TITLE
feat(proxy): verified forwarding for proxy backends

### DIFF
--- a/apps/MineOS.Api/Authorization/ServerAccessFilter.cs
+++ b/apps/MineOS.Api/Authorization/ServerAccessFilter.cs
@@ -71,7 +71,7 @@ public sealed class ServerAccessFilter : IEndpointFilter
         return !string.IsNullOrWhiteSpace(serverName);
     }
 
-    private static bool TryGetUserId(ClaimsPrincipal user, out int userId)
+    internal static bool TryGetUserId(ClaimsPrincipal user, out int userId)
     {
         userId = 0;
         var claim = user.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value

--- a/apps/MineOS.Api/Endpoints/ServerEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/ServerEndpoints.cs
@@ -370,6 +370,93 @@ public static class ServerEndpoints
             }
         });
 
+        // Proxy forwarding security. Both routes sit in the `servers` group, so
+        // ServerAccessFilter gates them against the server being acted on — the
+        // secure action deliberately targets the *backend*, which is the server
+        // whose files it changes.
+        servers.MapGet("/{name}/forwarding", async (
+            string name,
+            IProxyForwardingService forwardingService,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                return Results.Ok(await forwardingService.GetForwardingStatusAsync(name, cancellationToken));
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+        });
+
+        servers.MapGet("/{name}/forwarding/backends", async (
+            string name,
+            HttpContext httpContext,
+            IProxyForwardingService forwardingService,
+            IServerAccessService accessService,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var summary = await forwardingService.GetProxyBackendsAsync(name, cancellationToken);
+
+                // ServerAccessFilter only guards the proxy named in the route. The
+                // rows describe *other* servers, and "this one is open to
+                // impersonation" is exactly the sort of thing a partially
+                // privileged user should not learn about a server they cannot see.
+                var user = httpContext.User;
+                var role = user.FindFirstValue(ClaimTypes.Role) ?? "user";
+                var isAdmin = string.Equals(role, "admin", StringComparison.OrdinalIgnoreCase);
+
+                if (user.Identity?.IsAuthenticated == true && !isAdmin)
+                {
+                    if (!ServerAccessFilter.TryGetUserId(user, out var userId))
+                    {
+                        return Results.Unauthorized();
+                    }
+
+                    var visible = new List<BackendForwardingDto>();
+                    foreach (var backend in summary.Backends)
+                    {
+                        var access = await accessService.GetAccessAsync(
+                            userId, backend.ServerName, cancellationToken);
+                        if (access != null)
+                        {
+                            visible.Add(backend);
+                        }
+                    }
+                    summary = summary with { Backends = visible };
+                }
+
+                return Results.Ok(summary);
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+        });
+
+        servers.MapPost("/{name}/forwarding/secure", async (
+            string name,
+            IProxyForwardingService forwardingService,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                return Results.Ok(await forwardingService.SecureBackendAsync(name, cancellationToken));
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Refusals are expected here (no proxy, several proxies, a loader
+                // with no verified path) and each carries a message worth showing.
+                return Results.Conflict(new { error = ex.Message });
+            }
+        });
+
         // Server config
         servers.MapGet("/{name}/server-config", async (
             string name,

--- a/apps/MineOS.Api/Program.cs
+++ b/apps/MineOS.Api/Program.cs
@@ -182,6 +182,8 @@ builder.Services.AddSingleton<TelemetryReporterService>();
 builder.Services.AddSingleton<ITelemetryReportTrigger>(sp => sp.GetRequiredService<TelemetryReporterService>());
 builder.Services.AddHostedService(sp => sp.GetRequiredService<TelemetryReporterService>());
 builder.Services.AddHostedService<ApplicationLifetimeService>();
+builder.Services.AddSingleton<IContainerPortInspector, DockerPortInspector>();
+builder.Services.AddScoped<IProxyForwardingService, ProxyForwardingService>();
 builder.Services.AddSingleton<WatchdogService>();
 builder.Services.AddSingleton<IWatchdogService>(sp => sp.GetRequiredService<WatchdogService>());
 builder.Services.AddHostedService(sp => sp.GetRequiredService<WatchdogService>());

--- a/apps/MineOS.Application/Dtos/ProxyForwardingDtos.cs
+++ b/apps/MineOS.Application/Dtos/ProxyForwardingDtos.cs
@@ -1,0 +1,37 @@
+using MineOS.Domain.ValueObjects;
+
+namespace MineOS.Application.Dtos;
+
+/// <summary>
+/// A backend server's forwarding posture, derived fresh on every read.
+///
+/// Note what is absent: the forwarding secret. Whether the two sides agree is
+/// reported as <see cref="SecretMatches"/> and the value itself never crosses
+/// the API boundary — not in full, not redacted. The existing
+/// <see cref="VelocityConfigDto"/> exposes only the secret *file name*, and this
+/// keeps to that line.
+/// </summary>
+public record BackendForwardingDto(
+    string ServerName,
+    ProxyForwardingStatus Status,
+    // True when the server currently accepts unauthenticated connections:
+    // online-mode is off and nothing verifies the forwarded identity.
+    bool IsSpoofable,
+    ProxyForwardingKind ProxyKind,
+    LoaderTier Tier,
+    string? ProxyName,
+    string? Loader,
+    bool ServerOnlineMode,
+    bool BackendForwardingConfigured,
+    bool SecretMatches,
+    // Only meaningful when no verified path exists — then isolation is the
+    // only control and we report whether it actually holds.
+    ExposureVerdict Exposure,
+    string? ExposureDetail,
+    // What the caller can do about it, if anything: "secure", "install-mod", or null.
+    string? RemediationAction);
+
+/// <summary>One row of a proxy's backend roll-up.</summary>
+public record ProxyBackendSummaryDto(
+    string ProxyName,
+    IReadOnlyList<BackendForwardingDto> Backends);

--- a/apps/MineOS.Application/Interfaces/IContainerPortInspector.cs
+++ b/apps/MineOS.Application/Interfaces/IContainerPortInspector.cs
@@ -1,0 +1,17 @@
+using MineOS.Domain.ValueObjects;
+
+namespace MineOS.Application.Interfaces;
+
+public interface IContainerPortInspector
+{
+    /// <summary>
+    /// Reports whether a port is reachable from outside the host.
+    ///
+    /// Implementations must return <see cref="ExposureVerdict.Unknown"/> — never
+    /// <see cref="ExposureVerdict.NotExposed"/> — when they cannot actually tell.
+    /// This answer is used as a safety control for backends that have no way to
+    /// verify forwarded players, so guessing "probably fine" is the one behaviour
+    /// that must not happen.
+    /// </summary>
+    Task<(ExposureVerdict Verdict, string? Detail)> IsPortPublishedAsync(int port, CancellationToken cancellationToken);
+}

--- a/apps/MineOS.Application/Interfaces/IProxyForwardingService.cs
+++ b/apps/MineOS.Application/Interfaces/IProxyForwardingService.cs
@@ -1,0 +1,34 @@
+using MineOS.Application.Dtos;
+
+namespace MineOS.Application.Interfaces;
+
+public interface IProxyForwardingService
+{
+    /// <summary>
+    /// Derives the forwarding posture of a single server. Reads only — safe to
+    /// call on every page load, and deliberately not cached, so a hand-edited
+    /// server.properties is reflected immediately.
+    /// </summary>
+    Task<BackendForwardingDto> GetForwardingStatusAsync(string serverName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lists the forwarding posture of every backend a proxy claims.
+    /// Callers are responsible for filtering to servers the user may see.
+    /// </summary>
+    Task<ProxyBackendSummaryDto> GetProxyBackendsAsync(string proxyName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Configures verified (modern) forwarding between a backend and the proxy
+    /// that claims it: ensures the proxy's forwarding secret exists, writes the
+    /// backend's half, and only then turns off the backend's own online-mode.
+    ///
+    /// That ordering is deliberate. A failure part-way leaves a server that still
+    /// authenticates its own players — broken behind a proxy, but not open. The
+    /// reverse order would leave it live and unauthenticated.
+    ///
+    /// Idempotent. Throws <see cref="InvalidOperationException"/> when no proxy
+    /// claims the server, when more than one does, or when the backend's loader
+    /// has no verified-forwarding path.
+    /// </summary>
+    Task<BackendForwardingDto> SecureBackendAsync(string serverName, CancellationToken cancellationToken);
+}

--- a/apps/MineOS.Application/Interfaces/IServerService.cs
+++ b/apps/MineOS.Application/Interfaces/IServerService.cs
@@ -38,6 +38,13 @@ public interface IServerService
     Task AcceptEulaAsync(string name, CancellationToken cancellationToken);
     Task RunFtbInstallerAsync(string name, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Flags a server as needing a restart for pending config changes to apply.
+    /// Exposed because callers outside ServerService now change files a running
+    /// server has already read (proxy forwarding writes both halves of a pair).
+    /// </summary>
+    Task MarkRestartRequiredAsync(string name, CancellationToken cancellationToken);
+
     // Loader detection
     Task<ServerLoaderDto> DetectLoaderAsync(string name, CancellationToken cancellationToken);
     Task UpdateServerTypeAsync(string name, string serverType, string? proxyKind, CancellationToken cancellationToken);

--- a/apps/MineOS.Domain/ValueObjects/ProxyForwarding.cs
+++ b/apps/MineOS.Domain/ValueObjects/ProxyForwarding.cs
@@ -1,0 +1,156 @@
+namespace MineOS.Domain.ValueObjects;
+
+/// <summary>
+/// What a backend server's forwarding configuration currently amounts to.
+/// Always derived from files on disk at read time — never stored. A persisted
+/// "secured" flag goes stale the moment someone edits server.properties by hand,
+/// and a stale security badge is worse than no badge at all.
+/// </summary>
+public enum ProxyForwardingStatus
+{
+    /// <summary>Not listed as a backend by any proxy. Nothing to report.</summary>
+    NotABackend,
+
+    /// <summary>Verified forwarding, secrets agree, online-mode off. Correct.</summary>
+    Secured,
+
+    /// <summary>Enrolled but wrong. See <see cref="ForwardingAssessment.IsSpoofable"/>
+    /// for whether "wrong" currently means "anyone can join as anyone".</summary>
+    Misconfigured,
+
+    /// <summary>Not secured yet, but this backend can be: one click, or one mod.</summary>
+    Securable,
+
+    /// <summary>No verified-forwarding path exists for this combination.
+    /// Network isolation is the only control available.</summary>
+    Unverifiable
+}
+
+/// <summary>What kind of forwarding the proxy in front of this server performs.</summary>
+public enum ProxyForwardingKind
+{
+    /// <summary>No proxy claims this server.</summary>
+    None,
+
+    /// <summary>Velocity with player-info-forwarding-mode = "modern": the forwarded
+    /// player data is signed with the shared secret and the backend verifies it.</summary>
+    VelocityModern,
+
+    /// <summary>Velocity in none/legacy/bungeeguard mode — nothing the backend can verify.</summary>
+    VelocityUnverified,
+
+    /// <summary>BungeeCord. ip_forward carries no signature at all, so a direct
+    /// connection to the backend can claim any identity.</summary>
+    BungeeCord
+}
+
+/// <summary>Whether the backend's server software can verify forwarded player data.</summary>
+public enum LoaderTier
+{
+    /// <summary>Paper, Purpur, Folia — native modern forwarding via paper-global.yml.</summary>
+    Native,
+
+    /// <summary>Fabric/Quilt — possible, but only with FabricProxy-Lite installed.</summary>
+    ModRequired,
+
+    /// <summary>Forge, NeoForge, vanilla, Spigot, CraftBukkit — no verified path.</summary>
+    Unsupported
+}
+
+/// <summary>Whether the backend's port can actually be reached from outside the host.</summary>
+public enum ExposureVerdict
+{
+    /// <summary>Could not be determined. Never treat this as safe.</summary>
+    Unknown,
+
+    /// <summary>Positively determined that the port is not published.</summary>
+    NotExposed,
+
+    /// <summary>The port is published to the host, or the container uses host networking.</summary>
+    Exposed
+}
+
+/// <summary>
+/// The facts a status decision is made from. Gathering these touches the
+/// filesystem; deciding from them does not, which is what keeps
+/// <see cref="ProxyForwardingRules"/> pure and cheap to test.
+/// </summary>
+public sealed record ForwardingFacts(
+    bool IsBackend,
+    ProxyForwardingKind ProxyKind,
+    LoaderTier Tier,
+    // paper-global.yml (or FabricProxy-Lite.toml) exists and has forwarding enabled.
+    bool BackendForwardingConfigured,
+    // The backend's configured secret equals the proxy's forwarding.secret.
+    bool SecretMatches,
+    // online-mode in the backend's server.properties.
+    bool ServerOnlineMode);
+
+/// <summary>Status plus the one bit that actually matters for safety.</summary>
+public sealed record ForwardingAssessment(
+    ProxyForwardingStatus Status,
+    bool IsSpoofable);
+
+public static class ProxyForwardingRules
+{
+    /// <summary>
+    /// Decides a backend's forwarding status.
+    ///
+    /// The security-critical combination is online-mode=false *without* verified
+    /// forwarding: the backend has stopped authenticating players itself and
+    /// nothing has taken over that job, so any direct connection can claim any
+    /// username and UUID. That is reported as <see cref="ForwardingAssessment.IsSpoofable"/>,
+    /// separately from the status, because a server can be misconfigured while
+    /// still being perfectly safe (online-mode left on behind a proxy is merely
+    /// broken — players cannot join, but nobody can impersonate them either).
+    /// </summary>
+    public static ForwardingAssessment Resolve(ForwardingFacts facts)
+    {
+        if (!facts.IsBackend)
+        {
+            return new ForwardingAssessment(ProxyForwardingStatus.NotABackend, IsSpoofable: false);
+        }
+
+        var verified =
+            facts.ProxyKind == ProxyForwardingKind.VelocityModern &&
+            facts.Tier != LoaderTier.Unsupported &&
+            facts.BackendForwardingConfigured &&
+            facts.SecretMatches;
+
+        // online-mode=false is what removes the backend's own authentication.
+        // Without verified forwarding replacing it, the server is open.
+        var spoofable = !facts.ServerOnlineMode && !verified;
+
+        if (verified)
+        {
+            // Verified forwarding requires online-mode=false; Velocity performs the
+            // Mojang handshake instead. Leaving it on is broken, not dangerous.
+            return new ForwardingAssessment(
+                facts.ServerOnlineMode ? ProxyForwardingStatus.Misconfigured : ProxyForwardingStatus.Secured,
+                IsSpoofable: false);
+        }
+
+        // No verified path exists for this pairing, so securing it is not on offer.
+        // Say so plainly rather than dangling a fix button that cannot work.
+        if (facts.ProxyKind == ProxyForwardingKind.BungeeCord || facts.Tier == LoaderTier.Unsupported)
+        {
+            return new ForwardingAssessment(ProxyForwardingStatus.Unverifiable, spoofable);
+        }
+
+        return new ForwardingAssessment(
+            spoofable ? ProxyForwardingStatus.Misconfigured : ProxyForwardingStatus.Securable,
+            spoofable);
+    }
+
+    /// <summary>Maps a detected loader onto what it can do about forwarding.</summary>
+    public static LoaderTier TierFor(string? loader) => (loader ?? string.Empty).ToLowerInvariant() switch
+    {
+        // Paper's forwarding implementation; Purpur and Folia inherit it.
+        "paper" or "purpur" or "folia" => LoaderTier.Native,
+        // Needs FabricProxy-Lite. Quilt runs Fabric mods.
+        "fabric" or "quilt" => LoaderTier.ModRequired,
+        // Spigot/CraftBukkit are deliberately here: modern forwarding is a Paper
+        // feature, not a Bukkit one, so they have no verified path either.
+        _ => LoaderTier.Unsupported
+    };
+}

--- a/apps/MineOS.Infrastructure/Services/DockerPortInspector.cs
+++ b/apps/MineOS.Infrastructure/Services/DockerPortInspector.cs
@@ -1,0 +1,148 @@
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using MineOS.Application.Interfaces;
+using MineOS.Domain.ValueObjects;
+
+namespace MineOS.Infrastructure.Services;
+
+/// <summary>
+/// Answers "can the outside world reach this port?" by asking Docker about the
+/// container MineOS is running in, over the socket docker-compose already mounts.
+///
+/// .NET speaks Unix sockets natively, so this needs no Docker client library.
+///
+/// Every failure path returns <see cref="ExposureVerdict.Unknown"/>. This verdict
+/// is a security control for backends that cannot verify forwarded players, and a
+/// check that reports "not exposed" because it could not look is worse than no
+/// check at all.
+/// </summary>
+public sealed class DockerPortInspector : IContainerPortInspector
+{
+    private const string SocketPath = "/var/run/docker.sock";
+
+    private readonly ILogger<DockerPortInspector> _logger;
+
+    public DockerPortInspector(ILogger<DockerPortInspector> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<(ExposureVerdict Verdict, string? Detail)> IsPortPublishedAsync(
+        int port, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(SocketPath))
+        {
+            return (ExposureVerdict.Unknown,
+                "MineOS cannot see the Docker socket, so it cannot tell whether this port is reachable from outside. " +
+                "Check your firewall or port forwarding by hand.");
+        }
+
+        var containerId = ResolveContainerId();
+        if (string.IsNullOrWhiteSpace(containerId))
+        {
+            return (ExposureVerdict.Unknown, "Could not determine which container MineOS is running in.");
+        }
+
+        try
+        {
+            using var handler = new SocketsHttpHandler
+            {
+                ConnectCallback = async (_, ct) =>
+                {
+                    var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                    await socket.ConnectAsync(new UnixDomainSocketEndPoint(SocketPath), ct);
+                    return new NetworkStream(socket, ownsSocket: true);
+                }
+            };
+            using var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+            client.Timeout = TimeSpan.FromSeconds(5);
+
+            using var response = await client.GetAsync(
+                $"/containers/{containerId}/json", cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                return (ExposureVerdict.Unknown,
+                    $"Docker returned {(int)response.StatusCode} when asked about this container.");
+            }
+
+            using var doc = JsonDocument.Parse(
+                await response.Content.ReadAsStringAsync(cancellationToken));
+            return Evaluate(doc.RootElement, port);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Docker port inspection failed");
+            return (ExposureVerdict.Unknown, "Could not query Docker about published ports.");
+        }
+    }
+
+    /// <summary>
+    /// Reads the exposure answer out of a container inspect payload. Separated from
+    /// the transport so the interesting cases are testable without a Docker daemon.
+    /// </summary>
+    internal static (ExposureVerdict Verdict, string? Detail) Evaluate(JsonElement container, int port)
+    {
+        if (!container.TryGetProperty("HostConfig", out var hostConfig))
+        {
+            return (ExposureVerdict.Unknown, "Docker's response did not include host configuration.");
+        }
+
+        // Host networking bypasses port publishing entirely: every listening port
+        // is on the host's own interfaces, MC_PORT_RANGE notwithstanding.
+        if (hostConfig.TryGetProperty("NetworkMode", out var networkMode) &&
+            string.Equals(networkMode.GetString(), "host", StringComparison.OrdinalIgnoreCase))
+        {
+            return (ExposureVerdict.Exposed,
+                "MineOS is running with host networking, so every server port is reachable on the host's network.");
+        }
+
+        if (!hostConfig.TryGetProperty("PortBindings", out var bindings) ||
+            bindings.ValueKind != JsonValueKind.Object)
+        {
+            return (ExposureVerdict.Unknown, "Docker's response did not include port bindings.");
+        }
+
+        foreach (var binding in bindings.EnumerateObject())
+        {
+            // Keys look like "25565/tcp"; a null value means the key exists but
+            // publishes nothing, which is not an exposure.
+            var slash = binding.Name.IndexOf('/');
+            var portPart = slash > 0 ? binding.Name[..slash] : binding.Name;
+            if (!int.TryParse(portPart, out var boundPort) || boundPort != port)
+            {
+                continue;
+            }
+            if (binding.Value.ValueKind == JsonValueKind.Array && binding.Value.GetArrayLength() > 0)
+            {
+                return (ExposureVerdict.Exposed,
+                    $"Port {port} is published to the host, so this server can be reached directly.");
+            }
+        }
+
+        return (ExposureVerdict.NotExposed,
+            $"Port {port} is not published to the host, so this server is reachable only through the proxy.");
+    }
+
+    private static string? ResolveContainerId()
+    {
+        // Docker sets the container's hostname to its short id unless overridden.
+        var hostname = Environment.GetEnvironmentVariable("HOSTNAME");
+        if (!string.IsNullOrWhiteSpace(hostname))
+        {
+            return hostname;
+        }
+
+        try
+        {
+            return File.Exists("/etc/hostname")
+                ? File.ReadAllText("/etc/hostname").Trim()
+                : Environment.MachineName;
+        }
+        catch
+        {
+            return Environment.MachineName;
+        }
+    }
+}

--- a/apps/MineOS.Infrastructure/Services/ProxyForwardingService.cs
+++ b/apps/MineOS.Infrastructure/Services/ProxyForwardingService.cs
@@ -1,0 +1,662 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MineOS.Application.Dtos;
+using MineOS.Application.Interfaces;
+using MineOS.Application.Options;
+using MineOS.Domain.ValueObjects;
+using MineOS.Infrastructure.Utilities;
+using Tomlyn;
+using Tomlyn.Model;
+using YamlDotNet.RepresentationModel;
+
+namespace MineOS.Infrastructure.Services;
+
+/// <summary>
+/// Works out whether a backend server behind a proxy is actually protected, and
+/// configures it when it can be.
+///
+/// Nothing here is cached or persisted. Every answer is recomputed from the files
+/// on disk, because those files are what the servers actually read, and users edit
+/// them by hand.
+/// </summary>
+public class ProxyForwardingService : IProxyForwardingService
+{
+    private readonly IServerService _serverService;
+    private readonly IContainerPortInspector _portInspector;
+    private readonly HostOptions _options;
+    private readonly ILogger<ProxyForwardingService> _logger;
+
+    public ProxyForwardingService(
+        IServerService serverService,
+        IContainerPortInspector portInspector,
+        IOptions<HostOptions> options,
+        ILogger<ProxyForwardingService> logger)
+    {
+        _serverService = serverService;
+        _portInspector = portInspector;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    // Mirrors ServerService's path layout, which is private to that class.
+    private string GetServerPath(string name) =>
+        Path.Combine(_options.BaseDirectory, _options.ServersPathSegment, name);
+
+    private string GetPaperGlobalPath(string name) =>
+        Path.Combine(GetServerPath(name), "config", "paper-global.yml");
+
+    private string GetFabricProxyConfigPath(string name) =>
+        Path.Combine(GetServerPath(name), "config", "FabricProxy-Lite.toml");
+
+    public async Task<BackendForwardingDto> GetForwardingStatusAsync(
+        string serverName, CancellationToken cancellationToken)
+    {
+        var servers = await _serverService.ListServersAsync(cancellationToken);
+        return await BuildStatusAsync(serverName, servers, cancellationToken);
+    }
+
+    public async Task<ProxyBackendSummaryDto> GetProxyBackendsAsync(
+        string proxyName, CancellationToken cancellationToken)
+    {
+        var servers = await _serverService.ListServersAsync(cancellationToken);
+        var backendNames = await ResolveBackendNamesAsync(proxyName, servers, cancellationToken);
+
+        var results = new List<BackendForwardingDto>();
+        foreach (var backend in backendNames)
+        {
+            results.Add(await BuildStatusAsync(backend, servers, cancellationToken));
+        }
+
+        return new ProxyBackendSummaryDto(proxyName, results);
+    }
+
+    public async Task<BackendForwardingDto> SecureBackendAsync(
+        string serverName, CancellationToken cancellationToken)
+    {
+        var servers = await _serverService.ListServersAsync(cancellationToken);
+        var links = await FindClaimingProxiesAsync(serverName, servers, cancellationToken);
+
+        if (links.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"No proxy lists '{serverName}' as a backend. Add it to the proxy's servers list first.");
+        }
+        if (links.Count > 1)
+        {
+            // Refusing beats guessing: picking one would silently decide which
+            // proxy is allowed to authenticate players for this server.
+            throw new InvalidOperationException(
+                $"'{serverName}' is claimed by more than one proxy ({string.Join(", ", links.Select(l => l.ProxyName))}). " +
+                "Remove it from all but one before securing it.");
+        }
+
+        var link = links[0];
+        if (link.Kind == ProxyForwardingKind.BungeeCord)
+        {
+            throw new InvalidOperationException(
+                "BungeeCord's ip_forward carries no signature, so a backend behind it cannot verify " +
+                "forwarded players. Use a Velocity proxy, or keep this server unreachable from outside.");
+        }
+
+        var loader = await SafeDetectLoaderAsync(serverName, cancellationToken);
+        var tier = ProxyForwardingRules.TierFor(loader);
+        if (tier == LoaderTier.Unsupported)
+        {
+            throw new InvalidOperationException(
+                $"'{loader}' has no verified-forwarding support, so this backend cannot be secured. " +
+                "Keep its port unreachable from outside instead.");
+        }
+        if (tier == LoaderTier.ModRequired && !File.Exists(GetFabricProxyConfigPath(serverName)))
+        {
+            throw new InvalidOperationException(
+                "This Fabric server needs the FabricProxy-Lite mod before it can verify forwarded players. " +
+                "Install it, start the server once to generate its config, then secure it.");
+        }
+
+        // 1. Ensure the proxy has a secret. Reuse an existing one — regenerating
+        //    would break every sibling backend already secured against it.
+        var secret = await EnsureForwardingSecretAsync(link.ProxyName, cancellationToken);
+
+        // 2. Make the proxy verify forwarded players.
+        await EnsureModernForwardingAsync(link.ProxyName, cancellationToken);
+
+        // 3. Write the backend's half.
+        if (tier == LoaderTier.Native)
+        {
+            await WritePaperVelocityBlockAsync(serverName, secret, cancellationToken);
+        }
+        else
+        {
+            await WriteFabricProxySecretAsync(serverName, secret, cancellationToken);
+        }
+
+        // 4. Only now hand authentication over to the proxy. If any step above
+        //    threw, the server is still authenticating its own players: broken
+        //    behind the proxy, but not open to impersonation.
+        var properties = await _serverService.GetServerPropertiesAsync(serverName, cancellationToken);
+        properties["online-mode"] = "false";
+        await _serverService.UpdateServerPropertiesAsync(serverName, properties, cancellationToken);
+
+        await _serverService.MarkRestartRequiredAsync(serverName, cancellationToken);
+        await _serverService.MarkRestartRequiredAsync(link.ProxyName, cancellationToken);
+
+        _logger.LogInformation(
+            "Configured verified forwarding for backend {Backend} behind proxy {Proxy}",
+            serverName, link.ProxyName);
+
+        var refreshed = await _serverService.ListServersAsync(cancellationToken);
+        return await BuildStatusAsync(serverName, refreshed, cancellationToken);
+    }
+
+    // ---- status assembly -------------------------------------------------
+
+    private async Task<BackendForwardingDto> BuildStatusAsync(
+        string serverName, List<ServerDetailDto> servers, CancellationToken cancellationToken)
+    {
+        var links = await FindClaimingProxiesAsync(serverName, servers, cancellationToken);
+        var link = links.FirstOrDefault();
+
+        var loader = await SafeDetectLoaderAsync(serverName, cancellationToken);
+        var tier = ProxyForwardingRules.TierFor(loader);
+        var onlineMode = await ReadOnlineModeAsync(serverName, cancellationToken);
+
+        var configured = false;
+        var secretMatches = false;
+
+        if (link is not null && link.Kind != ProxyForwardingKind.BungeeCord)
+        {
+            var proxySecret = await ReadForwardingSecretAsync(link.ProxyName, cancellationToken);
+            var backendSecret = tier switch
+            {
+                LoaderTier.Native => ReadPaperVelocitySecret(serverName, out configured),
+                LoaderTier.ModRequired => ReadFabricProxySecret(serverName, out configured),
+                _ => null
+            };
+            secretMatches = SecretsAgree(proxySecret, backendSecret);
+        }
+
+        var facts = new ForwardingFacts(
+            IsBackend: link is not null,
+            ProxyKind: link?.Kind ?? ProxyForwardingKind.None,
+            Tier: tier,
+            BackendForwardingConfigured: configured,
+            SecretMatches: secretMatches,
+            ServerOnlineMode: onlineMode);
+
+        var assessment = ProxyForwardingRules.Resolve(facts);
+
+        // The exposure check is the only control left when nothing can be
+        // verified, so that is exactly when we spend the call.
+        var exposure = ExposureVerdict.Unknown;
+        string? exposureDetail = null;
+        if (assessment.Status == ProxyForwardingStatus.Unverifiable || assessment.IsSpoofable)
+        {
+            (exposure, exposureDetail) = await CheckExposureAsync(serverName, cancellationToken);
+        }
+
+        var remediation = assessment.Status switch
+        {
+            ProxyForwardingStatus.Securable or ProxyForwardingStatus.Misconfigured when tier == LoaderTier.Native
+                => "secure",
+            ProxyForwardingStatus.Securable or ProxyForwardingStatus.Misconfigured when tier == LoaderTier.ModRequired
+                => File.Exists(GetFabricProxyConfigPath(serverName)) ? "secure" : "install-mod",
+            _ => null
+        };
+
+        return new BackendForwardingDto(
+            ServerName: serverName,
+            Status: assessment.Status,
+            IsSpoofable: assessment.IsSpoofable,
+            ProxyKind: facts.ProxyKind,
+            Tier: tier,
+            ProxyName: link?.ProxyName,
+            Loader: loader,
+            ServerOnlineMode: onlineMode,
+            BackendForwardingConfigured: configured,
+            SecretMatches: secretMatches,
+            Exposure: exposure,
+            ExposureDetail: exposureDetail,
+            RemediationAction: remediation);
+    }
+
+    private sealed record ProxyLink(string ProxyName, ProxyForwardingKind Kind);
+
+    /// <summary>
+    /// Finds every proxy whose backend list points at this server. Matching is by
+    /// listen port plus a local-looking host: all servers share a host here, so the
+    /// port is what actually identifies the target.
+    /// </summary>
+    private async Task<List<ProxyLink>> FindClaimingProxiesAsync(
+        string serverName, List<ServerDetailDto> servers, CancellationToken cancellationToken)
+    {
+        var endpoint = await _serverService.GetServerListenEndpointAsync(serverName, cancellationToken);
+        var links = new List<ProxyLink>();
+        if (endpoint is null)
+        {
+            return links;
+        }
+
+        foreach (var proxy in servers.Where(s =>
+                     string.Equals(s.ServerType, "proxy", StringComparison.OrdinalIgnoreCase) &&
+                     !string.Equals(s.Name, serverName, StringComparison.OrdinalIgnoreCase)))
+        {
+            var addresses = await ReadBackendAddressesAsync(proxy.Name, cancellationToken);
+            if (addresses.Kind == ProxyForwardingKind.None)
+            {
+                continue;
+            }
+            if (addresses.Addresses.Any(a => AddressTargets(a, endpoint.Value.Port)))
+            {
+                links.Add(new ProxyLink(proxy.Name, addresses.Kind));
+            }
+        }
+
+        return links;
+    }
+
+    private async Task<List<string>> ResolveBackendNamesAsync(
+        string proxyName, List<ServerDetailDto> servers, CancellationToken cancellationToken)
+    {
+        var addresses = await ReadBackendAddressesAsync(proxyName, cancellationToken);
+        var names = new List<string>();
+
+        foreach (var server in servers.Where(s =>
+                     !string.Equals(s.ServerType, "proxy", StringComparison.OrdinalIgnoreCase)))
+        {
+            var endpoint = await _serverService.GetServerListenEndpointAsync(server.Name, cancellationToken);
+            if (endpoint is null)
+            {
+                continue;
+            }
+            if (addresses.Addresses.Any(a => AddressTargets(a, endpoint.Value.Port)))
+            {
+                names.Add(server.Name);
+            }
+        }
+
+        return names;
+    }
+
+    private sealed record BackendAddresses(ProxyForwardingKind Kind, IReadOnlyList<string> Addresses);
+
+    private async Task<BackendAddresses> ReadBackendAddressesAsync(
+        string proxyName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var velocity = await _serverService.GetVelocityConfigAsync(proxyName, cancellationToken);
+            if (velocity.Exists)
+            {
+                var kind = string.Equals(velocity.PlayerInfoForwardingMode, "modern", StringComparison.OrdinalIgnoreCase)
+                    ? ProxyForwardingKind.VelocityModern
+                    : ProxyForwardingKind.VelocityUnverified;
+                return new BackendAddresses(kind, velocity.Servers.Values.ToList());
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not read velocity.toml for {Proxy}", proxyName);
+        }
+
+        try
+        {
+            var bungee = await _serverService.GetBungeeConfigAsync(proxyName, cancellationToken);
+            if (bungee.Exists)
+            {
+                var addresses = (bungee.Servers ?? new Dictionary<string, BungeeBackendDto>())
+                    .Values.Where(b => b is not null).Select(b => b.Address).ToList();
+                return new BackendAddresses(ProxyForwardingKind.BungeeCord, addresses);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not read config.yml for {Proxy}", proxyName);
+        }
+
+        return new BackendAddresses(ProxyForwardingKind.None, Array.Empty<string>());
+    }
+
+    /// <summary>
+    /// True when a proxy backend address points at the given local port. Hosts are
+    /// compared loosely because "localhost", "127.0.0.1" and the container name all
+    /// resolve to the same server in practice; the port is the discriminator.
+    /// </summary>
+    internal static bool AddressTargets(string address, int port)
+    {
+        if (string.IsNullOrWhiteSpace(address))
+        {
+            return false;
+        }
+        var lastColon = address.LastIndexOf(':');
+        if (lastColon <= 0 || lastColon == address.Length - 1)
+        {
+            return false;
+        }
+        return int.TryParse(address[(lastColon + 1)..], out var parsed) && parsed == port;
+    }
+
+    // ---- reads -----------------------------------------------------------
+
+    private async Task<string?> SafeDetectLoaderAsync(string serverName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var loader = await _serverService.DetectLoaderAsync(serverName, cancellationToken);
+            return loader.Loader;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not detect loader for {Server}", serverName);
+            return null;
+        }
+    }
+
+    private async Task<bool> ReadOnlineModeAsync(string serverName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var properties = await _serverService.GetServerPropertiesAsync(serverName, cancellationToken);
+            // Minecraft's own default is true, and so is ours: assuming the safe
+            // value when the file is missing avoids inventing a scary warning.
+            return !properties.TryGetValue("online-mode", out var value) ||
+                   !string.Equals(value.Trim(), "false", StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not read server.properties for {Server}", serverName);
+            return true;
+        }
+    }
+
+    private string? ReadPaperVelocitySecret(string serverName, out bool configured)
+    {
+        configured = false;
+        var path = GetPaperGlobalPath(serverName);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            var stream = new YamlStream();
+            using var reader = new StringReader(File.ReadAllText(path));
+            stream.Load(reader);
+            if (stream.Documents.Count == 0 || stream.Documents[0].RootNode is not YamlMappingNode root)
+            {
+                return null;
+            }
+
+            if (!TryGetMap(root, "proxies", out var proxies) ||
+                !TryGetMap(proxies!, "velocity", out var velocity))
+            {
+                return null;
+            }
+
+            configured = ReadYamlBool(velocity!, "enabled");
+            return ReadYamlString(velocity!, "secret");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not read paper-global.yml for {Server}", serverName);
+            return null;
+        }
+    }
+
+    private string? ReadFabricProxySecret(string serverName, out bool configured)
+    {
+        configured = false;
+        var path = GetFabricProxyConfigPath(serverName);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            var model = Toml.ToModel(File.ReadAllText(path));
+            var secret = model.TryGetValue("secret", out var value) ? value as string : null;
+            configured = !string.IsNullOrEmpty(secret);
+            return secret;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not read FabricProxy-Lite.toml for {Server}", serverName);
+            return null;
+        }
+    }
+
+    private async Task<string?> ReadForwardingSecretAsync(string proxyName, CancellationToken cancellationToken)
+    {
+        var path = await GetForwardingSecretPathAsync(proxyName, cancellationToken);
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return (await File.ReadAllTextAsync(path, cancellationToken)).Trim();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not read forwarding secret for {Proxy}", proxyName);
+            return null;
+        }
+    }
+
+    private async Task<string> GetForwardingSecretPathAsync(string proxyName, CancellationToken cancellationToken)
+    {
+        var fileName = "forwarding.secret";
+        try
+        {
+            var velocity = await _serverService.GetVelocityConfigAsync(proxyName, cancellationToken);
+            if (!string.IsNullOrWhiteSpace(velocity.ForwardingSecretFile))
+            {
+                fileName = velocity.ForwardingSecretFile;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not read velocity.toml for {Proxy}; assuming forwarding.secret", proxyName);
+        }
+
+        // Velocity resolves this relative to its own directory. Reject anything
+        // that tries to climb out of it.
+        var safeName = Path.GetFileName(fileName);
+        if (string.IsNullOrWhiteSpace(safeName))
+        {
+            safeName = "forwarding.secret";
+        }
+        return Path.Combine(GetServerPath(proxyName), safeName);
+    }
+
+    /// <summary>
+    /// Length-independent comparison of the two sides' secrets. Both must be
+    /// present: two missing secrets are not a match, they are two holes.
+    /// </summary>
+    internal static bool SecretsAgree(string? proxySecret, string? backendSecret)
+    {
+        if (string.IsNullOrWhiteSpace(proxySecret) || string.IsNullOrWhiteSpace(backendSecret))
+        {
+            return false;
+        }
+        return CryptographicOperations.FixedTimeEquals(
+            System.Text.Encoding.UTF8.GetBytes(proxySecret.Trim()),
+            System.Text.Encoding.UTF8.GetBytes(backendSecret.Trim()));
+    }
+
+    // ---- writes ----------------------------------------------------------
+
+    private async Task<string> EnsureForwardingSecretAsync(string proxyName, CancellationToken cancellationToken)
+    {
+        var existing = await ReadForwardingSecretAsync(proxyName, cancellationToken);
+        if (!string.IsNullOrWhiteSpace(existing))
+        {
+            return existing;
+        }
+
+        var secret = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))
+            .Replace("+", "-").Replace("/", "_").TrimEnd('=');
+
+        var path = await GetForwardingSecretPathAsync(proxyName, cancellationToken);
+        await File.WriteAllTextAsync(path, secret, cancellationToken);
+        TryRestrictPermissions(path);
+        await OwnershipHelper.ChangeOwnershipAsync(path, _options.RunAsUid, _options.RunAsGid, _logger, cancellationToken);
+
+        _logger.LogInformation("Generated a forwarding secret for proxy {Proxy}", proxyName);
+        return secret;
+    }
+
+    private void TryRestrictPermissions(string path)
+    {
+        try
+        {
+            // Key material: owner read/write only.
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not restrict permissions on {Path}", path);
+        }
+    }
+
+    private async Task EnsureModernForwardingAsync(string proxyName, CancellationToken cancellationToken)
+    {
+        var velocity = await _serverService.GetVelocityConfigAsync(proxyName, cancellationToken);
+        if (string.Equals(velocity.PlayerInfoForwardingMode, "modern", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        await _serverService.UpdateVelocityConfigAsync(
+            proxyName,
+            velocity with { PlayerInfoForwardingMode = "modern" },
+            cancellationToken);
+
+        _logger.LogInformation("Switched proxy {Proxy} to modern player-info forwarding", proxyName);
+    }
+
+    /// <summary>
+    /// Writes proxies.velocity into paper-global.yml, editing the existing tree in
+    /// place. Paper's file carries well over a hundred keys we do not model, and
+    /// regenerating it would silently discard every one of them.
+    /// </summary>
+    private async Task WritePaperVelocityBlockAsync(
+        string serverName, string secret, CancellationToken cancellationToken)
+    {
+        var path = GetPaperGlobalPath(serverName);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+
+        var existingYaml = File.Exists(path)
+            ? await File.ReadAllTextAsync(path, cancellationToken)
+            : null;
+
+        await File.WriteAllTextAsync(path, UpsertPaperVelocityBlock(existingYaml, secret), cancellationToken);
+        TryRestrictPermissions(path);
+        await OwnershipHelper.ChangeOwnershipAsync(path, _options.RunAsUid, _options.RunAsGid, _logger, cancellationToken);
+    }
+
+    /// <summary>
+    /// Returns paper-global.yml with proxies.velocity set for verified forwarding,
+    /// editing the supplied document in place rather than regenerating it.
+    ///
+    /// Paper's file carries well over a hundred keys MineOS does not model, and a
+    /// regenerated file would silently discard every one of them — so this is kept
+    /// pure and covered by a round-trip test.
+    /// </summary>
+    internal static string UpsertPaperVelocityBlock(string? existingYaml, string secret)
+    {
+        var root = new YamlMappingNode();
+        if (!string.IsNullOrWhiteSpace(existingYaml))
+        {
+            var stream = new YamlStream();
+            using var reader = new StringReader(existingYaml);
+            stream.Load(reader);
+            if (stream.Documents.Count > 0 && stream.Documents[0].RootNode is YamlMappingNode existing)
+            {
+                root = existing;
+            }
+        }
+
+        var proxies = GetOrCreateMap(root, "proxies");
+        var velocity = GetOrCreateMap(proxies, "velocity");
+        velocity.Children[new YamlScalarNode("enabled")] = new YamlScalarNode("true");
+        // Paper's online-mode under velocity means "let the proxy tell us who this
+        // player is, and trust it because the payload is signed".
+        velocity.Children[new YamlScalarNode("online-mode")] = new YamlScalarNode("true");
+        velocity.Children[new YamlScalarNode("secret")] = new YamlScalarNode(secret);
+
+        var writer = new StringWriter();
+        new YamlStream(new YamlDocument(root)).Save(writer, assignAnchors: false);
+        return writer.ToString();
+    }
+
+    private async Task WriteFabricProxySecretAsync(
+        string serverName, string secret, CancellationToken cancellationToken)
+    {
+        var path = GetFabricProxyConfigPath(serverName);
+        var model = File.Exists(path)
+            ? Toml.ToModel(await File.ReadAllTextAsync(path, cancellationToken))
+            : new TomlTable();
+
+        model["secret"] = secret;
+        if (!model.ContainsKey("hackOnlineMode"))
+        {
+            model["hackOnlineMode"] = true;
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllTextAsync(path, Toml.FromModel(model), cancellationToken);
+        TryRestrictPermissions(path);
+        await OwnershipHelper.ChangeOwnershipAsync(path, _options.RunAsUid, _options.RunAsGid, _logger, cancellationToken);
+    }
+
+    // ---- exposure --------------------------------------------------------
+
+    private async Task<(ExposureVerdict, string?)> CheckExposureAsync(
+        string serverName, CancellationToken cancellationToken)
+    {
+        var endpoint = await _serverService.GetServerListenEndpointAsync(serverName, cancellationToken);
+        if (endpoint is null)
+        {
+            return (ExposureVerdict.Unknown, "Could not determine which port this server listens on.");
+        }
+        return await _portInspector.IsPortPublishedAsync(endpoint.Value.Port, cancellationToken);
+    }
+
+    // ---- yaml helpers ----------------------------------------------------
+
+    private static bool TryGetMap(YamlMappingNode parent, string key, out YamlMappingNode? map)
+    {
+        map = null;
+        if (parent.Children.TryGetValue(new YamlScalarNode(key), out var node) && node is YamlMappingNode found)
+        {
+            map = found;
+            return true;
+        }
+        return false;
+    }
+
+    private static YamlMappingNode GetOrCreateMap(YamlMappingNode parent, string key)
+    {
+        if (TryGetMap(parent, key, out var existing))
+        {
+            return existing!;
+        }
+        var created = new YamlMappingNode();
+        parent.Children[new YamlScalarNode(key)] = created;
+        return created;
+    }
+
+    private static string? ReadYamlString(YamlMappingNode node, string key) =>
+        node.Children.TryGetValue(new YamlScalarNode(key), out var v) && v is YamlScalarNode s
+            ? s.Value
+            : null;
+
+    private static bool ReadYamlBool(YamlMappingNode node, string key) =>
+        node.Children.TryGetValue(new YamlScalarNode(key), out var v) &&
+        v is YamlScalarNode s &&
+        bool.TryParse(s.Value, out var parsed) && parsed;
+}

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -1217,7 +1217,12 @@ public class ServerService : IServerService
             OnlineMode: true,
             ForceKeyAuthentication: true,
             PreventClientProxyConnections: false,
-            PlayerInfoForwardingMode: "none",
+            // Verified forwarding by default. "none" leaves backends unable to
+            // check who a forwarded player claims to be, which combined with the
+            // online-mode=false those backends require means anyone reaching one
+            // directly can join as anyone. Existing proxies keep whatever their
+            // velocity.toml already says — this default applies to new ones.
+            PlayerInfoForwardingMode: "modern",
             ForwardingSecretFile: "forwarding.secret",
             AnnounceForge: false,
             KickExistingPlayers: false,
@@ -1989,6 +1994,9 @@ public class ServerService : IServerService
         var eulaLine = lines.FirstOrDefault(line => line.TrimStart().StartsWith("eula=", StringComparison.OrdinalIgnoreCase));
         return eulaLine != null && eulaLine.Trim().Equals("eula=true", StringComparison.OrdinalIgnoreCase);
     }
+
+    public Task MarkRestartRequiredAsync(string name, CancellationToken cancellationToken) =>
+        MarkRestartRequiredAsync(name);
 
     private async Task MarkRestartRequiredAsync(string name)
     {

--- a/apps/MineOS.Tests/Unit/ProxyForwardingTests.cs
+++ b/apps/MineOS.Tests/Unit/ProxyForwardingTests.cs
@@ -1,0 +1,265 @@
+using System.Text.Json;
+using MineOS.Domain.ValueObjects;
+using MineOS.Infrastructure.Services;
+
+namespace MineOS.Tests.Unit;
+
+/// <summary>
+/// Covers the forwarding-security decision and the two file edits behind it.
+///
+/// The decision is deliberately a pure function over facts gathered elsewhere, so
+/// every interesting combination is testable without a filesystem, a proxy, or a
+/// running server.
+/// </summary>
+public class ProxyForwardingTests
+{
+    private static ForwardingFacts Facts(
+        bool isBackend = true,
+        ProxyForwardingKind kind = ProxyForwardingKind.VelocityModern,
+        LoaderTier tier = LoaderTier.Native,
+        bool configured = true,
+        bool secretMatches = true,
+        bool onlineMode = false) =>
+        new(isBackend, kind, tier, configured, secretMatches, onlineMode);
+
+    [Fact]
+    public void A_Standalone_Server_Is_Not_Assessed()
+    {
+        var result = ProxyForwardingRules.Resolve(Facts(isBackend: false));
+
+        Assert.Equal(ProxyForwardingStatus.NotABackend, result.Status);
+        Assert.False(result.IsSpoofable);
+    }
+
+    [Fact]
+    public void Modern_Forwarding_With_Matching_Secrets_Is_Secured()
+    {
+        var result = ProxyForwardingRules.Resolve(Facts());
+
+        Assert.Equal(ProxyForwardingStatus.Secured, result.Status);
+        Assert.False(result.IsSpoofable);
+    }
+
+    [Fact]
+    public void Online_Mode_Off_Without_Verified_Forwarding_Is_Spoofable()
+    {
+        // The combination this whole feature exists to catch: the backend has
+        // stopped authenticating players and nothing has taken the job over.
+        var result = ProxyForwardingRules.Resolve(
+            Facts(kind: ProxyForwardingKind.VelocityUnverified, configured: false, secretMatches: false));
+
+        Assert.Equal(ProxyForwardingStatus.Misconfigured, result.Status);
+        Assert.True(result.IsSpoofable);
+    }
+
+    [Fact]
+    public void A_Secret_Mismatch_Is_Spoofable_Even_Though_Both_Sides_Are_Configured()
+    {
+        // Looks configured from either side alone. Players cannot actually be
+        // verified, so online-mode=false still leaves the server open.
+        var result = ProxyForwardingRules.Resolve(Facts(secretMatches: false));
+
+        Assert.Equal(ProxyForwardingStatus.Misconfigured, result.Status);
+        Assert.True(result.IsSpoofable);
+    }
+
+    [Fact]
+    public void Online_Mode_Left_On_Is_Broken_But_Not_Dangerous()
+    {
+        // Players cannot join through the proxy, but the server still checks
+        // identities itself, so nobody can impersonate anyone.
+        var result = ProxyForwardingRules.Resolve(
+            Facts(kind: ProxyForwardingKind.VelocityUnverified, configured: false, onlineMode: true));
+
+        Assert.Equal(ProxyForwardingStatus.Securable, result.Status);
+        Assert.False(result.IsSpoofable);
+    }
+
+    [Fact]
+    public void Verified_Forwarding_With_Online_Mode_On_Is_Misconfigured_But_Safe()
+    {
+        var result = ProxyForwardingRules.Resolve(Facts(onlineMode: true));
+
+        Assert.Equal(ProxyForwardingStatus.Misconfigured, result.Status);
+        Assert.False(result.IsSpoofable);
+    }
+
+    [Fact]
+    public void A_Bungeecord_Backend_Is_Unverifiable_However_It_Is_Configured()
+    {
+        // ip_forward carries no signature, so there is nothing for the backend to
+        // check and no fix to offer beyond keeping the port unreachable.
+        var result = ProxyForwardingRules.Resolve(
+            Facts(kind: ProxyForwardingKind.BungeeCord, configured: true, secretMatches: true));
+
+        Assert.Equal(ProxyForwardingStatus.Unverifiable, result.Status);
+        Assert.True(result.IsSpoofable);
+    }
+
+    [Fact]
+    public void A_Forge_Backend_Is_Unverifiable_And_Reported_Spoofable_When_Open()
+    {
+        var result = ProxyForwardingRules.Resolve(Facts(tier: LoaderTier.Unsupported));
+
+        Assert.Equal(ProxyForwardingStatus.Unverifiable, result.Status);
+        Assert.True(result.IsSpoofable);
+    }
+
+    [Fact]
+    public void A_Fabric_Backend_Without_The_Mod_Is_Securable()
+    {
+        var result = ProxyForwardingRules.Resolve(
+            Facts(tier: LoaderTier.ModRequired, configured: false, secretMatches: false, onlineMode: true));
+
+        Assert.Equal(ProxyForwardingStatus.Securable, result.Status);
+        Assert.False(result.IsSpoofable);
+    }
+
+    [Theory]
+    [InlineData("paper", LoaderTier.Native)]
+    [InlineData("purpur", LoaderTier.Native)]
+    [InlineData("folia", LoaderTier.Native)]
+    [InlineData("fabric", LoaderTier.ModRequired)]
+    [InlineData("quilt", LoaderTier.ModRequired)]
+    [InlineData("forge", LoaderTier.Unsupported)]
+    [InlineData("neoforge", LoaderTier.Unsupported)]
+    [InlineData("vanilla", LoaderTier.Unsupported)]
+    // Modern forwarding is a Paper feature, not a Bukkit one.
+    [InlineData("spigot", LoaderTier.Unsupported)]
+    [InlineData("craftbukkit", LoaderTier.Unsupported)]
+    [InlineData(null, LoaderTier.Unsupported)]
+    public void Loader_Tiers_Reflect_What_Each_Server_Can_Verify(string? loader, LoaderTier expected)
+    {
+        Assert.Equal(expected, ProxyForwardingRules.TierFor(loader));
+    }
+
+    [Fact]
+    public void Two_Missing_Secrets_Are_Two_Holes_Not_A_Match()
+    {
+        Assert.False(ProxyForwardingService.SecretsAgree(null, null));
+        Assert.False(ProxyForwardingService.SecretsAgree("", ""));
+        Assert.False(ProxyForwardingService.SecretsAgree("   ", "   "));
+        Assert.False(ProxyForwardingService.SecretsAgree("abc", null));
+    }
+
+    [Fact]
+    public void Secrets_Match_Ignoring_Surrounding_Whitespace()
+    {
+        // Velocity writes the file without a trailing newline; editors add one.
+        Assert.True(ProxyForwardingService.SecretsAgree("s3cret", "s3cret\n"));
+        Assert.False(ProxyForwardingService.SecretsAgree("s3cret", "s3cretx"));
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1:25566", 25566, true)]
+    [InlineData("localhost:25566", 25566, true)]
+    [InlineData("mineos-api:25566", 25566, true)]
+    [InlineData("[::1]:25566", 25566, true)]
+    [InlineData("127.0.0.1:25565", 25566, false)]
+    [InlineData("127.0.0.1", 25566, false)]
+    [InlineData("", 25566, false)]
+    public void Backend_Addresses_Are_Matched_On_Port(string address, int port, bool expected)
+    {
+        Assert.Equal(expected, ProxyForwardingService.AddressTargets(address, port));
+    }
+
+    private const string PaperGlobalSample = """
+        _version: 29
+        block-updates:
+          disable-chorus-plant-updates: false
+        chunk-loading-advanced:
+          auto-config-send-distance: true
+        proxies:
+          bungee-cord:
+            online-mode: true
+          velocity:
+            enabled: false
+            online-mode: true
+            secret: ''
+        """;
+
+    [Fact]
+    public void Paper_Velocity_Block_Is_Enabled_Without_Touching_The_Rest_Of_The_File()
+    {
+        var result = ProxyForwardingService.UpsertPaperVelocityBlock(PaperGlobalSample, "topsecret");
+
+        // The keys we came for.
+        Assert.Contains("secret: topsecret", result);
+
+        // Everything Paper owns and we do not model must survive: regenerating
+        // this file instead of editing it would silently reset the server.
+        Assert.Contains("_version: 29", result);
+        Assert.Contains("disable-chorus-plant-updates", result);
+        Assert.Contains("auto-config-send-distance", result);
+        Assert.Contains("bungee-cord", result);
+    }
+
+    [Fact]
+    public void Paper_Velocity_Block_Is_Created_When_The_File_Does_Not_Exist_Yet()
+    {
+        // Paper fills in every key it owns on next start, so a minimal file is safe.
+        var result = ProxyForwardingService.UpsertPaperVelocityBlock(null, "topsecret");
+
+        Assert.Contains("proxies:", result);
+        Assert.Contains("velocity:", result);
+        Assert.Contains("enabled: true", result);
+        Assert.Contains("secret: topsecret", result);
+    }
+
+    private static JsonElement Container(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public void Host_Networking_Exposes_Every_Port()
+    {
+        var (verdict, detail) = DockerPortInspector.Evaluate(
+            Container("""{"HostConfig":{"NetworkMode":"host","PortBindings":{}}}"""), 25566);
+
+        Assert.Equal(ExposureVerdict.Exposed, verdict);
+        Assert.Contains("host networking", detail);
+    }
+
+    [Fact]
+    public void A_Published_Port_Is_Exposed()
+    {
+        var (verdict, _) = DockerPortInspector.Evaluate(
+            Container("""
+                {"HostConfig":{"NetworkMode":"bridge","PortBindings":{
+                  "25566/tcp":[{"HostIp":"","HostPort":"25566"}]}}}
+                """), 25566);
+
+        Assert.Equal(ExposureVerdict.Exposed, verdict);
+    }
+
+    [Fact]
+    public void An_Unpublished_Port_Is_Not_Exposed()
+    {
+        var (verdict, _) = DockerPortInspector.Evaluate(
+            Container("""
+                {"HostConfig":{"NetworkMode":"bridge","PortBindings":{
+                  "25565/tcp":[{"HostIp":"","HostPort":"25565"}]}}}
+                """), 25566);
+
+        Assert.Equal(ExposureVerdict.NotExposed, verdict);
+    }
+
+    [Fact]
+    public void A_Key_With_No_Bindings_Does_Not_Count_As_Published()
+    {
+        var (verdict, _) = DockerPortInspector.Evaluate(
+            Container("""{"HostConfig":{"NetworkMode":"bridge","PortBindings":{"25566/tcp":null}}}"""), 25566);
+
+        Assert.Equal(ExposureVerdict.NotExposed, verdict);
+    }
+
+    [Fact]
+    public void An_Unreadable_Answer_Is_Unknown_Never_Safe()
+    {
+        // The one behaviour that must not regress: no evidence is not evidence of
+        // safety, because this verdict is the only control for backends that
+        // cannot verify forwarded players at all.
+        Assert.Equal(ExposureVerdict.Unknown, DockerPortInspector.Evaluate(Container("{}"), 25566).Verdict);
+        Assert.Equal(
+            ExposureVerdict.Unknown,
+            DockerPortInspector.Evaluate(Container("""{"HostConfig":{"NetworkMode":"bridge"}}"""), 25566).Verdict);
+    }
+}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -813,3 +813,24 @@ export async function getPlayerActivityStats(
 	}
 	return { data: result.data?.data ?? null, error: null };
 }
+
+export async function getForwardingStatus(
+	fetcher: Fetcher,
+	name: string
+): Promise<ApiResult<import('./types').BackendForwarding>> {
+	return apiFetch(fetcher, `/api/servers/${name}/forwarding`);
+}
+
+export async function getProxyBackends(
+	fetcher: Fetcher,
+	name: string
+): Promise<ApiResult<import('./types').ProxyBackendSummary>> {
+	return apiFetch(fetcher, `/api/servers/${name}/forwarding/backends`);
+}
+
+export async function secureBackend(
+	fetcher: Fetcher,
+	name: string
+): Promise<ApiResult<import('./types').BackendForwarding>> {
+	return apiPost(fetcher, `/api/servers/${name}/forwarding/secure`);
+}

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -632,3 +632,39 @@ export type PlayerActivityStats = {
 	leaveCount: number;
 	deathCount: number;
 };
+
+export type ProxyForwardingStatus =
+	| 'NotABackend'
+	| 'Secured'
+	| 'Misconfigured'
+	| 'Securable'
+	| 'Unverifiable';
+
+export type ProxyForwardingKind = 'None' | 'VelocityModern' | 'VelocityUnverified' | 'BungeeCord';
+
+export type LoaderTier = 'Native' | 'ModRequired' | 'Unsupported';
+
+export type ExposureVerdict = 'Unknown' | 'NotExposed' | 'Exposed';
+
+// Note there is no secret here, by design: the API reports only whether the two
+// sides agree, never the value.
+export type BackendForwarding = {
+	serverName: string;
+	status: ProxyForwardingStatus;
+	isSpoofable: boolean;
+	proxyKind: ProxyForwardingKind;
+	tier: LoaderTier;
+	proxyName: string | null;
+	loader: string | null;
+	serverOnlineMode: boolean;
+	backendForwardingConfigured: boolean;
+	secretMatches: boolean;
+	exposure: ExposureVerdict;
+	exposureDetail: string | null;
+	remediationAction: 'secure' | 'install-mod' | null;
+};
+
+export type ProxyBackendSummary = {
+	proxyName: string;
+	backends: BackendForwarding[];
+};

--- a/apps/web/src/lib/components/ForwardingStatus.svelte
+++ b/apps/web/src/lib/components/ForwardingStatus.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+	import { invalidateAll } from '$app/navigation';
+	import { secureBackend } from '$lib/api/client';
+	import type { BackendForwarding } from '$lib/api/types';
+
+	let { forwarding }: { forwarding: BackendForwarding | null } = $props();
+
+	let busy = $state(false);
+	let error = $state<string | null>(null);
+
+	// A server nothing proxies has nothing to say here. Showing a reassuring
+	// "not applicable" panel on every standalone server would be noise, and
+	// noise is what makes people stop reading security warnings.
+	let visible = $derived(forwarding !== null && forwarding.status !== 'NotABackend');
+
+	let headline = $derived.by(() => {
+		if (!forwarding) return '';
+		if (forwarding.isSpoofable) return 'Anyone can join this server as anyone';
+		switch (forwarding.status) {
+			case 'Secured':
+				return 'Protected by verified proxy forwarding';
+			case 'Securable':
+				return 'Not reachable through the proxy yet';
+			case 'Misconfigured':
+				return 'Proxy forwarding is misconfigured';
+			case 'Unverifiable':
+				return 'This server cannot verify forwarded players';
+			default:
+				return '';
+		}
+	});
+
+	let detail = $derived.by(() => {
+		if (!forwarding) return '';
+		const proxy = forwarding.proxyName ?? 'a proxy';
+
+		if (forwarding.isSpoofable) {
+			return (
+				`This server has online-mode turned off, so it no longer checks who players are — ` +
+				`and nothing is verifying that for it. Anyone who can reach its port directly can join ` +
+				`as any username, including an operator's.`
+			);
+		}
+
+		switch (forwarding.status) {
+			case 'Secured':
+				return `${proxy} signs each player's identity and this server verifies the signature.`;
+			case 'Securable':
+				return (
+					`${proxy} lists this server as a backend, but players cannot join through it yet: ` +
+					`this server still authenticates them itself. Securing it hands that job to the proxy.`
+				);
+			case 'Misconfigured':
+				return (
+					`Verified forwarding is set up, but this server still has online-mode turned on, ` +
+					`so players cannot join through ${proxy}. Nobody can impersonate anyone — it is broken, not open.`
+				);
+			case 'Unverifiable':
+				return (
+					`${forwarding.loader ?? 'This server'} has no way to check that forwarded player ` +
+					`identities are genuine, so keeping its port unreachable from outside is the only protection.`
+				);
+			default:
+				return '';
+		}
+	});
+
+	async function secure() {
+		if (!forwarding) return;
+		busy = true;
+		error = null;
+		const result = await secureBackend(fetch, forwarding.serverName);
+		busy = false;
+		if (result.error) {
+			error = result.error;
+			return;
+		}
+		await invalidateAll();
+	}
+</script>
+
+{#if visible && forwarding}
+	<section
+		class="forwarding"
+		class:danger={forwarding.isSpoofable}
+		class:ok={forwarding.status === 'Secured'}
+	>
+		<div class="head">
+			<h2>{headline}</h2>
+			{#if forwarding.proxyName}
+				<span class="chip">behind {forwarding.proxyName}</span>
+			{/if}
+		</div>
+
+		<p>{detail}</p>
+
+		{#if forwarding.status === 'Unverifiable' || forwarding.isSpoofable}
+			<p class="exposure" class:danger={forwarding.exposure === 'Exposed'}>
+				{#if forwarding.exposure === 'Exposed'}
+					<strong>Reachable from outside.</strong>
+				{:else if forwarding.exposure === 'NotExposed'}
+					<strong>Not reachable from outside.</strong>
+				{:else}
+					<strong>Exposure unknown.</strong>
+				{/if}
+				{forwarding.exposureDetail ?? ''}
+			</p>
+		{/if}
+
+		{#if error}
+			<p class="error">{error}</p>
+		{/if}
+
+		{#if forwarding.remediationAction === 'secure'}
+			<button type="button" onclick={secure} disabled={busy}>
+				{busy ? 'Securing…' : 'Secure this backend'}
+			</button>
+			<p class="note">
+				Writes this server's forwarding config and turns off its own online-mode. Both this
+				server and the proxy need a restart afterwards.
+			</p>
+		{:else if forwarding.remediationAction === 'install-mod'}
+			<p class="note">
+				Fabric servers need the <strong>FabricProxy-Lite</strong> mod to verify forwarded players.
+				Install it from the Mods tab, start the server once so it writes its config, then secure it here.
+			</p>
+		{/if}
+	</section>
+{/if}
+
+<style>
+	.forwarding {
+		background: var(--mc-panel, rgba(22, 27, 46, 0.95));
+		border: 1px solid var(--border-color, #2a2f47);
+		border-left: 4px solid var(--warning, #d99a2b);
+		border-radius: 0.75rem;
+		padding: 1.25rem;
+		margin-bottom: 1rem;
+	}
+
+	.forwarding.danger {
+		border-left-color: var(--danger, #d9534f);
+	}
+
+	.forwarding.ok {
+		border-left-color: var(--success, #4caf50);
+	}
+
+	.head {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+	}
+
+	h2 {
+		margin: 0;
+		font-size: 1rem;
+	}
+
+	.chip {
+		font-size: 0.75rem;
+		padding: 0.15rem 0.5rem;
+		border-radius: 999px;
+		border: 1px solid var(--border-color, #2a2f47);
+		opacity: 0.85;
+	}
+
+	p {
+		margin: 0.6rem 0 0;
+		font-size: 0.9rem;
+		line-height: 1.5;
+	}
+
+	.exposure.danger {
+		color: var(--danger, #d9534f);
+	}
+
+	.note {
+		font-size: 0.8rem;
+		opacity: 0.75;
+	}
+
+	.error {
+		color: var(--danger, #d9534f);
+	}
+
+	button {
+		margin-top: 0.9rem;
+		padding: 0.5rem 1rem;
+		border-radius: 0.5rem;
+		border: 1px solid var(--border-color, #2a2f47);
+		background: var(--mc-accent, #3a6ea5);
+		color: inherit;
+		cursor: pointer;
+	}
+
+	button:disabled {
+		opacity: 0.6;
+		cursor: default;
+	}
+</style>

--- a/apps/web/src/lib/components/ProxyBackendRollup.svelte
+++ b/apps/web/src/lib/components/ProxyBackendRollup.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+	import type { ProxyBackendSummary, BackendForwarding } from '$lib/api/types';
+
+	let { summary }: { summary: ProxyBackendSummary | null } = $props();
+
+	let backends = $derived(summary?.backends ?? []);
+	let openCount = $derived(backends.filter((b) => b.isSpoofable).length);
+
+	function label(b: BackendForwarding): string {
+		if (b.isSpoofable) return 'Open to impersonation';
+		switch (b.status) {
+			case 'Secured':
+				return 'Secured';
+			case 'Securable':
+				return 'Not secured yet';
+			case 'Misconfigured':
+				return 'Misconfigured';
+			case 'Unverifiable':
+				return 'Cannot be verified';
+			default:
+				return 'Not a backend';
+		}
+	}
+
+	function tone(b: BackendForwarding): string {
+		if (b.isSpoofable) return 'danger';
+		if (b.status === 'Secured') return 'ok';
+		return 'warn';
+	}
+</script>
+
+{#if backends.length > 0}
+	<section class="rollup">
+		<div class="head">
+			<h2>Backend security</h2>
+			{#if openCount > 0}
+				<span class="chip danger">
+					{openCount} of {backends.length} open to impersonation
+				</span>
+			{:else}
+				<span class="chip">{backends.length} backend{backends.length === 1 ? '' : 's'}</span>
+			{/if}
+		</div>
+
+		<div class="scroll">
+			<table>
+				<thead>
+					<tr>
+						<th>Server</th>
+						<th>Type</th>
+						<th>Status</th>
+						<th>Reachable from outside</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each backends as backend (backend.serverName)}
+						<tr>
+							<td>
+								<a href="/servers/{backend.serverName}">{backend.serverName}</a>
+							</td>
+							<td>{backend.loader ?? 'unknown'}</td>
+							<td class={tone(backend)}>{label(backend)}</td>
+							<td>
+								{#if backend.status === 'Secured'}
+									<span class="muted">n/a — identities are verified</span>
+								{:else if backend.exposure === 'Exposed'}
+									<span class="danger">Yes</span>
+								{:else if backend.exposure === 'NotExposed'}
+									<span class="ok">No</span>
+								{:else}
+									<span class="muted">Unknown</span>
+								{/if}
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+
+		<p class="note">
+			Open a server to secure it. Backends that cannot verify forwarded players — Forge, vanilla,
+			or anything behind BungeeCord — rely entirely on not being reachable from outside.
+		</p>
+	</section>
+{/if}
+
+<style>
+	.rollup {
+		background: var(--mc-panel, rgba(22, 27, 46, 0.95));
+		border: 1px solid var(--border-color, #2a2f47);
+		border-radius: 0.75rem;
+		padding: 1.25rem;
+		margin-bottom: 1rem;
+	}
+
+	.head {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		flex-wrap: wrap;
+		margin-bottom: 0.75rem;
+	}
+
+	h2 {
+		margin: 0;
+		font-size: 1rem;
+	}
+
+	.chip {
+		font-size: 0.75rem;
+		padding: 0.15rem 0.5rem;
+		border-radius: 999px;
+		border: 1px solid var(--border-color, #2a2f47);
+	}
+
+	/* Wide content scrolls inside its own box rather than the page. */
+	.scroll {
+		overflow-x: auto;
+	}
+
+	table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.875rem;
+	}
+
+	th,
+	td {
+		text-align: left;
+		padding: 0.5rem 0.75rem;
+		border-bottom: 1px solid var(--border-color, #2a2f47);
+		white-space: nowrap;
+	}
+
+	th {
+		font-weight: 600;
+		opacity: 0.8;
+	}
+
+	.danger {
+		color: var(--danger, #d9534f);
+	}
+
+	.ok {
+		color: var(--success, #4caf50);
+	}
+
+	.warn {
+		color: var(--warning, #d99a2b);
+	}
+
+	.muted {
+		opacity: 0.65;
+	}
+
+	.note {
+		margin: 0.75rem 0 0;
+		font-size: 0.8rem;
+		opacity: 0.75;
+		line-height: 1.5;
+	}
+</style>

--- a/apps/web/src/routes/(app)/servers/[name]/+page.server.ts
+++ b/apps/web/src/routes/(app)/servers/[name]/+page.server.ts
@@ -1,11 +1,15 @@
 import type { PageServerLoad } from './$types';
-import { getServerStatus, getServerWatchdogStatus } from '$lib/api/client';
+import { getServerStatus, getServerWatchdogStatus, getForwardingStatus } from '$lib/api/client';
 
 export const load: PageServerLoad = async ({ params, fetch }) => {
 	const heartbeat = await getServerStatus(fetch, params.name);
 	const watchdog = await getServerWatchdogStatus(fetch, params.name);
+	// Derived fresh on every load rather than cached: a hand-edited
+	// server.properties must be reflected the next time the page is opened.
+	const forwarding = await getForwardingStatus(fetch, params.name);
 	return {
 		heartbeat,
-		watchdog
+		watchdog,
+		forwarding
 	};
 };

--- a/apps/web/src/routes/(app)/servers/[name]/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/+page.svelte
@@ -4,6 +4,7 @@
 	import { modal } from '$lib/stores/modal';
 	import { formatBytes, formatDate } from '$lib/utils/formatting';
 	import ChangeServerType from '$lib/components/ChangeServerType.svelte';
+	import ForwardingStatus from '$lib/components/ForwardingStatus.svelte';
 	import type { PageData } from './$types';
 	import type { LayoutData } from './$types';
 
@@ -430,6 +431,8 @@
 </script>
 
 <div class="dashboard">
+	<ForwardingStatus forwarding={data.forwarding?.data ?? null} />
+
 	<div class="grid">
 		<div class="card">
 			<h3>Server Information</h3>

--- a/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.server.ts
+++ b/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.server.ts
@@ -4,7 +4,8 @@ import {
 	updateVelocityConfig,
 	getBungeeConfig,
 	updateBungeeConfig,
-	getServer
+	getServer,
+	getProxyBackends
 } from '$lib/api/client';
 import { fail } from '@sveltejs/kit';
 
@@ -45,10 +46,15 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 		proxyKind = detectProxyKindFromJar(server.data?.config?.java?.jarFile ?? null);
 	}
 
+	// Roll-up of every backend this proxy claims, so the security posture of the
+	// whole set is visible from the place the backend list is edited.
+	const backends = await getProxyBackends(fetch, params.name);
+
 	return {
 		proxyKind,
 		velocityConfig: proxyKind === 'velocity' ? velocityConfig : null,
 		bungeeConfig: proxyKind === 'bungeecord' ? bungeeConfig : null,
+		backends,
 		serverName: params.name
 	};
 };

--- a/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/[name]/proxy-config/+page.svelte
@@ -4,6 +4,7 @@
 	import type { PageData, ActionData } from './$types';
 	import type { VelocityConfig } from '$lib/api/types';
 	import BungeeConfigEditor from './BungeeConfigEditor.svelte';
+	import ProxyBackendRollup from '$lib/components/ProxyBackendRollup.svelte';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 
@@ -150,6 +151,8 @@
 <svelte:head>
 	<title>Proxy Config | {data.serverName} | MineOS</title>
 </svelte:head>
+
+<ProxyBackendRollup summary={data.backends?.data ?? null} />
 
 {#if data.proxyKind !== 'velocity'}
 	<BungeeConfigEditor

--- a/docs/superpowers/specs/2026-08-20-proxy-forwarding-security-design.md
+++ b/docs/superpowers/specs/2026-08-20-proxy-forwarding-security-design.md
@@ -1,0 +1,209 @@
+# Proxy backend forwarding: secure by default, honest about the rest
+
+**Date:** 2026-08-20
+**Follows:** #99 (Velocity proxy support), #157 / #162 (BungeeCord proxy support)
+
+## Problem
+
+MineOS can already route several servers behind one port. `velocity.toml`'s
+`[forced-hosts]` table is read, written, and editable in the UI, so one proxy on
+25565 can serve `freemancraft.com` and `serverloco.win` from two different
+backends. That half works.
+
+The other half — making those backends *safe* — is entirely manual, and the
+default MineOS generates is the unsafe one.
+
+`ServerService.VelocityConfigDefaults` writes:
+
+```
+player-info-forwarding-mode = "none"
+```
+
+`none` is the unauthenticated forwarding mode. A server sitting behind a proxy
+must also run `online-mode=false`, because the proxy performs Mojang
+authentication on its behalf. Those two settings together mean **anyone who can
+open a TCP connection to the backend port can join as any username and UUID they
+like** — including an operator's. Nothing in MineOS writes the backend half that
+would prevent this, and nothing warns that it is missing.
+
+Two things make this worse than a documentation gap:
+
+1. `UpdateServerTypeAsync` pre-populates a new proxy's `[servers]` table with
+   *every* sibling Java server via `DiscoverJavaBackendsAsync`. Enrollment is
+   opt-out, so a user can acquire backends they never consciously enrolled.
+2. As of #162, BungeeCord is available too. Its `ip_forward: true` is the legacy
+   forwarding mode, which carries no signature at all — network isolation is the
+   only control that exists for it.
+
+## Goals
+
+1. A newly created Velocity proxy defaults to **verified** forwarding
+   (`modern`), with a generated `forwarding.secret`.
+2. Securing a Paper/Purpur backend is **one action**: MineOS writes
+   `config/paper-global.yml` and `server.properties` correctly, or fails without
+   leaving the server in a worse state than it found it.
+3. Every server reports, accurately and on every read, whether it is currently
+   spoofable.
+4. Where verified forwarding is impossible (Forge, vanilla, BungeeCord
+   `ip_forward`), MineOS **checks whether the backend is actually reachable from
+   outside** rather than printing a caveat.
+5. The forwarding secret never leaves the host. It is never returned by any API
+   response, in any form, redacted or otherwise.
+
+## Non-goals
+
+- **No blocking.** MineOS never refuses to enroll a backend. Self-hosted users
+  have legitimate setups the tool cannot model, and a hard block only pushes
+  them to hand-edit files, which loses the warning too.
+- **No auto-migration.** Existing proxies keep `player-info-forwarding-mode =
+  "none"` until a human acts. They will surface as `Misconfigured` with a fix
+  button. MineOS does not silently rewrite a running user's proxy config.
+- **No background reconciler.** Continuously forcing backend config to match
+  proxy config fights hand-edited files, which is hostile in a tool whose users
+  edit `server.properties` directly.
+- **No change to who-can-do-what.** Every new route sits in the existing
+  `servers` group behind `ServerAccessFilter`.
+- Bedrock is out of scope entirely — UDP 19132 is not proxied by Velocity or
+  BungeeCord and stays port-per-server.
+
+## Status model
+
+Status is **derived on every read, never stored.** No new table, no migration.
+A stored "secured" flag goes stale the moment someone edits `server.properties`
+by hand, and a stale security badge is worse than no badge.
+
+For a given server, resolution runs:
+
+1. **Is it a backend?** Scan sibling proxy servers' `velocity.toml` `[servers]`
+   (and `config.yml` `servers`) for an address matching this server's listen
+   endpoint, via the existing `GetServerListenEndpointAsync`.
+2. **What can it do?** `DetectLoaderAsync` gives the tier.
+3. **What is it?** Read `server.properties` `online-mode`, and for Paper,
+   `config/paper-global.yml` → `proxies.velocity.{enabled, online-mode, secret}`.
+4. **Do the secrets match?** Compared inside Infrastructure only.
+
+| Status | Meaning |
+|---|---|
+| `NotABackend` | Direct server, `online-mode=true`. Nothing to report. |
+| `Secured` | Modern forwarding, secrets match, `online-mode=false`. Correct. |
+| `Misconfigured` | Enrolled, `online-mode=false`, forwarding absent or secret mismatched. **Spoofable right now.** |
+| `Securable` | Fixable: one click (Paper/Purpur) or one mod (Fabric). |
+| `Unverifiable` | Forge / vanilla / BungeeCord `ip_forward`. Isolation is the only control. |
+
+### Capability tiers
+
+| Loader | Path |
+|---|---|
+| Paper, Purpur | Native modern forwarding. One-click secure. |
+| Fabric | Modern forwarding via FabricProxy-Lite. Offer install, then one-click. (PR 2) |
+| Forge, NeoForge, vanilla | No verified forwarding path. `Unverifiable` + exposure check. |
+
+## Write path
+
+`POST /servers/{name}/forwarding/secure`, acting on the **backend** server, so
+`ServerAccessFilter` gates it against a server the caller already has access to.
+Idempotent. Steps, in order:
+
+1. **Resolve the proxy.** Refuse if zero or more than one proxy claims this
+   backend — ambiguity here means guessing about security.
+2. **Ensure the secret.** If the proxy has no `forwarding.secret`, generate 32
+   bytes from `RandomNumberGenerator`, base64url-encode, write `0600`, chown via
+   `OwnershipHelper`. If one exists, **reuse it** — regenerating would break
+   every already-secured sibling backend.
+3. **Write the backend half.** `config/paper-global.yml` →
+   `proxies.velocity.{enabled: true, online-mode: true, secret: <value>}`, edited
+   in place with `YamlDotNet.RepresentationModel` so Paper's other keys survive.
+   Set the proxy's `player-info-forwarding-mode` to `modern` if still `none`.
+4. **Flip `online-mode=false`** in the backend's `server.properties` via
+   `UpdateServerPropertiesAsync`. Then `MarkRestartRequiredAsync` on both servers.
+
+**Step 4 is last, deliberately.** If step 3 fails part-way, the result is a
+backend that still authenticates its own players — broken behind a proxy, but not
+spoofable. The reverse order would leave a live, unauthenticated server. Fail
+toward the safe state.
+
+The action writes an `AuditLog` entry. It is a POST rather than part of a config
+save because it generates key material and has a real partial-failure mode.
+
+## Exposure check
+
+For `Unverifiable` backends, isolation is the only control, so MineOS verifies it
+instead of captioning it: read the API container's own port bindings over the
+already-mounted `/var/run/docker.sock`. .NET 8 speaks Unix sockets natively via
+`SocketsHttpHandler.ConnectCallback`, so **no new dependency is required**.
+
+| Verdict | Meaning |
+|---|---|
+| `Exposed` | The backend's port is published to the host, or `NetworkMode: host`. |
+| `NotExposed` | Positively determined that the port is not published. |
+| `Unknown` | The socket was unreadable or the answer was inconclusive. |
+
+**`Unknown` is never reported as `NotExposed`.** A security check that guesses
+"probably fine" is worse than one that admits it does not know.
+`docker-compose.host.yml` uses host networking, where every port is exposed
+regardless of `MC_PORT_RANGE`; that must report `Exposed`, not a computed
+false negative.
+
+## API surface
+
+| Route | Purpose |
+|---|---|
+| `GET /servers/{name}/forwarding` | Derived status, resolved proxy name, loader tier, `secretMatches: bool`, exposure verdict. |
+| `POST /servers/{name}/forwarding/secure` | The write path above. |
+| `GET /servers/{name}/forwarding/backends` | Proxy-side roll-up, filtered to servers the caller may access. |
+
+The DTO carries `secretMatches: bool` and **never the secret value**. The
+existing `VelocityConfigDto` exposes only `ForwardingSecretFile` (a filename);
+that stays.
+
+## Layering
+
+| Layer | Contents |
+|---|---|
+| `Domain` | `ProxyForwardingStatus`, `ExposureVerdict`, `BackendLink` — pure C#. |
+| `Application` | `IProxyForwardingService`, `BackendForwardingDto`. |
+| `Infrastructure` | `ProxyForwardingService`: TOML/YAML reads, secret generation, docker.sock. |
+| `Api` | Endpoints in the `servers` group; no logic. |
+
+## UI
+
+- **Backend server page:** a status strip. `Misconfigured` is loud and
+  non-dismissible: *"Players can currently join as anyone — this server accepts
+  unauthenticated connections"*, with the **Secure this backend** button.
+- **Proxy `proxy-config` page:** a backend roll-up showing every enrolled server
+  and its status, filtered to what the caller can access.
+- No `SystemNotification` rows are created; all of this is derived at read time.
+
+## Testing
+
+The core is pure and table-driven: given a proxy config, a loader, a
+`server.properties`, and a `paper-global.yml`, assert the status. Same shape as
+`BungeeConfigTests`, no service to stand up.
+
+- Status matrix across all five statuses and every loader tier.
+- Secret comparison: match, mismatch, missing on either side.
+- `paper-global.yml` round-trip preserving unmodeled Paper keys.
+- Write-path ordering: a failure in step 3 leaves `online-mode` untouched.
+- Exposure: published range, host networking, unreadable socket → `Unknown`.
+
+New tests must be measured against a captured clean baseline. `dotnet test` on
+`vibing` in a `mcr.microsoft.com/dotnet/sdk:8.0` container currently reports
+**53 passed / 6 failed / 59 total**; those 6 are pre-existing Bedrock and Mod
+integration failures.
+
+## Delivery
+
+**PR 1** — status model, derived endpoint, Paper/Purpur secure action, exposure
+check, `VelocityConfigDefaults` → `modern`, BungeeCord as `Unverifiable`.
+
+**PR 2** — Fabric: detect FabricProxy-Lite, offer to install it, then treat the
+backend as `Securable`. Requires a single-mod Modrinth install path;
+`IModrinthService` has search and version lookup, but `IModService` currently
+installs modpacks only.
+
+## Release notes
+
+Flipping the default to `modern` affects **new proxies only**. Users upgrading
+with existing proxies will suddenly see `Misconfigured` warnings on setups they
+believed were fine. Those setups are not fine — but the warning must be
+explained in the release notes rather than arriving as a surprise.

--- a/docs/superpowers/specs/2026-08-20-proxy-forwarding-security-design.md
+++ b/docs/superpowers/specs/2026-08-20-proxy-forwarding-security-design.md
@@ -186,10 +186,12 @@ The core is pure and table-driven: given a proxy config, a loader, a
 - Write-path ordering: a failure in step 3 leaves `online-mode` untouched.
 - Exposure: published range, host networking, unreadable socket → `Unknown`.
 
-New tests must be measured against a captured clean baseline. `dotnet test` on
-`vibing` in a `mcr.microsoft.com/dotnet/sdk:8.0` container currently reports
-**53 passed / 6 failed / 59 total**; those 6 are pre-existing Bedrock and Mod
-integration failures.
+New tests are measured against a captured clean baseline. That baseline used to
+carry 6 pre-existing failures; they turned out to be a single bug in
+`MineOsWebApplicationFactory`, which ran the integration tests against the real
+`/var/games/minecraft` instead of a temp directory (fixed separately in #163).
+`dotnet test` on `vibing` now reports **73 passed / 0 failed / 73 total**, so
+"green" means green and this feature is measured against zero.
 
 ## Delivery
 


### PR DESCRIPTION
Closes the gap left by #99 and #162: MineOS could already put several servers behind one port via Velocity's `forced-hosts`, but the config it generated was the unsafe one, and nothing wrote or checked the backend half.

## The problem

`VelocityConfigDefaults` wrote `player-info-forwarding-mode = "none"`. Backends behind a proxy must also run `online-mode=false`, because the proxy authenticates players on their behalf. Together those two settings mean **anyone who can open a TCP connection to a backend port can join as any username and UUID** — including an operator's.

Two things made it worse than a docs gap:

- `UpdateServerTypeAsync` pre-populates a new proxy's `[servers]` table with *every* sibling Java server, so enrollment is opt-out.
- #162 shipped BungeeCord, whose `ip_forward` carries no signature at all.

## What this adds

**Secure by default.** New Velocity proxies get `modern` forwarding and a generated `forwarding.secret`. Existing proxies are never rewritten — they surface as `Misconfigured` with a fix available. That's deliberate: MineOS does not silently rewrite a running user's proxy config.

**Derived status, never stored.** No new table, no migration. Every read recomputes from the files on disk, because a stored "secured" flag goes stale the moment someone edits `server.properties` by hand — and a stale security badge is worse than none.

`IsSpoofable` is reported *separately* from the status, because the two are not the same thing: a server with `online-mode` left on behind a proxy is broken (players can't join) but perfectly safe (nobody can impersonate anyone). Only `online-mode=false` **without** verified forwarding is dangerous, and that is the one the UI shouts about.

**One-click secure** for Paper/Purpur, and for Fabric once FabricProxy-Lite is present. The write order is the interesting part: secret → proxy mode → backend half → *then* `online-mode=false`. A partial failure leaves a server that still authenticates its own players — broken behind the proxy, but not open. The reverse order would leave it live and unauthenticated.

**Honest about what it can't fix.** Forge, vanilla and anything behind BungeeCord cannot verify forwarded identities, so isolation is their only control — and MineOS now *checks* it rather than printing a caveat, reading published ports over the Docker socket compose already mounts (no new dependency; .NET speaks Unix sockets natively). Host networking reports `Exposed` honestly. An unreadable answer is `Unknown`, **never** `NotExposed` — a check that guesses "probably fine" is worse than no check.

**The secret never leaves the host.** The DTO carries `secretMatches: bool` and never the value, redacted or otherwise.

## Deliberate non-goals

- **No blocking.** MineOS never refuses to enroll a backend. Self-hosted users have setups the tool can't model, and a hard block only pushes them to hand-edit files — which loses the warning too.
- **No background reconciler.** Continuously forcing backend config to match proxy config fights hand-edited files.
- **No change to who-can-do-what.** New routes sit in the `servers` group behind `ServerAccessFilter`. The secure action targets the *backend* — the server whose files it changes — so the existing ACL does real work. The proxy roll-up additionally filters rows to servers the caller can access: "this one is open to impersonation" is not something a partially privileged user should learn about a server they can't see.

## Testing

| | `vibing` | this branch |
|---|---|---|
| `dotnet test` | 73 passed, 0 failed | **109 passed, 0 failed** |
| `npm run check` | 5 errors, 93 warnings | 5 errors, 93 warnings |

+36 tests, no new svelte-check errors *or* warnings. The decision logic is a pure function over gathered facts, so the whole status matrix, both file edits, and every exposure verdict are covered without a filesystem, a proxy, or a running server.

Design doc: `docs/superpowers/specs/2026-08-20-proxy-forwarding-security-design.md`.

## Release notes

The default flip affects **new proxies only**. Users upgrading with existing proxies will suddenly see `Misconfigured` warnings on setups they believed were fine. Those setups are not fine — but this needs saying in the notes rather than arriving as a surprise.

## Follow-up

PR 2: detect and install FabricProxy-Lite so Fabric backends are one-click too. Needs a single-mod Modrinth install path — `IModrinthService` has search and version lookup, but `IModService` installs modpacks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
