### PR TITLE
CI: run web unit tests and type-check

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,4 +23,6 @@ jobs:
           cache: npm
           cache-dependency-path: apps/web/package-lock.json
       - run: npm ci
+      - run: npm run test:unit
+      - run: npm run check
       - run: npm run build


### PR DESCRIPTION
`node.js.yml` ran `npm ci && npm run build` only — broken unit tests and svelte-check errors never gated a PR (which is how five stale type errors survived). Adds two steps ahead of the build:

- `npm run test:unit` (vitest, ~1s)
- `npm run check` (svelte-check)

No untrusted input in the workflow; static commands only.

## Merge order

**Stacked on #177** (`fix/svelte-check-type-unions`) on purpose: `svelte-check` is only clean once the stale unions are fixed, so basing this on `vibing` would open red. After #177 merges, retarget this PR to `vibing` (Edit → base branch) and merge. If you'd rather not stack, merge #177 first and I'll retarget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)