### PR TITLE
feat(mods): resolve dependencies when installing a single mod (#21)

### DIFF
--- a/.claude/skills/local-lab/SKILL.md
+++ b/.claude/skills/local-lab/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: mineos-local-lab
+description: Use when testing mineos-sveltekit changes for real — standing up a throwaway MineOS in Docker, running the .NET suite without a local SDK, creating proxy/backend/Fabric servers, or verifying Minecraft behaviour (routing, forwarding security, mod installs) end to end.
+---
+
+# The local lab
+
+## Overview
+
+The lab is a throwaway MineOS stack in Docker with real Minecraft servers behind it. It exists because **this repo's most important behaviour is invisible to unit tests**: whether a hostname routes to the right backend, whether a secured backend actually refuses a spoofed login, whether a mod install produces a server that still boots.
+
+Every one of those has shipped broken at least once with a green test suite. The lab is how you catch that before a user does.
+
+## The Iron Rules
+
+1. **Never `docker compose down` without `-p mclab`.** The repo's own dev containers are named `mineos-api` / `mineos-web`. The lab uses `mclab-api` / `mclab-web` precisely so the two cannot collide — keep it that way, and never remove a container you did not create.
+2. **A green suite is not a working feature.** Enum serialization, loader-version confusion, and missing mod dependencies all passed every test and failed instantly against a real server. If a change touches the wire format, the Minecraft protocol, or an external API, run it here.
+3. **Rebuilding `api` kills every running Minecraft server.** They are `screen` sessions inside that container. After `--build`, restart the servers you need.
+4. **Wait for the rebuild before testing it.** `docker compose up -d --build` leaves the *old* container serving requests while the new image builds. Poll until the container's `StartedAt` moves, or you will test the code you just replaced. This has produced at least one "the fix didn't work" false alarm.
+5. **Lab settings are not production settings.** The proxy runs `online-mode=false` so a probe can log in without a Mojang account. On a real deployment that must be `true` — the forwarding secret protects backends, not the proxy's online-mode.
+
+## Running the .NET tests without a local SDK
+
+CI does not run the xUnit suite and you may not have `dotnet` installed. Run it in a container:
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" \
+  -v "$PWD:/src" -v "$HOME/.nuget-lab:/nuget" -w /src \
+  -e HOME=/tmp -e NUGET_PACKAGES=/nuget \
+  -e DOTNET_CLI_TELEMETRY_OPTOUT=1 -e DOTNET_NOLOGO=1 \
+  mcr.microsoft.com/dotnet/sdk:8.0 \
+  dotnet test apps/MineOS.Tests/MineOS.Tests.csproj
+```
+
+`--user` matters: without it the build writes root-owned `obj/`/`bin/` into your worktree. The `NUGET_PACKAGES` mount keeps restores fast across runs.
+
+**The suite should be 0 failures.** If you see integration tests failing on `/var/games`, you are on a commit older than the fix that isolated them to a temp root — rebase.
+
+## Standing up the lab
+
+Work from a git worktree so the lab never disturbs your checkout.
+
+```bash
+LAB=/tmp/mclab && mkdir -p "$LAB/minecraft" "$LAB/data"
+cat > "$LAB/.env" <<EOF
+ConnectionStrings__DefaultConnection=Data Source=/app/data/mineos.db
+Auth__SeedUsername=admin
+Auth__SeedPassword=admin123!
+Auth__JwtSecret=local-lab-jwt-secret-key-at-least-32-characters-long
+ApiKey__SeedKey=local-lab-api-key-0123456789
+HOST_BASE_DIRECTORY=$LAB/minecraft
+Data__Directory=$LAB/data
+Host__BaseDirectory=/var/games/minecraft
+Host__OwnerUid=1000
+Host__OwnerGid=1000
+API_PORT=5378
+WEB_PORT=3300
+MC_PORT_RANGE=25565-25570
+ORIGIN=http://localhost:3300
+MINEOS_TELEMETRY_ENABLED=false
+EOF
+
+cat > "$LAB/override.yml" <<'EOF'
+services:
+  api:
+    container_name: mclab-api
+  web:
+    container_name: mclab-web
+networks:
+  default:
+    name: mclab-network
+EOF
+
+docker compose --env-file "$LAB/.env" -p mclab \
+  -f docker-compose.yml -f docker-compose.build.yml -f "$LAB/override.yml" \
+  up -d --build
+```
+
+Ports are deliberately off the defaults (`3300`, `5378`) because a dev instance often holds `3000`/`5078`. `HOST_BASE_DIRECTORY` and `Data__Directory` are absolute so compose can run from the repo while state lives outside it.
+
+Web UI: `http://localhost:3300` — `admin` / `admin123!`.
+API: `http://localhost:5378/api/v1`, header `X-Api-Key: local-lab-api-key-0123456789`.
+
+**The API base path is `/api/v1`, and server listing is `GET /api/v1/host/servers`** (`/api/v1/servers` is POST-only). `GET /swagger/v1/swagger.json` is the fastest way to find a route.
+
+## Building a proxy topology
+
+Create backends **before** the proxy: proxy creation pre-populates its backend list from sibling Java servers.
+
+```bash
+K=local-lab-api-key-0123456789; B=http://localhost:5378/api/v1
+for s in alpha beta; do
+  curl -s -X POST -H "X-Api-Key: $K" -H 'Content-Type: application/json' \
+    -d "{\"name\":\"$s\",\"ownerUid\":1000,\"ownerGid\":1000,\"serverType\":\"java\"}" "$B/servers"
+done
+curl -s -X POST -H "X-Api-Key: $K" -H 'Content-Type: application/json' \
+  -d '{"name":"hub","ownerUid":1000,"ownerGid":1000,"serverType":"proxy","proxyKind":"velocity"}' "$B/servers"
+```
+
+Then, per server: download a profile, copy it in, accept the EULA, and trim memory.
+
+```bash
+curl -s -X POST -H "X-Api-Key: $K" "$B/profiles/paper-1.21.11/download"
+curl -s -X POST -H "X-Api-Key: $K" -H 'Content-Type: application/json' \
+  -d '{"serverName":"alpha"}' "$B/profiles/paper-1.21.11/copy-to-server"
+curl -s -X POST -H "X-Api-Key: $K" -H 'Content-Type: application/json' \
+  -d '{"accepted":true}' "$B/servers/alpha/eula"
+```
+
+Speed and memory matter — three JVMs on a laptop:
+
+- `javaXmx` **1024** for backends, **512** for the proxy (the default is 4096 each).
+- `level-type` `minecraft\:flat`, `view-distance` `4` — a flat world starts in seconds.
+- Give each backend a distinct `motd` (`MOTD-alpha`). **That is how you prove routing**, since a status ping reports the backend's MOTD.
+
+Fabric is not a profile. It has its own installer, and **`loaderVersion` is required** despite being nullable:
+
+```bash
+curl -s "$B/fabric/loader-versions" -H "X-Api-Key: $K"     # pick a stable one
+curl -s -X POST -H "X-Api-Key: $K" -H 'Content-Type: application/json' \
+  -d '{"minecraftVersion":"1.21.1","loaderVersion":"0.19.3","serverName":"gamma"}' "$B/fabric/install"
+```
+
+For routing tests, set the proxy's `pingPassthrough` to `ALL` — otherwise Velocity answers pings itself and every hostname looks identical.
+
+## Probing Minecraft without a game client
+
+`mcprobe.py` (next to this file) speaks enough of the protocol to answer the two questions that matter. The handshake carries the address the player typed, which is what `forced-hosts` routes on.
+
+```bash
+python3 mcprobe.py status 127.0.0.1 25565 alpha.example    # which backend answers?
+python3 mcprobe.py login  127.0.0.1 25566 alpha.example    # will it let me in?
+```
+
+**Three traps, all of which have produced wrong conclusions:**
+
+1. **The protocol version must match the server**, or you get `"Outdated client!"` and learn nothing about security. Read the real number from a status ping first (`version.protocol`) and pass it — do not hardcode.
+2. **Packet `0x03` is Set Compression, not acceptance.** After it the stream is compressed and the probe goes blind, so a rejection can look like a successful login. Set `network-compression-threshold=-1` on the server under test, and corroborate with its log: a real join logs the player, a refusal logs `lost connection`.
+3. **A connection reset usually means the server is still starting**, not that it refused you. Wait for `Done (` in `logs/latest.log`.
+
+## Verifying forwarding security
+
+The claim worth proving is that a *secured* backend refuses anyone who is not the proxy.
+
+```
+# Secured backend, direct connection:
+{"outcome": "REJECTED", "challenged_on": "velocity:player_info",
+ "message": "This server requires you to connect with Velocity."}
+
+# Unsecured backend with online-mode=false, direct connection:
+{"outcome": "ACCEPTED", "challenged_on": null}     # joined as any username
+```
+
+`challenged_on: velocity:player_info` is the signal: the backend demanded cryptographic proof of proxy identity. Its absence means nothing was verified.
+
+To reproduce the dangerous state deliberately: set a backend's `online-mode=false` **without** securing it, restart, and log in as any name. Turn `white-list` off first, or an unrelated whitelist will mask the result.
+
+## Teardown
+
+```bash
+docker compose -p mclab down
+rm -rf /tmp/mclab
+```
+
+Removing the state directory matters: worlds and jars add up to hundreds of megabytes.

--- a/.claude/skills/local-lab/mcprobe.py
+++ b/.claude/skills/local-lab/mcprobe.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+Minimal Minecraft Java protocol probe for the local lab.
+
+Answers two questions that no unit test can, without needing a game client:
+
+1. **Where does a hostname go?** The handshake packet carries the address the
+   player typed, which is exactly what Velocity's forced-hosts routes on. With
+   `ping-passthrough = "ALL"` the status reply comes from the chosen backend, so
+   its MOTD tells you which one you reached.
+
+2. **Is a secured backend really closed?** Status pings are never blocked, so
+   this needs a login attempt. A backend running Velocity modern forwarding
+   challenges every connection on the `velocity:player_info` channel; anything
+   that is not the proxy cannot answer, and gets refused.
+
+Usage:
+    python3 mcprobe.py status <host> <port> <hostname-to-claim> [protocol]
+    python3 mcprobe.py login  <host> <port> <hostname-to-claim> [protocol] [username]
+
+Read the protocol number from a status ping (`version.protocol`) and pass it to
+`login` — a mismatch is rejected as "Outdated client!" before the server ever
+reaches the forwarding check, which looks like a security result and is not one.
+"""
+import json
+import socket
+import struct
+import sys
+import uuid
+
+DEFAULT_PROTOCOL = 767  # 1.21.1; override per server.
+
+
+# ---- encoding ------------------------------------------------------------
+
+def write_varint(value: int) -> bytes:
+    out = b""
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        out += struct.pack("B", byte | (0x80 if value else 0))
+        if not value:
+            return out
+
+
+def write_string(text: str) -> bytes:
+    raw = text.encode("utf-8")
+    return write_varint(len(raw)) + raw
+
+
+def packet(packet_id: int, payload: bytes) -> bytes:
+    body = write_varint(packet_id) + payload
+    return write_varint(len(body)) + body
+
+
+def handshake(server_address: str, port: int, protocol: int, next_state: int) -> bytes:
+    """next_state: 1 = status, 2 = login."""
+    return packet(
+        0x00,
+        write_varint(protocol)
+        + write_string(server_address)   # the routing key — what the player "typed"
+        + struct.pack(">H", port)
+        + write_varint(next_state),
+    )
+
+
+# ---- decoding ------------------------------------------------------------
+
+class Reader:
+    def __init__(self, sock: socket.socket):
+        self.sock = sock
+
+    def byte(self) -> int:
+        chunk = self.sock.recv(1)
+        if not chunk:
+            raise EOFError("connection closed by peer")
+        return chunk[0]
+
+    def varint(self) -> int:
+        result = 0
+        for shift in range(0, 35, 7):
+            current = self.byte()
+            result |= (current & 0x7F) << shift
+            if not current & 0x80:
+                return result
+        raise ValueError("varint too long")
+
+    def exact(self, count: int) -> bytes:
+        buf = b""
+        while len(buf) < count:
+            chunk = self.sock.recv(count - len(buf))
+            if not chunk:
+                raise EOFError("connection closed mid-packet")
+            buf += chunk
+        return buf
+
+
+def read_varint_from(buf: bytes, offset: int):
+    result = 0
+    for shift in range(0, 35, 7):
+        current = buf[offset]
+        offset += 1
+        result |= (current & 0x7F) << shift
+        if not current & 0x80:
+            return result, offset
+    raise ValueError("varint too long")
+
+
+def read_packet(reader: Reader):
+    """Reads one whole packet as (id, payload). Buffering the entire body is what
+    keeps the stream in sync across a multi-packet login exchange."""
+    length = reader.varint()
+    body = reader.exact(length)
+    packet_id, offset = read_varint_from(body, 0)
+    return packet_id, body[offset:]
+
+
+# ---- probes --------------------------------------------------------------
+
+def status(host: str, port: int, claimed_hostname: str,
+           protocol: int = DEFAULT_PROTOCOL, timeout: float = 10.0) -> dict:
+    """Server list ping. Returns the parsed status JSON."""
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.settimeout(timeout)
+        sock.sendall(handshake(claimed_hostname, port, protocol, 1))
+        sock.sendall(packet(0x00, b""))
+
+        reader = Reader(sock)
+        packet_id, payload = read_packet(reader)
+        if packet_id != 0x00:
+            raise ValueError(f"unexpected status packet id 0x{packet_id:02x}")
+        length, offset = read_varint_from(payload, 0)
+        return json.loads(payload[offset:offset + length].decode("utf-8"))
+
+
+def login(host: str, port: int, claimed_hostname: str, username: str = "ProbeBot",
+          protocol: int = DEFAULT_PROTOCOL, timeout: float = 10.0) -> dict:
+    """
+    Attempt a login, answering any Login Plugin Request the way a non-proxy must.
+
+    Outcomes:
+      REJECTED              - refused; `challenged_on` names the channel it demanded
+      ACCEPTED              - let in (with challenged_on null, nothing was verified)
+      encryption-requested  - the server authenticates players itself (online-mode=true)
+
+    Caveat: packet 0x03 is Set Compression. After it the stream is compressed and
+    this probe cannot read further, so an ACCEPTED here may be premature — set
+    `network-compression-threshold=-1` on the server and check its log.
+    """
+    with socket.create_connection((host, port), timeout=timeout) as sock:
+        sock.settimeout(timeout)
+        sock.sendall(handshake(claimed_hostname, port, protocol, 2))
+        sock.sendall(packet(0x00, write_string(username) + uuid.uuid4().bytes))
+
+        reader = Reader(sock)
+        challenged = None
+
+        for _ in range(6):
+            try:
+                packet_id, payload = read_packet(reader)
+            except (EOFError, IndexError):
+                return {"outcome": "closed", "challenged_on": challenged,
+                        "message": "server closed the connection"}
+
+            if packet_id == 0x04:                        # Login Plugin Request
+                message_id, offset = read_varint_from(payload, 0)
+                channel_len, offset = read_varint_from(payload, offset)
+                challenged = payload[offset:offset + channel_len].decode("utf-8", errors="replace")
+                # "cannot answer" — the only honest reply from a non-proxy.
+                sock.sendall(packet(0x02, write_varint(message_id) + b"\x00"))
+                continue
+            if packet_id == 0x00:                        # Disconnect
+                length, offset = read_varint_from(payload, 0)
+                return {"outcome": "REJECTED", "challenged_on": challenged,
+                        "message": payload[offset:offset + length].decode("utf-8", errors="replace")}
+            if packet_id == 0x01:                        # Encryption Request
+                return {"outcome": "encryption-requested", "challenged_on": challenged,
+                        "message": "server authenticates players itself (online-mode=true)"}
+            if packet_id in (0x02, 0x03):
+                return {"outcome": "ACCEPTED", "challenged_on": challenged,
+                        "message": f"server let us in (packet 0x{packet_id:02x})"}
+
+        return {"outcome": "gave-up", "challenged_on": challenged, "message": "too many packets"}
+
+
+def _motd(status_json: dict) -> str:
+    description = status_json.get("description", "")
+    if isinstance(description, dict):
+        text = description.get("text", "")
+        for extra in description.get("extra", []) or []:
+            if isinstance(extra, dict):
+                text += extra.get("text", "")
+        return text or json.dumps(description)
+    return str(description)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 5:
+        raise SystemExit(__doc__)
+
+    mode, host, port, claimed = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
+    protocol = int(sys.argv[5]) if len(sys.argv) > 5 else DEFAULT_PROTOCOL
+
+    if mode == "status":
+        result = status(host, port, claimed, protocol)
+        print(json.dumps({
+            "motd": _motd(result),
+            "version": result.get("version", {}).get("name"),
+            "protocol": result.get("version", {}).get("protocol"),
+            "players": result.get("players", {}).get("online"),
+        }, indent=2))
+    elif mode == "login":
+        username = sys.argv[6] if len(sys.argv) > 6 else "ProbeBot"
+        print(json.dumps(login(host, port, claimed, username, protocol), indent=2))
+    else:
+        raise SystemExit(__doc__)

--- a/apps/MineOS.Api/Endpoints/ModEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/ModEndpoints.cs
@@ -520,8 +520,7 @@ public static class ModEndpoints
         modrinth.MapPost("/install", async (
             string name,
             [FromBody] ModrinthInstallRequest request,
-            IModrinthService modrinthService,
-            IModService modService,
+            IModDependencyService dependencyService,
             CancellationToken cancellationToken) =>
         {
             if (string.IsNullOrWhiteSpace(request.VersionId))
@@ -529,21 +528,63 @@ public static class ModEndpoints
                 return Results.BadRequest(new { error = "VersionId is required" });
             }
 
-            var version = await modrinthService.GetVersionAsync(request.VersionId, cancellationToken);
-            if (version == null)
+            try
             {
-                return Results.NotFound(new { error = "Version not found" });
+                // Installs hard dependencies alongside the mod. A mod whose
+                // required dependency is missing does not warn at startup —
+                // Fabric aborts the boot — so installing the jar alone was
+                // reliably breaking servers.
+                var result = await dependencyService.InstallWithDependenciesAsync(
+                    name,
+                    request.VersionId,
+                    request.OptionalProjectIds ?? Array.Empty<string>(),
+                    cancellationToken);
+
+                var installed = string.Join(", ", result.InstalledFiles);
+                return Results.Ok(new
+                {
+                    message = result.InstalledFiles.Count == 1
+                        ? $"Installed mod '{installed}'"
+                        : $"Installed {result.InstalledFiles.Count} files: {installed}",
+                    installedFiles = result.InstalledFiles,
+                    skippedAlreadyInstalled = result.SkippedAlreadyInstalled
+                });
+            }
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Unresolvable hard dependency: nothing was written, and the
+                // message names what could not be satisfied.
+                return Results.Conflict(new { error = ex.Message });
+            }
+        });
+
+        modrinth.MapGet("/install/plan", async (
+            string name,
+            [FromQuery] string versionId,
+            IModDependencyService dependencyService,
+            CancellationToken cancellationToken) =>
+        {
+            if (string.IsNullOrWhiteSpace(versionId))
+            {
+                return Results.BadRequest(new { error = "versionId is required" });
             }
 
-            var file = version.Files.FirstOrDefault(f => f.Primary) ?? version.Files.FirstOrDefault();
-            if (file == null)
+            try
             {
-                return Results.BadRequest(new { error = "No files available for this version" });
+                return Results.Ok(await dependencyService.PlanInstallAsync(name, versionId, cancellationToken));
             }
-
-            await using var stream = await modrinthService.OpenDownloadStreamAsync(file.Url, cancellationToken);
-            await modService.SaveModAsync(name, file.FileName, stream, cancellationToken);
-            return Results.Ok(new { message = $"Installed mod '{file.FileName}'" });
+            catch (DirectoryNotFoundException ex)
+            {
+                return Results.NotFound(new { error = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.Conflict(new { error = ex.Message });
+            }
         });
 
         var modrinthModpacks = servers.MapGroup("/{name}/mods/modrinth/modpacks");

--- a/apps/MineOS.Api/Endpoints/PluginEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/PluginEndpoints.cs
@@ -320,4 +320,7 @@ public static class PluginEndpoints
     }
 }
 
-public record ModrinthInstallRequest(string VersionId);
+// OptionalProjectIds is additive and only read by the mod install route: callers
+// that send just a version id keep working, and get hard dependencies resolved
+// for them. Plugins and resource packs share this record and ignore the field.
+public record ModrinthInstallRequest(string VersionId, IReadOnlyList<string>? OptionalProjectIds = null);

--- a/apps/MineOS.Api/Program.cs
+++ b/apps/MineOS.Api/Program.cs
@@ -182,6 +182,7 @@ builder.Services.AddSingleton<TelemetryReporterService>();
 builder.Services.AddSingleton<ITelemetryReportTrigger>(sp => sp.GetRequiredService<TelemetryReporterService>());
 builder.Services.AddHostedService(sp => sp.GetRequiredService<TelemetryReporterService>());
 builder.Services.AddHostedService<ApplicationLifetimeService>();
+builder.Services.AddScoped<IModDependencyService, ModDependencyService>();
 builder.Services.AddSingleton<IContainerPortInspector, DockerPortInspector>();
 builder.Services.AddScoped<IProxyForwardingService, ProxyForwardingService>();
 builder.Services.AddSingleton<WatchdogService>();

--- a/apps/MineOS.Application/Dtos/ModDependencyDtos.cs
+++ b/apps/MineOS.Application/Dtos/ModDependencyDtos.cs
@@ -1,0 +1,38 @@
+namespace MineOS.Application.Dtos;
+
+/// <summary>
+/// What installing a mod would actually do, worked out before anything is written.
+///
+/// The plan exists so the user sees the whole set first: a single "install" click
+/// can pull in several mods, and a server that starts missing a hard dependency
+/// does not warn — it fails to boot.
+/// </summary>
+public record ModInstallPlanDto(
+    string VersionId,
+    string ProjectId,
+    string Name,
+    string FileName,
+    // Hard dependencies that will be installed alongside it, in install order.
+    IReadOnlyList<ModDependencyItemDto> Required,
+    // Offered, not installed, unless the caller names them explicitly.
+    IReadOnlyList<ModDependencyItemDto> Optional,
+    // Dependencies this server already has. Listed so the plan explains itself
+    // rather than silently showing a shorter list than the mod's page implies.
+    IReadOnlyList<ModDependencyItemDto> AlreadyInstalled,
+    // Dependencies that could not be resolved for this loader/Minecraft version.
+    // Non-empty means installing would leave the server unable to start, so the
+    // install refuses rather than proceeding part-way.
+    IReadOnlyList<string> Problems);
+
+public record ModDependencyItemDto(
+    string ProjectId,
+    string? VersionId,
+    string Name,
+    string? FileName,
+    // "required" or "optional", as Modrinth reports it.
+    string DependencyType);
+
+/// <summary>What an install actually wrote.</summary>
+public record ModInstallResultDto(
+    IReadOnlyList<string> InstalledFiles,
+    IReadOnlyList<string> SkippedAlreadyInstalled);

--- a/apps/MineOS.Application/Interfaces/IModDependencyService.cs
+++ b/apps/MineOS.Application/Interfaces/IModDependencyService.cs
@@ -1,0 +1,29 @@
+using MineOS.Application.Dtos;
+
+namespace MineOS.Application.Interfaces;
+
+public interface IModDependencyService
+{
+    /// <summary>
+    /// Works out everything installing a Modrinth version would pull in, without
+    /// writing anything: hard dependencies (including dependencies of
+    /// dependencies), optional ones to offer, and which are already present.
+    /// </summary>
+    Task<ModInstallPlanDto> PlanInstallAsync(
+        string serverName, string versionId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Installs a mod together with its hard dependencies, plus any optional
+    /// dependencies named in <paramref name="approvedOptionalProjectIds"/>.
+    ///
+    /// Refuses when a hard dependency cannot be resolved for this server's loader
+    /// and Minecraft version. Installing part of the set would leave a server that
+    /// does not start — for Fabric, a missing required dependency aborts boot
+    /// outright — so nothing is written in that case.
+    /// </summary>
+    Task<ModInstallResultDto> InstallWithDependenciesAsync(
+        string serverName,
+        string versionId,
+        IReadOnlyList<string> approvedOptionalProjectIds,
+        CancellationToken cancellationToken);
+}

--- a/apps/MineOS.Application/Interfaces/IModrinthService.cs
+++ b/apps/MineOS.Application/Interfaces/IModrinthService.cs
@@ -50,5 +50,17 @@ public interface IModrinthService
     Task<ModrinthVersionDto?> GetVersionAsync(string versionId, CancellationToken cancellationToken);
     Task<ModrinthVersionDto?> GetVersionByFileHashAsync(string hash, string algorithm, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Identifies many local files at once. Used to work out which mods a server
+    /// already has: hashing the jars and asking Modrinth in one call is the only
+    /// reliable way, since a file's name says nothing about which project it is.
+    ///
+    /// Returns only the hashes Modrinth recognises; unknown files are simply absent.
+    /// </summary>
+    Task<IReadOnlyDictionary<string, ModrinthVersionDto>> GetVersionsByFileHashesAsync(
+        IReadOnlyList<string> hashes,
+        string algorithm,
+        CancellationToken cancellationToken);
+
     Task<Stream> OpenDownloadStreamAsync(string url, CancellationToken cancellationToken);
 }

--- a/apps/MineOS.Infrastructure/Services/ModDependencyService.cs
+++ b/apps/MineOS.Infrastructure/Services/ModDependencyService.cs
@@ -1,0 +1,404 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+using MineOS.Application.Dtos;
+using MineOS.Application.Interfaces;
+
+namespace MineOS.Infrastructure.Services;
+
+/// <summary>
+/// Resolves what a single-mod install really involves.
+///
+/// Modpack installs have resolved dependencies for a while
+/// (<c>ModService.ResolveModrinthDependenciesAsync</c>), but installing one mod
+/// from the browser wrote exactly one file. A mod whose hard dependency is missing
+/// does not warn on startup — Fabric aborts the boot entirely — so the failure
+/// landed on the user as "my server stopped working after I installed a mod".
+/// </summary>
+public class ModDependencyService : IModDependencyService
+{
+    // A mod graph deep enough to hit this is a sign something is wrong; the visited
+    // set already prevents cycles, so this only bounds pathological breadth.
+    private const int MaxResolutionRounds = 64;
+
+    private readonly IModrinthService _modrinthService;
+    private readonly IModService _modService;
+    private readonly IServerService _serverService;
+    private readonly ILogger<ModDependencyService> _logger;
+
+    public ModDependencyService(
+        IModrinthService modrinthService,
+        IModService modService,
+        IServerService serverService,
+        ILogger<ModDependencyService> logger)
+    {
+        _modrinthService = modrinthService;
+        _modService = modService;
+        _serverService = serverService;
+        _logger = logger;
+    }
+
+    public async Task<ModInstallPlanDto> PlanInstallAsync(
+        string serverName, string versionId, CancellationToken cancellationToken)
+    {
+        var root = await _modrinthService.GetVersionAsync(versionId, cancellationToken)
+                   ?? throw new InvalidOperationException($"Modrinth version '{versionId}' was not found.");
+
+        var rootFile = SelectPrimaryFile(root)
+                       ?? throw new InvalidOperationException("That version has no downloadable file.");
+
+        var (loader, gameVersion) = await ResolveServerTargetAsync(serverName, cancellationToken);
+        var installedProjectIds = await GetInstalledProjectIdsAsync(serverName, cancellationToken);
+
+        var required = new List<ModDependencyItemDto>();
+        var optional = new List<ModDependencyItemDto>();
+        var alreadyInstalled = new List<ModDependencyItemDto>();
+        var problems = new List<string>();
+
+        // Breadth-first over hard dependencies. `seen` is what stops a dependency
+        // cycle from looping forever, and also keeps a diamond dependency from
+        // being installed twice.
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var queue = new Queue<ModrinthDependencyDto>();
+
+        foreach (var dependency in root.Dependencies ?? Array.Empty<ModrinthDependencyDto>())
+        {
+            EnqueueOrOffer(dependency, queue, seen, optional);
+        }
+
+        var rounds = 0;
+        while (queue.Count > 0 && rounds++ < MaxResolutionRounds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var dependency = queue.Dequeue();
+            var projectId = dependency.ProjectId!;
+
+            if (installedProjectIds.TryGetValue(projectId, out var installedName))
+            {
+                alreadyInstalled.Add(new ModDependencyItemDto(
+                    projectId, null, installedName, null, "required"));
+                continue;
+            }
+
+            var resolved = await ResolveDependencyVersionAsync(
+                dependency, loader, gameVersion, cancellationToken);
+
+            if (resolved is null)
+            {
+                var label = await DescribeProjectAsync(projectId, cancellationToken);
+                problems.Add(
+                    $"{label} has no build for {DescribeTarget(loader, gameVersion)}");
+                continue;
+            }
+
+            var file = SelectPrimaryFile(resolved);
+            if (file is null)
+            {
+                problems.Add($"{projectId} has no downloadable file");
+                continue;
+            }
+
+            required.Add(new ModDependencyItemDto(
+                resolved.ProjectId,
+                resolved.Id,
+                await DescribeProjectAsync(resolved.ProjectId, cancellationToken),
+                file.FileName,
+                "required"));
+
+            // Dependencies of dependencies.
+            foreach (var child in resolved.Dependencies ?? Array.Empty<ModrinthDependencyDto>())
+            {
+                EnqueueOrOffer(child, queue, seen, optional);
+            }
+        }
+
+        // Optional entries are collected during the walk, where only the project id
+        // is known. They are shown to a human who has to decide whether to install
+        // them, and "EE4vxUHj" is not a decision anyone can make — so resolve the
+        // titles before returning. Only optional ones need this; required entries
+        // already carry a name from their resolved version.
+        for (var i = 0; i < optional.Count; i++)
+        {
+            var name = await DescribeProjectAsync(optional[i].ProjectId, cancellationToken);
+            optional[i] = optional[i] with { Name = name };
+        }
+
+        return new ModInstallPlanDto(
+            VersionId: root.Id,
+            ProjectId: root.ProjectId,
+            Name: root.Name,
+            FileName: rootFile.FileName,
+            Required: required,
+            Optional: optional,
+            AlreadyInstalled: alreadyInstalled,
+            Problems: problems);
+    }
+
+    public async Task<ModInstallResultDto> InstallWithDependenciesAsync(
+        string serverName,
+        string versionId,
+        IReadOnlyList<string> approvedOptionalProjectIds,
+        CancellationToken cancellationToken)
+    {
+        var plan = await PlanInstallAsync(serverName, versionId, cancellationToken);
+
+        if (plan.Problems.Count > 0)
+        {
+            // All-or-nothing on purpose: a partially installed set is the exact
+            // state that stops a server booting, and it is harder to diagnose than
+            // a refusal with a reason.
+            throw new InvalidOperationException(
+                $"Cannot install '{plan.Name}': {string.Join("; ", plan.Problems)}. Nothing was installed.");
+        }
+
+        var (loader, gameVersion) = await ResolveServerTargetAsync(serverName, cancellationToken);
+        var installed = new List<string>();
+
+        // Dependencies first, so the mod is never on disk without them — even if
+        // something fails midway.
+        foreach (var dependency in plan.Required)
+        {
+            await InstallVersionAsync(serverName, dependency.VersionId!, cancellationToken);
+            installed.Add(dependency.FileName!);
+        }
+
+        foreach (var projectId in approvedOptionalProjectIds ?? Array.Empty<string>())
+        {
+            var offered = plan.Optional.FirstOrDefault(o =>
+                string.Equals(o.ProjectId, projectId, StringComparison.OrdinalIgnoreCase));
+            if (offered is null)
+            {
+                // Only things the plan actually offered may be installed: this is
+                // what stops an arbitrary project id being smuggled in.
+                _logger.LogWarning(
+                    "Ignoring optional dependency {ProjectId}: it was not part of the plan for {Server}",
+                    projectId, serverName);
+                continue;
+            }
+
+            var resolved = await ResolveDependencyVersionAsync(
+                new ModrinthDependencyDto(offered.ProjectId, offered.VersionId, "optional"),
+                loader, gameVersion, cancellationToken);
+            var file = SelectPrimaryFile(resolved);
+            if (resolved is null || file is null)
+            {
+                _logger.LogWarning(
+                    "Skipping optional dependency {ProjectId}: no compatible build", projectId);
+                continue;
+            }
+
+            await InstallVersionAsync(serverName, resolved.Id, cancellationToken);
+            installed.Add(file.FileName);
+        }
+
+        await InstallVersionAsync(serverName, plan.VersionId, cancellationToken);
+        installed.Add(plan.FileName);
+
+        await _serverService.MarkRestartRequiredAsync(serverName, cancellationToken);
+        _logger.LogInformation(
+            "Installed {Count} file(s) for {Server}: {Files}",
+            installed.Count, serverName, string.Join(", ", installed));
+
+        return new ModInstallResultDto(
+            installed,
+            plan.AlreadyInstalled.Select(a => a.Name).ToList());
+    }
+
+    // ---- helpers ---------------------------------------------------------
+
+    /// <summary>
+    /// Queues a hard dependency for resolution, or records an optional one to
+    /// offer. Dependencies with no project id (Modrinth allows a bare version
+    /// reference) cannot be resolved or de-duplicated, so they are skipped.
+    /// </summary>
+    private static void EnqueueOrOffer(
+        ModrinthDependencyDto dependency,
+        Queue<ModrinthDependencyDto> queue,
+        HashSet<string> seen,
+        List<ModDependencyItemDto> optional)
+    {
+        if (string.IsNullOrWhiteSpace(dependency.ProjectId) || !seen.Add(dependency.ProjectId))
+        {
+            return;
+        }
+
+        if (string.Equals(dependency.DependencyType, "required", StringComparison.OrdinalIgnoreCase))
+        {
+            queue.Enqueue(dependency);
+        }
+        else if (string.Equals(dependency.DependencyType, "optional", StringComparison.OrdinalIgnoreCase))
+        {
+            optional.Add(new ModDependencyItemDto(
+                dependency.ProjectId, dependency.VersionId, dependency.ProjectId, null, "optional"));
+        }
+        // "incompatible" and "embedded" are deliberately ignored: neither is
+        // something to install alongside the mod.
+    }
+
+    private async Task<ModrinthVersionDto?> ResolveDependencyVersionAsync(
+        ModrinthDependencyDto dependency,
+        string? loader,
+        string? gameVersion,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(dependency.VersionId))
+        {
+            var pinned = await _modrinthService.GetVersionAsync(dependency.VersionId, cancellationToken);
+            if (pinned is not null && IsCompatible(pinned, loader, gameVersion))
+            {
+                return pinned;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(dependency.ProjectId))
+        {
+            return null;
+        }
+
+        var candidates = await _modrinthService.GetProjectVersionsAsync(
+            dependency.ProjectId, loader, gameVersion, cancellationToken);
+
+        return candidates?
+            .Where(v => IsCompatible(v, loader, gameVersion))
+            .OrderByDescending(v => v.DatePublished)
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Whether a version suits this server. An empty loader or game-version list
+    /// on Modrinth's side means "unspecified", which is treated as compatible
+    /// rather than rejected — refusing those would block datapack-style projects
+    /// that legitimately declare neither.
+    /// </summary>
+    internal static bool IsCompatible(ModrinthVersionDto version, string? loader, string? gameVersion)
+    {
+        if (!string.IsNullOrWhiteSpace(gameVersion) &&
+            version.GameVersions is { Count: > 0 } &&
+            !version.GameVersions.Contains(gameVersion, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(loader) &&
+            version.Loaders is { Count: > 0 } &&
+            !version.Loaders.Contains(loader, StringComparer.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static ModrinthVersionFileDto? SelectPrimaryFile(ModrinthVersionDto? version)
+    {
+        if (version?.Files is null || version.Files.Count == 0)
+        {
+            return null;
+        }
+        return version.Files.FirstOrDefault(f => f.Primary)
+               ?? version.Files.FirstOrDefault(f => f.FileName.EndsWith(".jar", StringComparison.OrdinalIgnoreCase));
+    }
+
+    internal static string DescribeTarget(string? loader, string? gameVersion) =>
+        (loader, gameVersion) switch
+        {
+            (null or "", null or "") => "this server",
+            (null or "", _) => $"Minecraft {gameVersion}",
+            (_, null or "") => loader!,
+            _ => $"{loader} {gameVersion}"
+        };
+
+    private async Task<string> DescribeProjectAsync(string projectId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var project = await _modrinthService.GetProjectAsync(projectId, cancellationToken);
+            return string.IsNullOrWhiteSpace(project?.Title) ? projectId : project!.Title;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not read Modrinth project {ProjectId}", projectId);
+            return projectId;
+        }
+    }
+
+    private async Task InstallVersionAsync(
+        string serverName, string versionId, CancellationToken cancellationToken)
+    {
+        var version = await _modrinthService.GetVersionAsync(versionId, cancellationToken)
+                      ?? throw new InvalidOperationException($"Modrinth version '{versionId}' disappeared mid-install.");
+        var file = SelectPrimaryFile(version)
+                   ?? throw new InvalidOperationException($"Modrinth version '{versionId}' has no downloadable file.");
+
+        await using var stream = await _modrinthService.OpenDownloadStreamAsync(file.Url, cancellationToken);
+        await _modService.SaveModAsync(serverName, file.FileName, stream, cancellationToken);
+    }
+
+    private async Task<(string? Loader, string? GameVersion)> ResolveServerTargetAsync(
+        string serverName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var detected = await _serverService.DetectLoaderAsync(serverName, cancellationToken);
+            return (detected.Loader, detected.MinecraftVersion);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not detect the loader for {Server}", serverName);
+            return (null, null);
+        }
+    }
+
+    /// <summary>
+    /// Which Modrinth projects this server already has, by hashing the installed
+    /// jars and asking Modrinth in a single call. File names are not usable for
+    /// this — they say nothing reliable about which project a jar is.
+    /// </summary>
+    private async Task<Dictionary<string, string>> GetInstalledProjectIdsAsync(
+        string serverName, CancellationToken cancellationToken)
+    {
+        var installed = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            var mods = await _modService.ListModsAsync(serverName, cancellationToken);
+            var hashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var mod in mods.Where(m => !m.IsDisabled))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var path = await _modService.GetModPathAsync(serverName, mod.FileName, cancellationToken);
+                if (!File.Exists(path))
+                {
+                    continue;
+                }
+
+                await using var stream = File.OpenRead(path);
+                var hash = Convert.ToHexString(await SHA1.HashDataAsync(stream, cancellationToken)).ToLowerInvariant();
+                hashes[hash] = mod.FileName;
+            }
+
+            if (hashes.Count == 0)
+            {
+                return installed;
+            }
+
+            var found = await _modrinthService.GetVersionsByFileHashesAsync(
+                hashes.Keys.ToList(), "sha1", cancellationToken);
+
+            foreach (var (hash, version) in found)
+            {
+                installed[version.ProjectId] = hashes.TryGetValue(hash, out var fileName)
+                    ? fileName
+                    : version.Name;
+            }
+        }
+        catch (Exception ex)
+        {
+            // Worst case we offer to install something already present, which
+            // overwrites the same file. That is far better than failing the plan.
+            _logger.LogWarning(ex, "Could not determine installed mods for {Server}", serverName);
+        }
+
+        return installed;
+    }
+}

--- a/apps/MineOS.Infrastructure/Services/ModrinthService.cs
+++ b/apps/MineOS.Infrastructure/Services/ModrinthService.cs
@@ -160,6 +160,44 @@ public sealed class ModrinthService : IModrinthService
         return response == null ? null : MapVersion(response);
     }
 
+    public async Task<IReadOnlyDictionary<string, ModrinthVersionDto>> GetVersionsByFileHashesAsync(
+        IReadOnlyList<string> hashes,
+        string algorithm,
+        CancellationToken cancellationToken)
+    {
+        var result = new Dictionary<string, ModrinthVersionDto>(StringComparer.OrdinalIgnoreCase);
+        if (hashes is null || hashes.Count == 0)
+        {
+            return result;
+        }
+
+        var response = await _httpClient.PostAsJsonAsync(
+            "version_files",
+            new { hashes, algorithm },
+            cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning(
+                "Modrinth bulk hash lookup returned {Status}; treating every file as unknown",
+                (int)response.StatusCode);
+            return result;
+        }
+
+        var payload = await response.Content.ReadFromJsonAsync<Dictionary<string, ModrinthVersionResponse>>(
+            JsonOptions, cancellationToken);
+
+        foreach (var (hash, version) in payload ?? new Dictionary<string, ModrinthVersionResponse>())
+        {
+            if (version is not null)
+            {
+                result[hash] = MapVersion(version);
+            }
+        }
+
+        return result;
+    }
+
     public async Task<Stream> OpenDownloadStreamAsync(string url, CancellationToken cancellationToken)
     {
         return await _httpClient.GetStreamAsync(url, cancellationToken);

--- a/apps/MineOS.Tests/Unit/ModDependencyServiceTests.cs
+++ b/apps/MineOS.Tests/Unit/ModDependencyServiceTests.cs
@@ -1,0 +1,289 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MineOS.Application.Dtos;
+using MineOS.Application.Interfaces;
+using MineOS.Infrastructure.Services;
+using Moq;
+
+namespace MineOS.Tests.Unit;
+
+/// <summary>
+/// Covers single-mod dependency resolution (#21).
+///
+/// The behaviour worth guarding is what happens when resolution *cannot* succeed:
+/// a mod installed without its hard dependency does not warn at startup, it stops
+/// the server booting, so an unresolvable dependency has to refuse the whole
+/// install rather than write part of it.
+/// </summary>
+public class ModDependencyServiceTests
+{
+    private static ModrinthVersionDto Version(
+        string id,
+        string projectId,
+        string name = "mod",
+        string[]? gameVersions = null,
+        string[]? loaders = null,
+        ModrinthDependencyDto[]? dependencies = null) =>
+        new(id, projectId, name, "1.0.0", DateTimeOffset.Parse("2026-01-01T00:00:00Z"), 0,
+            gameVersions ?? new[] { "1.21.1" },
+            loaders ?? new[] { "fabric" },
+            new[] { new ModrinthVersionFileDto($"https://cdn/{id}.jar", $"{name}-{id}.jar", 10, true) },
+            dependencies ?? Array.Empty<ModrinthDependencyDto>());
+
+    private sealed class Harness
+    {
+        public Mock<IModrinthService> Modrinth { get; } = new(MockBehavior.Loose);
+        public Mock<IModService> Mods { get; } = new(MockBehavior.Loose);
+        public Mock<IServerService> Servers { get; } = new(MockBehavior.Loose);
+
+        public Harness(params ModrinthVersionDto[] catalogue)
+        {
+            Servers.Setup(s => s.DetectLoaderAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ServerLoaderDto("fabric", "0.19.3", "1.21.1"));
+
+            Mods.Setup(m => m.ListModsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Array.Empty<InstalledModDto>());
+
+            Modrinth.Setup(m => m.GetVersionsByFileHashesAsync(
+                    It.IsAny<IReadOnlyList<string>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Dictionary<string, ModrinthVersionDto>());
+
+            Modrinth.Setup(m => m.GetProjectAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string id, CancellationToken _) =>
+                    new ModrinthProjectDto(
+                        id, id, id, "", null, "mod", 0,
+                        Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(),
+                        null, null, null));
+
+            foreach (var version in catalogue)
+            {
+                var captured = version;
+                Modrinth.Setup(m => m.GetVersionAsync(captured.Id, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(captured);
+                Modrinth.Setup(m => m.GetProjectVersionsAsync(
+                        captured.ProjectId, It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new[] { captured });
+            }
+        }
+
+        public ModDependencyService Build() => new(
+            Modrinth.Object, Mods.Object, Servers.Object,
+            NullLogger<ModDependencyService>.Instance);
+    }
+
+    private static ModrinthDependencyDto Required(string projectId) => new(projectId, null, "required");
+    private static ModrinthDependencyDto Optional(string projectId) => new(projectId, null, "optional");
+
+    [Fact]
+    public async Task A_Mod_With_No_Dependencies_Plans_Only_Itself()
+    {
+        var harness = new Harness(Version("v1", "root"));
+
+        var plan = await harness.Build().PlanInstallAsync("srv", "v1", CancellationToken.None);
+
+        Assert.Empty(plan.Required);
+        Assert.Empty(plan.Optional);
+        Assert.Empty(plan.Problems);
+    }
+
+    [Fact]
+    public async Task Hard_Dependencies_Are_Planned_Including_Their_Own()
+    {
+        // root -> api -> core: the nested case, which is the one that actually
+        // breaks servers when it is missed.
+        var harness = new Harness(
+            Version("v1", "root", dependencies: new[] { Required("api") }),
+            Version("v2", "api", "fabric-api", dependencies: new[] { Required("core") }),
+            Version("v3", "core", "core-lib"));
+
+        var plan = await harness.Build().PlanInstallAsync("srv", "v1", CancellationToken.None);
+
+        Assert.Equal(new[] { "api", "core" }, plan.Required.Select(r => r.ProjectId));
+        Assert.Empty(plan.Problems);
+    }
+
+    [Fact]
+    public async Task A_Dependency_Cycle_Terminates()
+    {
+        var harness = new Harness(
+            Version("v1", "root", dependencies: new[] { Required("a") }),
+            Version("v2", "a", "a", dependencies: new[] { Required("b") }),
+            Version("v3", "b", "b", dependencies: new[] { Required("a") }));
+
+        var plan = await harness.Build().PlanInstallAsync("srv", "v1", CancellationToken.None);
+
+        Assert.Equal(new[] { "a", "b" }, plan.Required.Select(r => r.ProjectId));
+    }
+
+    [Fact]
+    public async Task Optional_Dependencies_Are_Offered_But_Not_Planned_For_Install()
+    {
+        var harness = new Harness(
+            Version("v1", "root", dependencies: new[] { Required("api"), Optional("extras") }),
+            Version("v2", "api", "fabric-api"),
+            Version("v3", "extras", "extras"));
+
+        var plan = await harness.Build().PlanInstallAsync("srv", "v1", CancellationToken.None);
+
+        Assert.Equal(new[] { "api" }, plan.Required.Select(r => r.ProjectId));
+        Assert.Equal(new[] { "extras" }, plan.Optional.Select(o => o.ProjectId));
+    }
+
+    [Fact]
+    public async Task An_Already_Installed_Dependency_Is_Reported_Not_Reinstalled()
+    {
+        var harness = new Harness(
+            Version("v1", "root", dependencies: new[] { Required("api") }),
+            Version("v2", "api", "fabric-api"));
+
+        // A real file on disk: identification works by hashing the jar, so a
+        // path that does not exist would skip the lookup entirely and test nothing.
+        var jarPath = Path.Combine(Path.GetTempPath(), $"mineos-test-{Guid.NewGuid():N}.jar");
+        await File.WriteAllBytesAsync(jarPath, new byte[] { 1, 2, 3 });
+
+        harness.Mods.Setup(m => m.ListModsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new InstalledModDto("fabric-api.jar", 10, DateTimeOffset.UtcNow, false) });
+        harness.Mods.Setup(m => m.GetModPathAsync("srv", "fabric-api.jar", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(jarPath);
+
+        // The hash lookup is what identifies an installed jar; simulate a match.
+        harness.Modrinth.Setup(m => m.GetVersionsByFileHashesAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, ModrinthVersionDto>
+            {
+                ["deadbeef"] = Version("v2", "api", "fabric-api")
+            });
+
+        try
+        {
+            var plan = await harness.Build().PlanInstallAsync("srv", "v1", CancellationToken.None);
+
+            Assert.Empty(plan.Required);
+            Assert.Equal(new[] { "api" }, plan.AlreadyInstalled.Select(a => a.ProjectId));
+        }
+        finally
+        {
+            File.Delete(jarPath);
+        }
+    }
+
+    [Fact]
+    public async Task An_Unresolvable_Hard_Dependency_Becomes_A_Problem()
+    {
+        var harness = new Harness(Version("v1", "root", dependencies: new[] { Required("missing") }));
+        harness.Modrinth.Setup(m => m.GetProjectVersionsAsync(
+                "missing", It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ModrinthVersionDto>());
+
+        var plan = await harness.Build().PlanInstallAsync("srv", "v1", CancellationToken.None);
+
+        Assert.Single(plan.Problems);
+        Assert.Contains("fabric 1.21.1", plan.Problems[0]);
+    }
+
+    [Fact]
+    public async Task Installing_Refuses_Entirely_When_A_Hard_Dependency_Cannot_Be_Resolved()
+    {
+        // The important one: a partial install is what leaves a server unable to
+        // boot, and it is harder to diagnose than an outright refusal.
+        var harness = new Harness(Version("v1", "root", dependencies: new[] { Required("missing") }));
+        harness.Modrinth.Setup(m => m.GetProjectVersionsAsync(
+                "missing", It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ModrinthVersionDto>());
+
+        var service = harness.Build();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.InstallWithDependenciesAsync("srv", "v1", Array.Empty<string>(), CancellationToken.None));
+
+        harness.Mods.Verify(
+            m => m.SaveModAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Dependencies_Are_Written_Before_The_Mod_That_Needs_Them()
+    {
+        var harness = new Harness(
+            Version("v1", "root", dependencies: new[] { Required("api") }),
+            Version("v2", "api", "fabric-api"));
+
+        var order = new List<string>();
+        harness.Mods.Setup(m => m.SaveModAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .Callback((string _, string file, Stream _, CancellationToken _) => order.Add(file))
+            .Returns(Task.CompletedTask);
+        harness.Modrinth.Setup(m => m.OpenDownloadStreamAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MemoryStream(new byte[] { 1 }));
+
+        await harness.Build().InstallWithDependenciesAsync("srv", "v1", Array.Empty<string>(), CancellationToken.None);
+
+        Assert.Equal(2, order.Count);
+        Assert.StartsWith("fabric-api-", order[0]);
+        Assert.StartsWith("mod-v1", order[1]);
+    }
+
+    [Fact]
+    public async Task An_Optional_Dependency_Is_Installed_Only_When_Approved()
+    {
+        var harness = new Harness(
+            Version("v1", "root", dependencies: new[] { Optional("extras") }),
+            Version("v3", "extras", "extras"));
+
+        var saved = new List<string>();
+        harness.Mods.Setup(m => m.SaveModAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .Callback((string _, string file, Stream _, CancellationToken _) => saved.Add(file))
+            .Returns(Task.CompletedTask);
+        harness.Modrinth.Setup(m => m.OpenDownloadStreamAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MemoryStream(new byte[] { 1 }));
+
+        var service = harness.Build();
+
+        await service.InstallWithDependenciesAsync("srv", "v1", Array.Empty<string>(), CancellationToken.None);
+        Assert.Single(saved);
+
+        saved.Clear();
+        await service.InstallWithDependenciesAsync("srv", "v1", new[] { "extras" }, CancellationToken.None);
+        Assert.Equal(2, saved.Count);
+    }
+
+    [Fact]
+    public async Task An_Optional_Project_The_Plan_Never_Offered_Is_Ignored()
+    {
+        // Approvals are checked against the plan so an arbitrary project id in the
+        // request body cannot cause an unrelated download.
+        var harness = new Harness(Version("v1", "root"));
+        harness.Mods.Setup(m => m.SaveModAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        harness.Modrinth.Setup(m => m.OpenDownloadStreamAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MemoryStream(new byte[] { 1 }));
+
+        var result = await harness.Build()
+            .InstallWithDependenciesAsync("srv", "v1", new[] { "totally-unrelated" }, CancellationToken.None);
+
+        Assert.Single(result.InstalledFiles);
+    }
+
+    [Theory]
+    [InlineData("1.21.1", "fabric", true)]
+    [InlineData("1.20.1", "fabric", false)]
+    [InlineData("1.21.1", "forge", false)]
+    public void Compatibility_Checks_Both_Game_Version_And_Loader(
+        string gameVersion, string loader, bool expected)
+    {
+        var version = Version("v", "p", gameVersions: new[] { "1.21.1" }, loaders: new[] { "fabric" });
+
+        Assert.Equal(expected, ModDependencyService.IsCompatible(version, loader, gameVersion));
+    }
+
+    [Fact]
+    public void A_Version_Declaring_Nothing_Is_Treated_As_Compatible()
+    {
+        // Modrinth leaves these empty for datapack-style projects; rejecting them
+        // would block legitimate dependencies.
+        var version = Version("v", "p", gameVersions: Array.Empty<string>(), loaders: Array.Empty<string>());
+
+        Assert.True(ModDependencyService.IsCompatible(version, "fabric", "1.21.1"));
+    }
+}

--- a/apps/web/src/lib/components/ModrinthModSearch.svelte
+++ b/apps/web/src/lib/components/ModrinthModSearch.svelte
@@ -177,8 +177,54 @@
 		}
 	}
 
+	// Asks the server what this install would actually pull in. Returns null when
+	// the plan cannot be fetched, in which case we install anyway — the backend
+	// resolves dependencies regardless, so a failed preview should not block the
+	// user, only leave them less informed.
+	async function fetchPlan(versionId: string) {
+		try {
+			const res = await fetch(
+				`/api/servers/${encodeURIComponent(serverName)}/mods/modrinth/install/plan?versionId=${encodeURIComponent(versionId)}`
+			);
+			return res.ok ? await res.json() : null;
+		} catch {
+			return null;
+		}
+	}
+
 	async function installVersion(versionId: string) {
 		if (!versionId) return;
+
+		const plan = await fetchPlan(versionId);
+
+		// Only interrupt when there is something to say. A mod with no extra
+		// dependencies installs on one click, as it always did.
+		if (plan && (plan.required?.length || plan.optional?.length || plan.problems?.length)) {
+			if (plan.problems?.length) {
+				await modal.error(
+					`${plan.name} cannot be installed on this server:\n\n` +
+						plan.problems.join('\n') +
+						'\n\nNothing was installed.'
+				);
+				return;
+			}
+
+			const lines = [`Installing ${plan.name} will also install:`, ''];
+			for (const dep of plan.required) lines.push(`  • ${dep.name} (required)`);
+			if (plan.alreadyInstalled?.length) {
+				lines.push('', 'Already installed:');
+				for (const dep of plan.alreadyInstalled) lines.push(`  • ${dep.name}`);
+			}
+			if (plan.optional?.length) {
+				lines.push('', 'Optional add-ons this mod supports (not installed):');
+				for (const dep of plan.optional) lines.push(`  • ${dep.name}`);
+			}
+
+			if (!(await modal.confirm(lines.join('\n'), 'Install with dependencies'))) {
+				return;
+			}
+		}
+
 		installingVersionId = versionId;
 		try {
 			const res = await fetch(`/api/servers/${encodeURIComponent(serverName)}/mods/modrinth/install`, {
@@ -193,7 +239,13 @@
 				return;
 			}
 
-			await modal.success('Mod downloaded. Restart the server to apply changes.');
+			const result = await res.json().catch(() => null);
+			const count = result?.installedFiles?.length ?? 1;
+			await modal.success(
+				count > 1
+					? `${count} files downloaded (mod plus dependencies). Restart the server to apply changes.`
+					: 'Mod downloaded. Restart the server to apply changes.'
+			);
 			detailOpen = false;
 			onInstallComplete?.();
 		} catch (err) {


### PR DESCRIPTION
Closes #21.

Modpack installs have resolved dependencies for a while (`ModService.ResolveModrinthDependenciesAsync`), but **installing one mod from the browser wrote exactly one file.** A mod whose hard dependency is missing doesn't warn at startup — Fabric aborts the boot entirely — so this reached users as *"my server stopped working after I installed a mod."*

## What's new

**`GET /mods/modrinth/install/plan?versionId=…`** — what an install would actually do, before anything is written:

```json
{ "name": "[Fabric] Sodium Extra 0.9.3 for Minecraft 1.21.1",
  "required":        [{ "name": "Sodium", "fileName": "sodium-fabric-0.8.13-beta.2+mc1.21.1.jar" }],
  "optional":        [{ "name": "Greenlight" }, { "name": "Iris Shaders" }, { "name": "Reese's Sodium Options" }],
  "alreadyInstalled": [], "problems": [] }
```

**`POST /mods/modrinth/install`** now installs hard dependencies alongside the mod — dependencies first, so the mod is never on disk without them. Callers that send only a `versionId` keep working and simply get a correct install.

The browser previews the plan and asks first, but **only when there's something to say** — a mod with no extra dependencies still installs on one click.

## Decisions worth reviewing

**Unresolvable hard dependency ⇒ refuse the whole install.** A partial set is exactly the state that stops a server booting, and it's harder to diagnose than a refusal naming what couldn't be satisfied. Nothing is written.

**"Already installed" is determined by hashing.** File names say nothing reliable about which Modrinth project a jar is, so the installed jars are SHA1'd and resolved in a single bulk call (`GetVersionsByFileHashesAsync`, new). If that lookup fails the plan still succeeds — worst case we re-download a file that's already there, which beats failing the operation.

**Optional dependencies are offered, never auto-installed**, and only ones the plan actually offered can be approved — an arbitrary project id in the request body can't trigger an unrelated download.

**Cycles and depth**: the visited set makes a dependency cycle terminate; a round cap bounds pathological breadth. Both covered by tests.

## Against the issue's acceptance criteria

- ✅ Detect dependencies from Modrinth · ✅ Show the list before installing · ✅ Confirm before installing · ✅ Install approved dependencies · ✅ Nested dependencies · ✅ Skip already-installed · ✅ Optional handled separately
- ⚠️ *"Progress indicator during multi-mod installation"* — the install is synchronous and reports what it wrote (`installedFiles`); the UI shows its existing spinner. A job/progress stream would be the follow-up if you want it for large sets.
- ❌ **CurseForge is not covered.** This is Modrinth-only; the CurseForge install path still installs a single file. Worth its own issue.

## Bonus: `mineos-local-lab` skill

Adds `.claude/skills/local-lab/` documenting the Docker lab all of this was verified in — running the .NET suite without a local SDK, standing up a proxy with backends, and `mcprobe.py` for testing Minecraft behaviour with no game client.

It also records the three traps that produced *wrong conclusions* during this work: a protocol-version mismatch masquerading as a security result, packet `0x03` (Set Compression) looking like a successful login, and connection resets that mean "still starting" rather than "refused".

## Testing

| | `vibing` | this branch |
|---|---|---|
| `dotnet test` | 145 passed, 0 failed | **159 passed, 0 failed** |
| `npm run check` | 5 errors, 93 warnings | 5 errors, 93 warnings |

The resolver is tested through a mocked `IModrinthService`, covering nested chains, cycles, optional-vs-required, already-installed, and — most importantly — that a failed resolution writes **nothing** (`SaveModAsync` verified `Times.Never`).

Verified against real Modrinth data in the lab: installing Sodium Extra pulled in Sodium automatically, and re-planning then reported it as already installed rather than duplicating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
