### PR TITLE
fix(mods): report the game version separately from the loader version

### DIFF
--- a/apps/MineOS.Api/Endpoints/ModEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/ModEndpoints.cs
@@ -663,7 +663,15 @@ public static class ModEndpoints
             try
             {
                 var result = await serverService.DetectLoaderAsync(name, cancellationToken);
-                return Results.Ok(new { loader = result.Loader, version = result.Version });
+                // minecraftVersion is additive: existing clients keep reading
+                // loader/version unchanged, and anything that needs the game
+                // version no longer has to infer it from the loader version.
+                return Results.Ok(new
+                {
+                    loader = result.Loader,
+                    version = result.Version,
+                    minecraftVersion = result.MinecraftVersion
+                });
             }
             catch (DirectoryNotFoundException ex)
             {
@@ -710,10 +718,15 @@ public static class ModEndpoints
     {
         try
         {
-            // Use the canonical detection from ServerService
+            // Use the canonical detection from ServerService.
+            //
+            // MinecraftVersion, not Version: the latter is the LOADER's version, and
+            // for Fabric/Quilt the two are unrelated. Filtering Modrinth by a loader
+            // version ("0.19.3") matched nothing, so mod search returned zero results
+            // on every Fabric server.
             var detected = await serverService.DetectLoaderAsync(serverName, cancellationToken);
             var loader = detected.Loader;
-            var version = detected.Version;
+            var version = detected.MinecraftVersion;
 
             // If we have a loader but no version, try to get it from the profile
             if (loader != null && version == null)

--- a/apps/MineOS.Application/Dtos/ServerDtos.cs
+++ b/apps/MineOS.Application/Dtos/ServerDtos.cs
@@ -1,6 +1,9 @@
 namespace MineOS.Application.Dtos;
 
-public record ServerLoaderDto(string? Loader, string? Version);
+// Version is the LOADER's version; MinecraftVersion is the game version. They are
+// the same thing for Paper-style jars and completely different for Fabric/Quilt,
+// where "fabric-server-mc.1.21.1-loader.0.19.3.jar" is game 1.21.1, loader 0.19.3.
+public record ServerLoaderDto(string? Loader, string? Version, string? MinecraftVersion = null);
 
 public record CronJobDto(string Hash, string Source, string Action, string? Msg, bool Enabled);
 

--- a/apps/MineOS.Infrastructure/Services/FabricForwardingMod.cs
+++ b/apps/MineOS.Infrastructure/Services/FabricForwardingMod.cs
@@ -44,32 +44,6 @@ internal static class FabricForwardingMod
     }
 
     /// <summary>
-    /// Pulls the Minecraft version out of a Fabric/Quilt server jar name, e.g.
-    /// "fabric-server-mc.1.21.1-loader.0.19.3.jar" -> "1.21.1".
-    ///
-    /// Needed because DetectLoaderAsync reports the *loader* version for these
-    /// servers (0.19.3), not the game version. Asking Modrinth for builds
-    /// supporting "Minecraft 0.19.3" matches nothing, so without this the install
-    /// refuses on every Fabric server it is offered.
-    /// </summary>
-    internal static string? TryParseMinecraftVersion(string? jarFile)
-    {
-        if (string.IsNullOrWhiteSpace(jarFile))
-        {
-            return null;
-        }
-
-        // "mc.1.21.1" / "mc1.21.1" is the marker Fabric and Quilt both use, and it
-        // is unambiguous — unlike the bare numbers elsewhere in the name.
-        var match = System.Text.RegularExpressions.Regex.Match(
-            jarFile,
-            @"mc\.?(?<mc>\d+\.\d+(?:\.\d+)?)",
-            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-
-        return match.Success ? match.Groups["mc"].Value : null;
-    }
-
-    /// <summary>
     /// Picks the newest release that suits this server, or null when none does.
     ///
     /// Returning null matters: installing a FabricProxy-Lite built for another

--- a/apps/MineOS.Infrastructure/Services/ProxyForwardingService.cs
+++ b/apps/MineOS.Infrastructure/Services/ProxyForwardingService.cs
@@ -257,17 +257,16 @@ public class ProxyForwardingService : IProxyForwardingService
     {
         try
         {
-            var config = await _serverService.GetServerConfigAsync(serverName, cancellationToken);
-
-            // The jar name is the reliable source here. DetectLoaderAsync's Version
-            // is the *loader* version for Fabric/Quilt (0.19.3), not the game
-            // version, and feeding that to Modrinth matches nothing.
-            var fromJar = FabricForwardingMod.TryParseMinecraftVersion(config.Java.JarFile);
-            if (!string.IsNullOrWhiteSpace(fromJar))
+            // DetectLoaderAsync now reports the game version separately from the
+            // loader version, so this uses the same source as the mods browser
+            // rather than parsing jar names a second time.
+            var detected = await _serverService.DetectLoaderAsync(serverName, cancellationToken);
+            if (!string.IsNullOrWhiteSpace(detected.MinecraftVersion))
             {
-                return fromJar;
+                return detected.MinecraftVersion;
             }
 
+            var config = await _serverService.GetServerConfigAsync(serverName, cancellationToken);
             if (!string.IsNullOrWhiteSpace(config.Minecraft.Profile))
             {
                 var profile = await _profileService.GetProfileAsync(config.Minecraft.Profile, cancellationToken);

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -2464,6 +2464,55 @@ public class ServerService : IServerService
         return match.Success ? match.Groups["v"].Value : null;
     }
 
+    /// <summary>
+    /// Extracts the Minecraft version a server jar targets.
+    ///
+    /// This is deliberately separate from <see cref="ExtractLoaderVersion"/>, which
+    /// reports the *loader's* version. For Fabric and Quilt the two differ
+    /// completely — "fabric-server-mc.1.21.1-loader.0.19.3.jar" is Minecraft 1.21.1
+    /// running loader 0.19.3 — and treating the loader version as the game version
+    /// made every Modrinth query filter on a game version that does not exist,
+    /// which returned zero mods for every Fabric server.
+    ///
+    /// Returns null when the jar name carries no usable version, so callers can
+    /// fall back to the configured profile rather than filtering on a wrong value.
+    /// </summary>
+    public static string? ParseMinecraftVersion(string? jarValue)
+    {
+        if (string.IsNullOrWhiteSpace(jarValue))
+        {
+            return null;
+        }
+
+        // Fabric and Quilt tag the game version explicitly, which is unambiguous.
+        var mcTagged = System.Text.RegularExpressions.Regex.Match(
+            jarValue, @"mc\.?(?<mc>\d+\.\d+(?:\.\d+)?)",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        if (mcTagged.Success)
+        {
+            return mcTagged.Groups["mc"].Value;
+        }
+
+        // NeoForge names carry no Minecraft version at all: its own version encodes
+        // it, so 21.1.227 means Minecraft 1.21.1 and 21.0.x means 1.21.
+        var neoforge = System.Text.RegularExpressions.Regex.Match(
+            jarValue, @"neoforge[-/\\](?<major>\d+)\.(?<minor>\d+)\.\d+",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        if (neoforge.Success)
+        {
+            var major = neoforge.Groups["major"].Value;
+            var minor = neoforge.Groups["minor"].Value;
+            return minor == "0" ? $"1.{major}" : $"1.{major}.{minor}";
+        }
+
+        // Everything else (paper-1.21.11-132.jar, forge-1.20.1-47.2.0.jar,
+        // minecraft_server.1.20.1.jar) carries a literal 1.x[.y]; the leftmost
+        // match is the game version, later numbers are build or loader versions.
+        var literal = System.Text.RegularExpressions.Regex.Match(
+            jarValue, @"(?:^|[-_./\\])(?<mc>1\.\d+(?:\.\d+)?)(?:[-_./\\]|$)");
+        return literal.Success ? literal.Groups["mc"].Value : null;
+    }
+
     public async Task<ServerLoaderDto> DetectLoaderAsync(string name, CancellationToken cancellationToken)
     {
         var serverPath = GetServerPath(name);
@@ -2487,15 +2536,15 @@ public class ServerService : IServerService
             // "forge", and NeoForge also uses the @argfile syntax — so an ordering/@-based
             // check would otherwise mislabel NeoForge servers as Forge.
             if (jarLower.Contains("neoforge") || jarLower.Contains("neoforged"))
-                return new ServerLoaderDto("neoforge", ExtractLoaderVersion("neoforge", jarFile));
+                return new ServerLoaderDto("neoforge", ExtractLoaderVersion("neoforge", jarFile), ParseMinecraftVersion(jarFile));
             if (jarLower.Contains("minecraftforge") || jarLower.Contains("forge"))
-                return new ServerLoaderDto("forge", ExtractLoaderVersion("forge", jarFile));
-            if (jarLower.Contains("fabric")) return new ServerLoaderDto("fabric", ExtractLoaderVersion("fabric", jarFile));
-            if (jarLower.Contains("quilt")) return new ServerLoaderDto("quilt", ExtractLoaderVersion("quilt", jarFile));
-            if (jarLower.Contains("paper")) return new ServerLoaderDto("paper", null);
-            if (jarLower.Contains("spigot")) return new ServerLoaderDto("spigot", null);
-            if (jarLower.Contains("purpur")) return new ServerLoaderDto("purpur", null);
-            if (jarLower.Contains("bukkit")) return new ServerLoaderDto("bukkit", null);
+                return new ServerLoaderDto("forge", ExtractLoaderVersion("forge", jarFile), ParseMinecraftVersion(jarFile));
+            if (jarLower.Contains("fabric")) return new ServerLoaderDto("fabric", ExtractLoaderVersion("fabric", jarFile), ParseMinecraftVersion(jarFile));
+            if (jarLower.Contains("quilt")) return new ServerLoaderDto("quilt", ExtractLoaderVersion("quilt", jarFile), ParseMinecraftVersion(jarFile));
+            if (jarLower.Contains("paper")) return new ServerLoaderDto("paper", null, ParseMinecraftVersion(jarFile));
+            if (jarLower.Contains("spigot")) return new ServerLoaderDto("spigot", null, ParseMinecraftVersion(jarFile));
+            if (jarLower.Contains("purpur")) return new ServerLoaderDto("purpur", null, ParseMinecraftVersion(jarFile));
+            if (jarLower.Contains("bukkit")) return new ServerLoaderDto("bukkit", null, ParseMinecraftVersion(jarFile));
         }
 
         // Priority 3: bare @argfile with no loader hint in the path — legacy Forge modpacks

--- a/apps/MineOS.Tests/Unit/FabricForwardingModTests.cs
+++ b/apps/MineOS.Tests/Unit/FabricForwardingModTests.cs
@@ -33,29 +33,6 @@ public class FabricForwardingModTests
         Assert.False(FabricForwardingMod.IsForwardingModJar("FabricProxy-Lite-0.9.0.jar.disabled"));
     }
 
-    [Theory]
-    [InlineData("fabric-server-mc.1.21.1-loader.0.19.3.jar", "1.21.1")]
-    [InlineData("fabric-server-mc.1.20-loader.0.15.0.jar", "1.20")]
-    [InlineData("quilt-server-mc.1.21.4-loader.0.26.0.jar", "1.21.4")]
-    [InlineData("server.jar", null)]
-    [InlineData("", null)]
-    [InlineData(null, null)]
-    public void The_Minecraft_Version_Comes_From_The_Jar_Name(string? jar, string? expected)
-    {
-        // Regression test for a bug found running this against a real Fabric
-        // install: DetectLoaderAsync reports the LOADER version for Fabric
-        // (0.19.3), so using it as the game version asked Modrinth for builds
-        // supporting "Minecraft 0.19.3" and the install refused every time.
-        Assert.Equal(expected, FabricForwardingMod.TryParseMinecraftVersion(jar));
-    }
-
-    [Fact]
-    public void The_Loader_Version_Is_Never_Mistaken_For_The_Game_Version()
-    {
-        Assert.Equal("1.21.1",
-            FabricForwardingMod.TryParseMinecraftVersion("fabric-server-mc.1.21.1-loader.0.19.3.jar"));
-    }
-
     private static ModrinthVersionDto Version(
         string id, string number, string published, string[] gameVersions, string[] loaders,
         ModrinthVersionFileDto[]? files = null, ModrinthDependencyDto[]? dependencies = null) =>

--- a/apps/MineOS.Tests/Unit/MinecraftVersionParsingTests.cs
+++ b/apps/MineOS.Tests/Unit/MinecraftVersionParsingTests.cs
@@ -1,0 +1,61 @@
+using MineOS.Infrastructure.Services;
+
+namespace MineOS.Tests.Unit;
+
+/// <summary>
+/// Covers ServerService.ParseMinecraftVersion, which answers "which Minecraft
+/// version does this server run?" from the configured jar value.
+///
+/// This exists because the answer was previously taken from the loader version,
+/// which for Fabric and Quilt is an entirely different number. Every Modrinth
+/// query for a Fabric server filtered on a game version that does not exist, so
+/// mod search returned nothing at all.
+/// </summary>
+public class MinecraftVersionParsingTests
+{
+    [Theory]
+    // Fabric and Quilt tag the game version; the trailing number is the loader.
+    [InlineData("fabric-server-mc.1.21.1-loader.0.19.3.jar", "1.21.1")]
+    [InlineData("fabric-server-mc.1.20-loader.0.15.0.jar", "1.20")]
+    [InlineData("quilt-server-mc.1.21.4-loader.0.26.0.jar", "1.21.4")]
+    // Server jars that carry the version literally; later numbers are build ids.
+    [InlineData("paper-1.21.11-132.jar", "1.21.11")]
+    [InlineData("purpur-1.20.4-2147.jar", "1.20.4")]
+    [InlineData("spigot-1.20.1.jar", "1.20.1")]
+    [InlineData("minecraft_server.1.20.1.jar", "1.20.1")]
+    // Classic Forge puts the game version first, its own second.
+    [InlineData("forge-1.20.1-47.2.0.jar", "1.20.1")]
+    // Nothing usable: better to return null and let the caller fall back to the
+    // configured profile than to filter on a wrong value.
+    [InlineData("server.jar", null)]
+    [InlineData("custom-build.jar", null)]
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    public void The_Game_Version_Is_Read_From_The_Jar_Value(string? jar, string? expected)
+    {
+        Assert.Equal(expected, ServerService.ParseMinecraftVersion(jar));
+    }
+
+    [Theory]
+    // NeoForge names carry no Minecraft version: its own encodes it, so 21.1.227
+    // is Minecraft 1.21.1 and a zero minor means the .0 release (21.0.x -> 1.21).
+    [InlineData("neoforge-21.1.227.jar", "1.21.1")]
+    [InlineData("neoforge-20.4.190.jar", "1.20.4")]
+    [InlineData("neoforge-21.0.100.jar", "1.21")]
+    [InlineData("@libraries/net/neoforged/neoforge/21.1.227/unix_args.txt", "1.21.1")]
+    public void NeoForge_Versions_Are_Translated_To_Their_Minecraft_Version(string jar, string expected)
+    {
+        Assert.Equal(expected, ServerService.ParseMinecraftVersion(jar));
+    }
+
+    [Fact]
+    public void The_Loader_Version_Is_Never_Returned_As_The_Game_Version()
+    {
+        // The specific regression: 0.19.3 is the Fabric loader, not a Minecraft
+        // version, and Modrinth has no mods for it.
+        var parsed = ServerService.ParseMinecraftVersion("fabric-server-mc.1.21.1-loader.0.19.3.jar");
+
+        Assert.Equal("1.21.1", parsed);
+        Assert.NotEqual("0.19.3", parsed);
+    }
+}


### PR DESCRIPTION
Fixes #167. Found while building #166 — the Fabric forwarding work hit the same root cause, and it turned out to break something much more visible.

## The bug

Mod search returned **zero results on every Fabric/Quilt server**.

`ModEndpoints.ResolveServerDefaultsAsync` used `ServerLoaderDto.Version` as the Minecraft version, but `DetectLoaderAsync` fills that field with `ExtractLoaderVersion(...)` — the *loader's* version. For Fabric the two are unrelated:

```
fabric-server-mc.1.21.1-loader.0.19.3.jar
                  ^ game version   ^ loader version
```

So Modrinth was queried with `game_versions=["0.19.3"]`, which matches nothing. No error, no empty-state explanation — just an empty list.

Paper is affected the other way: `DetectLoaderAsync` returns `null` for it, so search falls back to **unfiltered** results and offers mods for the wrong Minecraft version unless a profile happens to be configured.

## The fix

`ServerLoaderDto` gains `MinecraftVersion` (additive, defaults to `null`), derived by a new `ServerService.ParseMinecraftVersion` from the configured jar value:

| Jar | Game version |
|---|---|
| `fabric-server-mc.1.21.1-loader.0.19.3.jar` | `1.21.1` |
| `paper-1.21.11-132.jar` | `1.21.11` |
| `forge-1.20.1-47.2.0.jar` | `1.20.1` |
| `neoforge-21.1.227.jar` | `1.21.1` |
| `server.jar` | `null` → caller falls back to the profile |

NeoForge needs the translation because its names carry no Minecraft version at all — its own version encodes it, and a zero minor means the `.0` release (`21.0.x` → `1.21`).

`Version` keeps meaning the loader version, which is what the UI version chips display, so nothing visible changes there.

This also **removes the duplicate parser** introduced with the forwarding work in #166 — one implementation instead of two that can drift apart.

`GET /servers/{name}/loader` now also returns `minecraftVersion`. Existing clients read `loader`/`version` unchanged.

## Testing

| | `vibing` | this branch |
|---|---|---|
| `dotnet test` | 135 passed, 0 failed | **145 passed, 0 failed** |

Verified against a real Fabric 1.21.1 server in Docker:

```
GET .../mods/modrinth/search?query=sodium
before: {"totalHits": 0}
after:  {"totalHits": 43}
```

The new tests cover each jar shape, the NeoForge translation including the zero-minor case, and the specific regression that `0.19.3` must never be returned as a game version.

## Not covered here

`ResolveServerDefaultsAsync`'s profile fallback is untouched, and #21 (dependency resolution for single-mod installs) remains open — #166 only resolves dependencies for the forwarding mod, not for user-initiated installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
