### PR TITLE
fix(proxy): send enum names, not numbers, in the forwarding DTO

### DIFF
--- a/apps/MineOS.Application/Dtos/ProxyForwardingDtos.cs
+++ b/apps/MineOS.Application/Dtos/ProxyForwardingDtos.cs
@@ -1,5 +1,3 @@
-using MineOS.Domain.ValueObjects;
-
 namespace MineOS.Application.Dtos;
 
 /// <summary>
@@ -13,12 +11,16 @@ namespace MineOS.Application.Dtos;
 /// </summary>
 public record BackendForwardingDto(
     string ServerName,
-    ProxyForwardingStatus Status,
+    // Enum *names*, not numbers. System.Text.Json serializes enums as integers by
+    // default, and the web client matches on names ('Secured', 'Exposed'). Sending
+    // 3 where the UI expects "Securable" fails silently: the panel renders with an
+    // empty headline rather than erroring, so nothing surfaces the mismatch.
+    string Status,
     // True when the server currently accepts unauthenticated connections:
     // online-mode is off and nothing verifies the forwarded identity.
     bool IsSpoofable,
-    ProxyForwardingKind ProxyKind,
-    LoaderTier Tier,
+    string ProxyKind,
+    string Tier,
     string? ProxyName,
     string? Loader,
     bool ServerOnlineMode,
@@ -26,7 +28,7 @@ public record BackendForwardingDto(
     bool SecretMatches,
     // Only meaningful when no verified path exists — then isolation is the
     // only control and we report whether it actually holds.
-    ExposureVerdict Exposure,
+    string Exposure,
     string? ExposureDetail,
     // What the caller can do about it, if anything: "secure", "install-mod", or null.
     string? RemediationAction);

--- a/apps/MineOS.Infrastructure/Services/ProxyForwardingService.cs
+++ b/apps/MineOS.Infrastructure/Services/ProxyForwardingService.cs
@@ -206,16 +206,16 @@ public class ProxyForwardingService : IProxyForwardingService
 
         return new BackendForwardingDto(
             ServerName: serverName,
-            Status: assessment.Status,
+            Status: assessment.Status.ToString(),
             IsSpoofable: assessment.IsSpoofable,
-            ProxyKind: facts.ProxyKind,
-            Tier: tier,
+            ProxyKind: facts.ProxyKind.ToString(),
+            Tier: tier.ToString(),
             ProxyName: link?.ProxyName,
             Loader: loader,
             ServerOnlineMode: onlineMode,
             BackendForwardingConfigured: configured,
             SecretMatches: secretMatches,
-            Exposure: exposure,
+            Exposure: exposure.ToString(),
             ExposureDetail: exposureDetail,
             RemediationAction: remediation);
     }

--- a/apps/MineOS.Tests/Unit/ProxyForwardingTests.cs
+++ b/apps/MineOS.Tests/Unit/ProxyForwardingTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using MineOS.Application.Dtos;
 using MineOS.Domain.ValueObjects;
 using MineOS.Infrastructure.Services;
 
@@ -204,6 +205,57 @@ public class ProxyForwardingTests
         Assert.Contains("velocity:", result);
         Assert.Contains("enabled: true", result);
         Assert.Contains("secret: topsecret", result);
+    }
+
+    [Fact]
+    public void The_Dto_Puts_Enum_Names_On_The_Wire_Not_Numbers()
+    {
+        // Regression test for a bug the C# and TypeScript suites both missed by
+        // testing either side in isolation: System.Text.Json serializes enums as
+        // integers by default, so the API sent {"status":3} while the web client
+        // matched on 'Securable'. Nothing threw — the panel just rendered with an
+        // empty headline, which is the worst way for a security warning to fail.
+        var dto = new BackendForwardingDto(
+            ServerName: "freemancraft",
+            Status: ProxyForwardingStatus.Securable.ToString(),
+            IsSpoofable: false,
+            ProxyKind: ProxyForwardingKind.VelocityModern.ToString(),
+            Tier: LoaderTier.Native.ToString(),
+            ProxyName: "hub",
+            Loader: "paper",
+            ServerOnlineMode: true,
+            BackendForwardingConfigured: false,
+            SecretMatches: false,
+            Exposure: ExposureVerdict.Unknown.ToString(),
+            ExposureDetail: null,
+            RemediationAction: "secure");
+
+        var json = JsonSerializer.Serialize(dto);
+
+        Assert.Contains("\"status\":\"Securable\"", json, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"proxyKind\":\"VelocityModern\"", json, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"tier\":\"Native\"", json, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"exposure\":\"Unknown\"", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Every_Status_And_Verdict_Name_Matches_What_The_Web_Client_Expects()
+    {
+        // These strings are duplicated in apps/web/src/lib/api/types.ts. If an enum
+        // member is ever renamed, this fails here rather than silently blanking a
+        // warning in the browser.
+        Assert.Equal(
+            new[] { "NotABackend", "Secured", "Misconfigured", "Securable", "Unverifiable" },
+            Enum.GetNames<ProxyForwardingStatus>());
+        Assert.Equal(
+            new[] { "None", "VelocityModern", "VelocityUnverified", "BungeeCord" },
+            Enum.GetNames<ProxyForwardingKind>());
+        Assert.Equal(
+            new[] { "Native", "ModRequired", "Unsupported" },
+            Enum.GetNames<LoaderTier>());
+        Assert.Equal(
+            new[] { "Unknown", "NotExposed", "Exposed" },
+            Enum.GetNames<ExposureVerdict>());
     }
 
     private static JsonElement Container(string json) => JsonDocument.Parse(json).RootElement;


### PR DESCRIPTION
The security panel from #164 rendered with an **empty headline and description**. Found by running it against a real deployment, not by any test.

`System.Text.Json` serializes enums as integers by default, so the API sent:

```json
{"status": 3, "proxyKind": 1, "tier": 0, "exposure": 0}
```

while `ForwardingStatus.svelte` matches on names (`status === 'Securable'`). Every comparison fell through to the default branch. Nothing threw, nothing logged — the panel just came up blank, which for a warning that says *"anyone can join this server as anyone"* is the worst available failure mode.

The C# suite and `svelte-check` were both green throughout. Each side was correct in isolation; nothing exercised the wire format between them.

## The fix

The DTO carries enum **names** explicitly. The alternative — `ConfigureHttpJsonOptions` with `JsonStringEnumConverter` — would have been more idiomatic but also changes `ConsoleLogSource`'s shape for existing clients, so it's the wrong trade for a bug fix.

`ForwardingFacts` keeps the real enums: this is a wire-format concern, not a domain one.

## Regression cover

- `The_Dto_Puts_Enum_Names_On_The_Wire_Not_Numbers` — serializes the DTO and asserts `"status":"Securable"`.
- `Every_Status_And_Verdict_Name_Matches_What_The_Web_Client_Expects` — pins the enum member names that `types.ts` duplicates, so a rename fails here rather than silently blanking a warning in a browser.

## Testing

`dotnet test`: **111 passed, 0 failed** (was 109).

Verified end-to-end against a local Docker deployment: proxy on 25565 with two Paper backends, `forced-hosts` for two hostnames, one backend secured and one deliberately left vulnerable. The panel now renders the correct headline for both states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
