### PR TITLE
chore(deps): bump Microsoft.OpenApi to 2.12.2 (GHSA-v5pm-xwqc-g5wc)

### DIFF
--- a/apps/MineOS.Api/MineOS.Api.csproj
+++ b/apps/MineOS.Api/MineOS.Api.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.OpenApi" Version="2.3.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.12.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />


### PR DESCRIPTION
`Microsoft.OpenApi` was pinned at **2.3.0**, inside the vulnerable range of [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) (`>= 2.0.0-preview.11, <= 2.7.4`) — circular schema references can terminate OpenAPI parsing. Rated **high**, and `NU1903` surfaced on every build of `MineOS.Api`.

Bumped to **2.12.2**, the current 2.x release.

**Why not 3.x:** the advisory is patched from 2.7.5, and Swashbuckle 10.1.0 already resolves against the 2.x line. Staying on 2.x clears the advisory without a major-version migration to evaluate. The 3.x line has its own patched floor (3.5.4) if you want to move later.

## Verification

| | before | after |
|---|---|---|
| `NU1903` occurrences | 2 | **0** |
| `dotnet test` | 145 passed, 0 failed | 145 passed, 0 failed |

The two `CS8619` nullability warnings in `ServerEndpoints` are pre-existing and unchanged by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)