### PR TITLE
Fix all svelte-check type errors

### DIFF
--- a/apps/web/src/lib/components/ChangeServerType.svelte
+++ b/apps/web/src/lib/components/ChangeServerType.svelte
@@ -19,7 +19,7 @@
 		onComplete: () => void;
 	} = $props();
 
-	type ServerType = 'vanilla' | 'paper' | 'spigot' | 'forge' | 'neoforge' | 'fabric' | 'quilt' | 'velocity' | 'bungeecord';
+	type ServerType = 'vanilla' | 'paper' | 'spigot' | 'bedrock' | 'forge' | 'neoforge' | 'fabric' | 'quilt' | 'velocity' | 'bungeecord';
 
 	const serverTypes: { id: ServerType; name: string; category: string }[] = [
 		{ id: 'vanilla', name: 'Vanilla', category: 'vanilla' },

--- a/apps/web/src/lib/components/ChangeServerType.svelte
+++ b/apps/web/src/lib/components/ChangeServerType.svelte
@@ -19,6 +19,9 @@
 		onComplete: () => void;
 	} = $props();
 
+	// 'bedrock' has no entry in serverTypes below, so it is never a target of
+	// selectType; it belongs in the union because currentServerType can be
+	// bedrock, and the guards that refuse a Bedrock/Java swap depend on it.
 	type ServerType = 'vanilla' | 'paper' | 'spigot' | 'bedrock' | 'forge' | 'neoforge' | 'fabric' | 'quilt' | 'velocity' | 'bungeecord';
 
 	const serverTypes: { id: ServerType; name: string; category: string }[] = [

--- a/apps/web/src/routes/(app)/servers/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/+page.svelte
@@ -535,7 +535,7 @@
 							src="/api/servers/{server.name}/icon"
 							alt="{server.name} icon"
 							class="server-icon"
-							onerror={(e) => (e.currentTarget.style.display = 'none')}
+							onerror={(e) => ((e.currentTarget as HTMLElement).style.display = 'none')}
 						/>
 					</div>
 					<div class="server-title">

--- a/apps/web/src/routes/(app)/servers/new/version-pickers/VanillaVersions.svelte
+++ b/apps/web/src/routes/(app)/servers/new/version-pickers/VanillaVersions.svelte
@@ -4,7 +4,7 @@
 
 	interface Props {
 		profiles: Profile[];
-		implementation: 'vanilla' | 'paper' | 'spigot';
+		implementation: 'vanilla' | 'paper' | 'spigot' | 'craftbukkit';
 		onselect: (profile: Profile) => void;
 		onready?: (fn: (() => void) | null) => void;
 	}

--- a/apps/web/src/routes/(app)/servers/new/version-pickers/VanillaVersions.svelte
+++ b/apps/web/src/routes/(app)/servers/new/version-pickers/VanillaVersions.svelte
@@ -4,6 +4,9 @@
 
 	interface Props {
 		profiles: Profile[];
+		// 'craftbukkit' is filtered below and offered by BuildTools, but the
+		// wizard's VersionSelect does not route it here yet; the union stays
+		// wide so that support is not deleted while it waits for a caller.
 		implementation: 'vanilla' | 'paper' | 'spigot' | 'craftbukkit';
 		onselect: (profile: Profile) => void;
 		onready?: (fn: (() => void) | null) => void;


### PR DESCRIPTION
Three one-line type fixes so `npm run check` reports **0 errors** (was 5 on `vibing`):

- **ChangeServerType.svelte** — the local `ServerType` union gains `'bedrock'`. The component already handles bedrock everywhere (profile filter case, `selectType` guard, `detectCategory`); the union just predated it.
- **VanillaVersions.svelte** — prop union accepts `'craftbukkit'`, which its own profile-filter switch already implements.
- **servers/+page.svelte** — cast `currentTarget` to `HTMLElement` before setting `style` in the icon-fallback handler.

No behavior changes. 19/19 vitest green; check goes from 5 errors → 0.

Note for review order: this is independent of #176 and touches two files that PR also touches (`servers/+page.svelte` icon line only). Whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)