### PR TITLE
feat(proxy): one-click FabricProxy-Lite install for Fabric backends

### DIFF
--- a/apps/MineOS.Api/Endpoints/ServerEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/ServerEndpoints.cs
@@ -457,6 +457,27 @@ public static class ServerEndpoints
             }
         });
 
+        servers.MapPost("/{name}/forwarding/install-mod", async (
+            string name,
+            IProxyForwardingService forwardingService,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                return Results.Ok(await forwardingService.InstallForwardingModAsync(name, cancellationToken));
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Wrong loader, or no build matching this Minecraft version. Both
+                // carry a message the user needs to read.
+                return Results.Conflict(new { error = ex.Message });
+            }
+        });
+
         // Server config
         servers.MapGet("/{name}/server-config", async (
             string name,

--- a/apps/MineOS.Application/Interfaces/IProxyForwardingService.cs
+++ b/apps/MineOS.Application/Interfaces/IProxyForwardingService.cs
@@ -31,4 +31,15 @@ public interface IProxyForwardingService
     /// has no verified-forwarding path.
     /// </summary>
     Task<BackendForwardingDto> SecureBackendAsync(string serverName, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Installs the mod a Fabric backend needs before it can verify forwarded
+    /// players (FabricProxy-Lite), picking a build that matches the server's
+    /// Minecraft version.
+    ///
+    /// Idempotent. Throws <see cref="InvalidOperationException"/> when the server
+    /// is not Fabric, or when no build matches — installing a mismatched build
+    /// would leave a server that looks secured while verifying nothing.
+    /// </summary>
+    Task<BackendForwardingDto> InstallForwardingModAsync(string serverName, CancellationToken cancellationToken);
 }

--- a/apps/MineOS.Infrastructure/Services/FabricForwardingMod.cs
+++ b/apps/MineOS.Infrastructure/Services/FabricForwardingMod.cs
@@ -1,0 +1,141 @@
+using MineOS.Application.Dtos;
+
+namespace MineOS.Infrastructure.Services;
+
+/// <summary>
+/// Knowledge about FabricProxy-Lite, the mod that gives a Fabric server the
+/// ability to verify Velocity's modern forwarding. Paper implements that natively;
+/// Fabric needs this one jar, which is the whole reason Fabric is a separate tier.
+///
+/// The decisions here are pure so they can be tested without Modrinth or a server.
+/// </summary>
+internal static class FabricForwardingMod
+{
+    /// <summary>Modrinth accepts the slug wherever it accepts a project id.</summary>
+    internal const string ModrinthProjectId = "fabricproxy-lite";
+
+    internal const string DisplayName = "FabricProxy-Lite";
+
+    /// <summary>
+    /// Recognises the mod's jar across the spellings it ships under
+    /// ("FabricProxy-Lite-0.9.0.jar", "fabricproxy_lite.jar", …).
+    ///
+    /// Only enabled jars count. MineOS disables a mod by renaming it, and a
+    /// disabled FabricProxy-Lite verifies nothing — treating it as present would
+    /// report a spoofable server as secured, which is the one mistake this whole
+    /// feature exists to prevent.
+    /// </summary>
+    internal static bool IsForwardingModJar(string? fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            return false;
+        }
+
+        var name = fileName.Trim().ToLowerInvariant();
+        if (!name.EndsWith(".jar", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Collapse the separators authors vary on so one comparison covers them all.
+        var squashed = name.Replace("-", "").Replace("_", "").Replace(" ", "");
+        return squashed.Contains("fabricproxylite", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Pulls the Minecraft version out of a Fabric/Quilt server jar name, e.g.
+    /// "fabric-server-mc.1.21.1-loader.0.19.3.jar" -> "1.21.1".
+    ///
+    /// Needed because DetectLoaderAsync reports the *loader* version for these
+    /// servers (0.19.3), not the game version. Asking Modrinth for builds
+    /// supporting "Minecraft 0.19.3" matches nothing, so without this the install
+    /// refuses on every Fabric server it is offered.
+    /// </summary>
+    internal static string? TryParseMinecraftVersion(string? jarFile)
+    {
+        if (string.IsNullOrWhiteSpace(jarFile))
+        {
+            return null;
+        }
+
+        // "mc.1.21.1" / "mc1.21.1" is the marker Fabric and Quilt both use, and it
+        // is unambiguous — unlike the bare numbers elsewhere in the name.
+        var match = System.Text.RegularExpressions.Regex.Match(
+            jarFile,
+            @"mc\.?(?<mc>\d+\.\d+(?:\.\d+)?)",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        return match.Success ? match.Groups["mc"].Value : null;
+    }
+
+    /// <summary>
+    /// Picks the newest release that suits this server, or null when none does.
+    ///
+    /// Returning null matters: installing a FabricProxy-Lite built for another
+    /// Minecraft version leaves a server that looks secured and silently fails to
+    /// verify anything, so "no suitable build" must surface as a refusal rather
+    /// than a best guess.
+    /// </summary>
+    internal static ModrinthVersionDto? SelectVersion(
+        IReadOnlyList<ModrinthVersionDto> versions, string? gameVersion)
+    {
+        if (versions is null || versions.Count == 0)
+        {
+            return null;
+        }
+
+        var candidates = versions.Where(v =>
+            v.Loaders is null ||
+            v.Loaders.Count == 0 ||
+            v.Loaders.Any(l => string.Equals(l, "fabric", StringComparison.OrdinalIgnoreCase)));
+
+        if (!string.IsNullOrWhiteSpace(gameVersion))
+        {
+            candidates = candidates.Where(v =>
+                v.GameVersions is not null &&
+                v.GameVersions.Any(g => string.Equals(g, gameVersion, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        return candidates.OrderByDescending(v => v.DatePublished).FirstOrDefault();
+    }
+
+    /// <summary>
+    /// The project ids this version cannot run without.
+    ///
+    /// FabricProxy-Lite requires Fabric API, and a Fabric server whose mod has an
+    /// unmet hard dependency does not start with a warning — it refuses to boot at
+    /// all. Installing the mod without its dependencies is therefore worse than
+    /// not offering the install.
+    /// </summary>
+    internal static IReadOnlyList<string> RequiredDependencyProjects(ModrinthVersionDto? version)
+    {
+        if (version?.Dependencies is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        return version.Dependencies
+            .Where(d => string.Equals(d.DependencyType, "required", StringComparison.OrdinalIgnoreCase))
+            .Select(d => d.ProjectId)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(id => id!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    /// <summary>
+    /// The file to download from a version. Modrinth marks one file primary; the
+    /// rest are sources and javadoc jars, which would install cleanly and do
+    /// nothing.
+    /// </summary>
+    internal static ModrinthVersionFileDto? SelectFile(ModrinthVersionDto? version)
+    {
+        if (version?.Files is null || version.Files.Count == 0)
+        {
+            return null;
+        }
+        return version.Files.FirstOrDefault(f => f.Primary)
+               ?? version.Files.FirstOrDefault(f => f.FileName.EndsWith(".jar", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/apps/MineOS.Infrastructure/Services/ProxyForwardingService.cs
+++ b/apps/MineOS.Infrastructure/Services/ProxyForwardingService.cs
@@ -23,17 +23,26 @@ namespace MineOS.Infrastructure.Services;
 public class ProxyForwardingService : IProxyForwardingService
 {
     private readonly IServerService _serverService;
+    private readonly IModService _modService;
+    private readonly IModrinthService _modrinthService;
+    private readonly IProfileService _profileService;
     private readonly IContainerPortInspector _portInspector;
     private readonly HostOptions _options;
     private readonly ILogger<ProxyForwardingService> _logger;
 
     public ProxyForwardingService(
         IServerService serverService,
+        IModService modService,
+        IModrinthService modrinthService,
+        IProfileService profileService,
         IContainerPortInspector portInspector,
         IOptions<HostOptions> options,
         ILogger<ProxyForwardingService> logger)
     {
         _serverService = serverService;
+        _modService = modService;
+        _modrinthService = modrinthService;
+        _profileService = profileService;
         _portInspector = portInspector;
         _options = options.Value;
         _logger = logger;
@@ -107,11 +116,11 @@ public class ProxyForwardingService : IProxyForwardingService
                 $"'{loader}' has no verified-forwarding support, so this backend cannot be secured. " +
                 "Keep its port unreachable from outside instead.");
         }
-        if (tier == LoaderTier.ModRequired && !File.Exists(GetFabricProxyConfigPath(serverName)))
+        if (tier == LoaderTier.ModRequired && !await HasForwardingModAsync(serverName, cancellationToken))
         {
             throw new InvalidOperationException(
-                "This Fabric server needs the FabricProxy-Lite mod before it can verify forwarded players. " +
-                "Install it, start the server once to generate its config, then secure it.");
+                $"This Fabric server needs the {FabricForwardingMod.DisplayName} mod before it can verify " +
+                "forwarded players. Install it first — MineOS can do that for you.");
         }
 
         // 1. Ensure the proxy has a secret. Reuse an existing one — regenerating
@@ -147,6 +156,133 @@ public class ProxyForwardingService : IProxyForwardingService
 
         var refreshed = await _serverService.ListServersAsync(cancellationToken);
         return await BuildStatusAsync(serverName, refreshed, cancellationToken);
+    }
+
+    public async Task<BackendForwardingDto> InstallForwardingModAsync(
+        string serverName, CancellationToken cancellationToken)
+    {
+        var loader = await SafeDetectLoaderAsync(serverName, cancellationToken);
+        if (ProxyForwardingRules.TierFor(loader) != LoaderTier.ModRequired)
+        {
+            throw new InvalidOperationException(
+                $"{FabricForwardingMod.DisplayName} is only for Fabric servers. " +
+                $"'{loader ?? "This server"}' does not use it.");
+        }
+
+        if (await HasForwardingModAsync(serverName, cancellationToken))
+        {
+            _logger.LogInformation(
+                "{Mod} already installed for {Server}; nothing to do", FabricForwardingMod.DisplayName, serverName);
+            return await GetForwardingStatusAsync(serverName, cancellationToken);
+        }
+
+        var gameVersion = await ResolveGameVersionAsync(serverName, cancellationToken);
+        var versions = await _modrinthService.GetProjectVersionsAsync(
+            FabricForwardingMod.ModrinthProjectId, "fabric", gameVersion, cancellationToken);
+
+        var version = FabricForwardingMod.SelectVersion(versions, gameVersion);
+        var file = FabricForwardingMod.SelectFile(version);
+        if (version is null || file is null)
+        {
+            // Refusing beats installing a build for the wrong Minecraft version:
+            // that would leave a server that looks secured and verifies nothing.
+            throw new InvalidOperationException(
+                $"No {FabricForwardingMod.DisplayName} build was found for " +
+                $"{(string.IsNullOrWhiteSpace(gameVersion) ? "this server" : $"Minecraft {gameVersion}")}. " +
+                "Install it manually from the Mods tab, then secure this backend.");
+        }
+
+        // Hard dependencies first. Fabric refuses to boot at all when a mod's
+        // required dependency is missing, so a half-installed set is worse than
+        // no install: the button would leave the server unable to start.
+        var installed = new List<string>();
+        foreach (var dependencyId in FabricForwardingMod.RequiredDependencyProjects(version))
+        {
+            var dependencyVersions = await _modrinthService.GetProjectVersionsAsync(
+                dependencyId, "fabric", gameVersion, cancellationToken);
+            var dependencyVersion = FabricForwardingMod.SelectVersion(dependencyVersions, gameVersion);
+            var dependencyFile = FabricForwardingMod.SelectFile(dependencyVersion);
+
+            if (dependencyFile is null)
+            {
+                throw new InvalidOperationException(
+                    $"{FabricForwardingMod.DisplayName} needs '{dependencyId}', but no build of it was found " +
+                    $"for {(string.IsNullOrWhiteSpace(gameVersion) ? "this server" : $"Minecraft {gameVersion}")}. " +
+                    "Nothing was installed.");
+            }
+
+            await InstallFileAsync(serverName, dependencyFile, cancellationToken);
+            installed.Add(dependencyFile.FileName);
+        }
+
+        await InstallFileAsync(serverName, file, cancellationToken);
+        installed.Add(file.FileName);
+
+        await _serverService.MarkRestartRequiredAsync(serverName, cancellationToken);
+        _logger.LogInformation(
+            "Installed {Mod} {Version} for {Server}: {Files}",
+            FabricForwardingMod.DisplayName, version.VersionNumber, serverName, string.Join(", ", installed));
+
+        return await GetForwardingStatusAsync(serverName, cancellationToken);
+    }
+
+    private async Task InstallFileAsync(
+        string serverName, ModrinthVersionFileDto file, CancellationToken cancellationToken)
+    {
+        await using var download = await _modrinthService.OpenDownloadStreamAsync(file.Url, cancellationToken);
+        await _modService.SaveModAsync(serverName, file.FileName, download, cancellationToken);
+    }
+
+    private async Task<bool> HasForwardingModAsync(string serverName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var mods = await _modService.ListModsAsync(serverName, cancellationToken);
+            // A disabled jar loads nothing, so it does not count as installed.
+            return mods.Any(m => !m.IsDisabled && FabricForwardingMod.IsForwardingModJar(m.FileName));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not list mods for {Server}", serverName);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The Minecraft version this server runs, used to pick a matching mod build.
+    /// Mirrors how the mods endpoints resolve it: detection first, then the
+    /// configured profile as a fallback.
+    /// </summary>
+    private async Task<string?> ResolveGameVersionAsync(string serverName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var config = await _serverService.GetServerConfigAsync(serverName, cancellationToken);
+
+            // The jar name is the reliable source here. DetectLoaderAsync's Version
+            // is the *loader* version for Fabric/Quilt (0.19.3), not the game
+            // version, and feeding that to Modrinth matches nothing.
+            var fromJar = FabricForwardingMod.TryParseMinecraftVersion(config.Java.JarFile);
+            if (!string.IsNullOrWhiteSpace(fromJar))
+            {
+                return fromJar;
+            }
+
+            if (!string.IsNullOrWhiteSpace(config.Minecraft.Profile))
+            {
+                var profile = await _profileService.GetProfileAsync(config.Minecraft.Profile, cancellationToken);
+                if (!string.IsNullOrWhiteSpace(profile?.Version))
+                {
+                    return profile!.Version;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not resolve the Minecraft version for {Server}", serverName);
+        }
+
+        return null;
     }
 
     // ---- status assembly -------------------------------------------------
@@ -186,6 +322,9 @@ public class ProxyForwardingService : IProxyForwardingService
 
         var assessment = ProxyForwardingRules.Resolve(facts);
 
+        var hasForwardingMod = tier == LoaderTier.ModRequired &&
+                               await HasForwardingModAsync(serverName, cancellationToken);
+
         // The exposure check is the only control left when nothing can be
         // verified, so that is exactly when we spend the call.
         var exposure = ExposureVerdict.Unknown;
@@ -200,7 +339,7 @@ public class ProxyForwardingService : IProxyForwardingService
             ProxyForwardingStatus.Securable or ProxyForwardingStatus.Misconfigured when tier == LoaderTier.Native
                 => "secure",
             ProxyForwardingStatus.Securable or ProxyForwardingStatus.Misconfigured when tier == LoaderTier.ModRequired
-                => File.Exists(GetFabricProxyConfigPath(serverName)) ? "secure" : "install-mod",
+                => hasForwardingMod ? "secure" : "install-mod",
             _ => null
         };
 

--- a/apps/MineOS.Tests/Unit/FabricForwardingModTests.cs
+++ b/apps/MineOS.Tests/Unit/FabricForwardingModTests.cs
@@ -1,0 +1,170 @@
+using MineOS.Application.Dtos;
+using MineOS.Infrastructure.Services;
+
+namespace MineOS.Tests.Unit;
+
+/// <summary>
+/// Covers the two decisions behind installing FabricProxy-Lite: recognising the
+/// mod on disk, and choosing which build to fetch. Both are pure, so neither test
+/// needs Modrinth or a server.
+/// </summary>
+public class FabricForwardingModTests
+{
+    [Theory]
+    [InlineData("FabricProxy-Lite-0.9.0.jar", true)]
+    [InlineData("fabricproxy-lite.jar", true)]
+    [InlineData("fabricproxy_lite-1.2.3.jar", true)]
+    [InlineData("FabricProxy Lite.jar", true)]
+    [InlineData("fabricproxy.jar", false)]        // the older, different mod
+    [InlineData("lithium-fabric-0.11.jar", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void The_Mod_Jar_Is_Recognised_Across_Its_Spellings(string? fileName, bool expected)
+    {
+        Assert.Equal(expected, FabricForwardingMod.IsForwardingModJar(fileName));
+    }
+
+    [Fact]
+    public void A_Renamed_Disabled_Jar_Is_Not_A_Jar()
+    {
+        // MineOS disables a mod by renaming it away from .jar. A disabled
+        // FabricProxy-Lite verifies nothing, so counting it as installed would
+        // report a spoofable server as secured.
+        Assert.False(FabricForwardingMod.IsForwardingModJar("FabricProxy-Lite-0.9.0.jar.disabled"));
+    }
+
+    [Theory]
+    [InlineData("fabric-server-mc.1.21.1-loader.0.19.3.jar", "1.21.1")]
+    [InlineData("fabric-server-mc.1.20-loader.0.15.0.jar", "1.20")]
+    [InlineData("quilt-server-mc.1.21.4-loader.0.26.0.jar", "1.21.4")]
+    [InlineData("server.jar", null)]
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    public void The_Minecraft_Version_Comes_From_The_Jar_Name(string? jar, string? expected)
+    {
+        // Regression test for a bug found running this against a real Fabric
+        // install: DetectLoaderAsync reports the LOADER version for Fabric
+        // (0.19.3), so using it as the game version asked Modrinth for builds
+        // supporting "Minecraft 0.19.3" and the install refused every time.
+        Assert.Equal(expected, FabricForwardingMod.TryParseMinecraftVersion(jar));
+    }
+
+    [Fact]
+    public void The_Loader_Version_Is_Never_Mistaken_For_The_Game_Version()
+    {
+        Assert.Equal("1.21.1",
+            FabricForwardingMod.TryParseMinecraftVersion("fabric-server-mc.1.21.1-loader.0.19.3.jar"));
+    }
+
+    private static ModrinthVersionDto Version(
+        string id, string number, string published, string[] gameVersions, string[] loaders,
+        ModrinthVersionFileDto[]? files = null, ModrinthDependencyDto[]? dependencies = null) =>
+        new(id, "proj", number, number, DateTimeOffset.Parse(published), 0,
+            gameVersions, loaders,
+            files ?? new[] { new ModrinthVersionFileDto($"https://cdn/{number}.jar", $"{number}.jar", 1000, true) },
+            dependencies ?? Array.Empty<ModrinthDependencyDto>());
+
+    [Fact]
+    public void The_Newest_Build_For_This_Minecraft_Version_Wins()
+    {
+        var versions = new[]
+        {
+            Version("a", "0.8.0", "2026-01-01T00:00:00Z", new[] { "1.21.1" }, new[] { "fabric" }),
+            Version("b", "0.9.0", "2026-06-01T00:00:00Z", new[] { "1.21.1" }, new[] { "fabric" }),
+            Version("c", "1.0.0", "2026-07-01T00:00:00Z", new[] { "1.21.4" }, new[] { "fabric" }),
+        };
+
+        var chosen = FabricForwardingMod.SelectVersion(versions, "1.21.1");
+
+        Assert.Equal("0.9.0", chosen?.VersionNumber);
+    }
+
+    [Fact]
+    public void No_Matching_Minecraft_Version_Returns_Null_Rather_Than_A_Guess()
+    {
+        // Installing a build for the wrong Minecraft version leaves a server that
+        // looks secured and verifies nothing, so this must refuse, not approximate.
+        var versions = new[]
+        {
+            Version("a", "1.0.0", "2026-07-01T00:00:00Z", new[] { "1.21.4" }, new[] { "fabric" }),
+        };
+
+        Assert.Null(FabricForwardingMod.SelectVersion(versions, "1.20.1"));
+    }
+
+    [Fact]
+    public void Builds_For_Other_Loaders_Are_Ignored()
+    {
+        var versions = new[]
+        {
+            Version("a", "9.9.9", "2026-08-01T00:00:00Z", new[] { "1.21.1" }, new[] { "forge" }),
+            Version("b", "0.9.0", "2026-06-01T00:00:00Z", new[] { "1.21.1" }, new[] { "fabric" }),
+        };
+
+        Assert.Equal("0.9.0", FabricForwardingMod.SelectVersion(versions, "1.21.1")?.VersionNumber);
+    }
+
+    [Fact]
+    public void An_Unknown_Minecraft_Version_Falls_Back_To_The_Newest_Fabric_Build()
+    {
+        var versions = new[]
+        {
+            Version("a", "0.8.0", "2026-01-01T00:00:00Z", new[] { "1.21.1" }, new[] { "fabric" }),
+            Version("b", "1.0.0", "2026-07-01T00:00:00Z", new[] { "1.21.4" }, new[] { "fabric" }),
+        };
+
+        Assert.Equal("1.0.0", FabricForwardingMod.SelectVersion(versions, null)?.VersionNumber);
+    }
+
+    [Fact]
+    public void Selecting_From_An_Empty_List_Is_Null_Not_A_Crash()
+    {
+        Assert.Null(FabricForwardingMod.SelectVersion(Array.Empty<ModrinthVersionDto>(), "1.21.1"));
+        Assert.Null(FabricForwardingMod.SelectFile(null));
+    }
+
+    [Fact]
+    public void The_Primary_File_Is_Chosen_Over_Sources_Jars()
+    {
+        // Modrinth versions often carry sources/javadoc jars alongside the mod.
+        // Installing one of those succeeds and does nothing.
+        var version = Version("a", "0.9.0", "2026-06-01T00:00:00Z", new[] { "1.21.1" }, new[] { "fabric" },
+            new[]
+            {
+                new ModrinthVersionFileDto("https://cdn/sources.jar", "fabricproxy-lite-sources.jar", 10, false),
+                new ModrinthVersionFileDto("https://cdn/mod.jar", "fabricproxy-lite-0.9.0.jar", 100, true),
+            });
+
+        Assert.Equal("fabricproxy-lite-0.9.0.jar", FabricForwardingMod.SelectFile(version)?.FileName);
+    }
+
+    [Fact]
+    public void Required_Dependencies_Are_Collected_And_Optional_Ones_Ignored()
+    {
+        // Regression test for a bug found by starting a real Fabric server after
+        // the install: FabricProxy-Lite hard-requires Fabric API, and Fabric
+        // refuses to BOOT when a required dependency is missing. Installing the
+        // mod alone left the server unable to start at all.
+        var version = Version("a", "2.10.1", "2026-06-01T00:00:00Z", new[] { "1.21.1" }, new[] { "fabric" },
+            dependencies: new[]
+            {
+                new ModrinthDependencyDto("P7dR8mSH", null, "required"),   // fabric-api
+                new ModrinthDependencyDto("optional1", null, "optional"),
+                new ModrinthDependencyDto(null, "someVersion", "required"), // no project id to fetch
+                new ModrinthDependencyDto("P7dR8mSH", null, "required"),   // duplicate
+            });
+
+        var required = FabricForwardingMod.RequiredDependencyProjects(version);
+
+        Assert.Equal(new[] { "P7dR8mSH" }, required);
+    }
+
+    [Fact]
+    public void A_Version_With_No_Dependencies_Yields_An_Empty_List()
+    {
+        var version = Version("a", "1.0.0", "2026-06-01T00:00:00Z", new[] { "1.21.1" }, new[] { "fabric" });
+
+        Assert.Empty(FabricForwardingMod.RequiredDependencyProjects(version));
+        Assert.Empty(FabricForwardingMod.RequiredDependencyProjects(null));
+    }
+}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -834,3 +834,10 @@ export async function secureBackend(
 ): Promise<ApiResult<import('./types').BackendForwarding>> {
 	return apiPost(fetcher, `/api/servers/${name}/forwarding/secure`);
 }
+
+export async function installForwardingMod(
+	fetcher: Fetcher,
+	name: string
+): Promise<ApiResult<import('./types').BackendForwarding>> {
+	return apiPost(fetcher, `/api/servers/${name}/forwarding/install-mod`);
+}

--- a/apps/web/src/lib/components/ForwardingStatus.svelte
+++ b/apps/web/src/lib/components/ForwardingStatus.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { invalidateAll } from '$app/navigation';
-	import { secureBackend } from '$lib/api/client';
+	import { secureBackend, installForwardingMod } from '$lib/api/client';
 	import type { BackendForwarding } from '$lib/api/types';
 
 	let { forwarding }: { forwarding: BackendForwarding | null } = $props();
@@ -65,6 +65,19 @@
 		}
 	});
 
+	async function installMod() {
+		if (!forwarding) return;
+		busy = true;
+		error = null;
+		const result = await installForwardingMod(fetch, forwarding.serverName);
+		busy = false;
+		if (result.error) {
+			error = result.error;
+			return;
+		}
+		await invalidateAll();
+	}
+
 	async function secure() {
 		if (!forwarding) return;
 		busy = true;
@@ -120,9 +133,13 @@
 				server and the proxy need a restart afterwards.
 			</p>
 		{:else if forwarding.remediationAction === 'install-mod'}
+			<button type="button" onclick={installMod} disabled={busy}>
+				{busy ? 'Installing…' : 'Install FabricProxy-Lite'}
+			</button>
 			<p class="note">
 				Fabric servers need the <strong>FabricProxy-Lite</strong> mod to verify forwarded players.
-				Install it from the Mods tab, start the server once so it writes its config, then secure it here.
+				MineOS picks a build matching this server's Minecraft version; you can secure the backend
+				once it is installed.
 			</p>
 		{/if}
 	</section>

--- a/docs/superpowers/specs/2026-08-20-proxy-forwarding-security-design.md
+++ b/docs/superpowers/specs/2026-08-20-proxy-forwarding-security-design.md
@@ -199,9 +199,20 @@ carry 6 pre-existing failures; they turned out to be a single bug in
 check, `VelocityConfigDefaults` → `modern`, BungeeCord as `Unverifiable`.
 
 **PR 2** — Fabric: detect FabricProxy-Lite, offer to install it, then treat the
-backend as `Securable`. Requires a single-mod Modrinth install path;
-`IModrinthService` has search and version lookup, but `IModService` currently
-installs modpacks only.
+backend as `Securable`. **Delivered.**
+
+Three things only surfaced once it ran against a real Fabric server, and each is
+now covered by a regression test:
+
+1. `DetectLoaderAsync` reports the *loader* version for Fabric (`0.19.3`), not
+   the game version, so the Minecraft version is parsed from the server jar name
+   (`fabric-server-mc.1.21.1-loader.0.19.3.jar`) instead. Without this, every
+   install was refused.
+2. FabricProxy-Lite hard-requires Fabric API, and Fabric **refuses to boot** when
+   a required dependency is missing — so the install resolves required Modrinth
+   dependencies too, or aborts without installing anything.
+3. A disabled mod jar must not count as installed; MineOS disables mods by
+   renaming them, and a disabled FabricProxy-Lite verifies nothing.
 
 ## Release notes
 


### PR DESCRIPTION
Completes the middle tier of the forwarding work from #164. Paper verifies forwarded players natively; Fabric can too, but only with **FabricProxy-Lite** installed — which is why it was a separate tier and a separate PR.

`POST /servers/{name}/forwarding/install-mod` resolves a build matching the server's Minecraft version from Modrinth, installs it through the existing `IModrinthService` / `IModService` seams, and leaves the backend ready to secure. The panel's "install it yourself from the Mods tab" note is now a button.

## What running it against a real Fabric server taught me

All three of these passed every unit test and failed in reality. Each now has a regression test.

**1. `DetectLoaderAsync` returns the loader version, not the game version.** For a Fabric server it reports `0.19.3` — the *loader* — so the code asked Modrinth for builds supporting "Minecraft 0.19.3" and matched nothing. Every install refused. The Minecraft version now comes from the jar name (`fabric-server-mc.1.21.1-loader.0.19.3.jar`).

Worth flagging: `ModEndpoints.ResolveServerDefaultsAsync` resolves the game version the same way, so the mods browser likely mis-filters for Fabric servers too. Untouched here — separate PR.

**2. FabricProxy-Lite hard-requires Fabric API, and Fabric refuses to *boot* without it.** Not a warning — the server dies on startup:

```
Incompatible mods found!
 - Mod 'FabricProxy Lite' 2.10.1 requires version 0.100.1 or later of fabric-api, which is missing!
```

Installing the mod alone left a server that wouldn't start, which is worse than not offering the button. Required Modrinth dependencies are now installed alongside it, and a dependency with no matching build aborts the whole install rather than leaving a half-installed set.

**3. A disabled mod jar must not count as installed.** MineOS disables mods by renaming them; a disabled FabricProxy-Lite verifies nothing, so counting it would report a spoofable server as `Secured`.

## Refusals over guesses

`SelectVersion` returns null when nothing matches the server's Minecraft version, and the endpoint turns that into a 409 with a readable message. Installing a mismatched build would leave a server that *looks* secured and verifies nothing — the one outcome worth failing loudly to avoid.

## Testing

| | `vibing` | this branch |
|---|---|---|
| `dotnet test` | 111 passed, 0 failed | **135 passed, 0 failed** |
| `npm run check` | 5 errors, 93 warnings | 5 errors, 93 warnings |

Verified end to end on a real Fabric 1.21.1 server behind a Velocity proxy in Docker — install, secure, restart — using a Minecraft protocol probe:

- Direct connection: challenged on `velocity:player_info`, rejected with `"This server requires you to connect with Velocity."`
- Through the proxy: `fabric.example` still routes to that backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
