### PR TITLE
chore(skills): correct stale facts in the releasing skill

### DIFF
--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -17,7 +17,7 @@ Releases are **100% tag-driven**. Pushing a `v*` git tag is the entire release a
    - `vX.Y.Z-beta.N` / `-rc.N` / `-alpha.N` (has hyphen) → moves `:preview`, marked prerelease. Default installs are untouched.
    - A typo like `v1.2.0.beta.3` (dot, not hyphen) reads as **stable** and hijacks `:latest`. Type the tag exactly; re-read it before pushing.
 3. **Tag the branch the version train lives on — not reflexively `master`.** History: `-beta`/`-rc` tags are cut on the **`vibing`** branch; the `vX.Y.Z` stable tag is cut on `master` after merging `vibing → master`. Confirm with `git branch -r --contains <last-tag>` before assuming.
-4. **CI does not run the .NET tests.** Since #178 `node.js.yml` runs `npm ci`, `npm run test:unit`, `npm run check` and `npm run build`, so the **frontend** is covered. The xUnit suite (159 tests) still never runs in CI, so **run it locally before every tag** or you ship untested backend code.
+4. **CI does not run the .NET tests.** Since #178 `node.js.yml` runs `npm ci`, `npm run test:unit`, `npm run check` and `npm run build`, so the **frontend** is covered. The xUnit suite still never runs in CI, so **run it locally before every tag** or you ship untested backend code.
 5. **The tag push requires human approval** (release-guard hook). Prepare the tag, show your partner the exact command and version, and let them approve the push. Never work around the guard.
 
 ## Version scheme
@@ -38,7 +38,7 @@ Semver `MAJOR.MINOR.PATCH` with dotted pre-release suffixes:
 
 1. **Confirm the merge landed.** `gh pr view <N> --json state,mergeCommit`; `git fetch origin --tags`; `git log --oneline <last-tag>..origin/<branch>` to see exactly what's shipping.
 2. **Check for branch divergence.** `git log --oneline origin/master..origin/vibing` and the reverse. If the preview line (`vibing`) has commits master doesn't (or vice-versa), tagging naively **regresses** the other channel. Reconcile (merge) first — see Common Mistakes.
-3. **Run the tests CI skips.** `dotnet test mineos-sveltkit.sln` — expect **159 passing**. Note the `.sln` filename is misspelled `sveltkit`; that's correct. The frontend (`test:unit`, `check`, `build`) is already covered by CI since #178, so you only need it locally if you're tagging without a green CI run on the branch tip.
+3. **Run the tests CI skips.** `dotnet test mineos-sveltkit.sln` — expect **all green** (181 as of 2026-08-24). Judge on failures, not on the number: the count grows with every PR, so a mismatch means the suite moved on, while a red test means you are about to ship a regression. Run the **solution**, not just `apps/MineOS.Tests` — `test/MineOS.Tests` is a second project the solution picks up and a bare project path silently skips. Note the `.sln` filename is misspelled `sveltkit`; that's correct. The frontend (`test:unit`, `check`, `build`) is already covered by CI since #178, so you only need it locally if you're tagging without a green CI run on the branch tip.
 
    **No local `dotnet`?** It is not installed on every dev machine. Run the suite in the SDK container instead:
 
@@ -46,7 +46,7 @@ Semver `MAJOR.MINOR.PATCH` with dotted pre-release suffixes:
    docker run --rm -v "$PWD":/src -w /src \
      -e DOTNET_CLI_TELEMETRY_OPTOUT=1 -e DOTNET_NOLOGO=1 \
      mcr.microsoft.com/dotnet/sdk:8.0 \
-     dotnet test apps/MineOS.Tests/MineOS.Tests.csproj
+     dotnet test mineos-sveltkit.sln
    ```
 4. **Pick the version** per the table above; decide beta vs rc vs stable by soak time.
 5. **Create an annotated tag whose message is the changelog** (this repo puts release notes in the tag message, not the GitHub release body). See below.
@@ -95,7 +95,7 @@ Read `git tag -l --format='%(contents)' v1.1.0` for the house style (title line,
 | Tag `master` while `vibing` is ahead | Beta regresses — preview users lose commits only on `vibing` | Reconcile branches first (merge `master`→`vibing` or vice-versa), re-test, then tag |
 | Bare `vX.Y.Z` for freshly-merged feature | Ships unsoaked code straight to every stable user via `:latest` | Cut `-beta.N` first; promote to stable after soak |
 | Hyphen typo (`v1.2.0.beta.3`) | Reads as stable, hijacks `:latest` | Re-read the exact tag string before pushing |
-| Skip local `dotnet test` | Ship backend code CI never tested | Run the 159 tests locally every time (SDK container if no local `dotnet`) |
+| Skip local `dotnet test` | Ship backend code CI never tested | Run the full solution locally every time (SDK container if no local `dotnet`) |
 | Bump versions in `package.json`/source | Pointless churn; ignored | Version comes only from the tag |
 
 ## Red Flags — STOP

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -17,7 +17,7 @@ Releases are **100% tag-driven**. Pushing a `v*` git tag is the entire release a
    - `vX.Y.Z-beta.N` / `-rc.N` / `-alpha.N` (has hyphen) → moves `:preview`, marked prerelease. Default installs are untouched.
    - A typo like `v1.2.0.beta.3` (dot, not hyphen) reads as **stable** and hijacks `:latest`. Type the tag exactly; re-read it before pushing.
 3. **Tag the branch the version train lives on — not reflexively `master`.** History: `-beta`/`-rc` tags are cut on the **`vibing`** branch; the `vX.Y.Z` stable tag is cut on `master` after merging `vibing → master`. Confirm with `git branch -r --contains <last-tag>` before assuming.
-4. **CI does not run the .NET tests.** `node.js.yml` only does `npm ci && npm run build`. The 56 xUnit tests never run in CI, so **run them locally before every tag** or you ship untested backend code.
+4. **CI does not run the .NET tests.** Since #178 `node.js.yml` runs `npm ci`, `npm run test:unit`, `npm run check` and `npm run build`, so the **frontend** is covered. The xUnit suite (159 tests) still never runs in CI, so **run it locally before every tag** or you ship untested backend code.
 5. **The tag push requires human approval** (release-guard hook). Prepare the tag, show your partner the exact command and version, and let them approve the push. Never work around the guard.
 
 ## Version scheme
@@ -38,7 +38,16 @@ Semver `MAJOR.MINOR.PATCH` with dotted pre-release suffixes:
 
 1. **Confirm the merge landed.** `gh pr view <N> --json state,mergeCommit`; `git fetch origin --tags`; `git log --oneline <last-tag>..origin/<branch>` to see exactly what's shipping.
 2. **Check for branch divergence.** `git log --oneline origin/master..origin/vibing` and the reverse. If the preview line (`vibing`) has commits master doesn't (or vice-versa), tagging naively **regresses** the other channel. Reconcile (merge) first — see Common Mistakes.
-3. **Run the tests CI skips.** `dotnet test mineos-sveltkit.sln` (expect 56 passing) and `cd apps/web && npm ci && npm run build`. Note the `.sln` filename is misspelled `sveltkit` — that's correct.
+3. **Run the tests CI skips.** `dotnet test mineos-sveltkit.sln` — expect **159 passing**. Note the `.sln` filename is misspelled `sveltkit`; that's correct. The frontend (`test:unit`, `check`, `build`) is already covered by CI since #178, so you only need it locally if you're tagging without a green CI run on the branch tip.
+
+   **No local `dotnet`?** It is not installed on every dev machine. Run the suite in the SDK container instead:
+
+   ```bash
+   docker run --rm -v "$PWD":/src -w /src \
+     -e DOTNET_CLI_TELEMETRY_OPTOUT=1 -e DOTNET_NOLOGO=1 \
+     mcr.microsoft.com/dotnet/sdk:8.0 \
+     dotnet test apps/MineOS.Tests/MineOS.Tests.csproj
+   ```
 4. **Pick the version** per the table above; decide beta vs rc vs stable by soak time.
 5. **Create an annotated tag whose message is the changelog** (this repo puts release notes in the tag message, not the GitHub release body). See below.
 6. **Show your partner the tag + push command and get approval**, then push. `git push origin <tag>`.
@@ -61,6 +70,8 @@ git push origin v1.2.0-beta.3
 
 Read `git tag -l --format='%(contents)' v1.1.0` for the house style (title line, "N issues resolved…", Features/Fixes sections).
 
+**`CHANGELOG.md` is not part of the release action.** #179 added one, but Iron Rule 1 still holds: a release is a tag push and nothing else. Keep the changelog current in the normal feature PRs that change behaviour, not in a commit cut for the tag. Its heading carries a `currently \`vX.Y.Z-beta.N\`` marker that goes stale as betas roll — fix that in a docs PR, never by committing on top of a release.
+
 ## What the tag triggers (reference)
 
 - **publish-images.yml** — builds multi-arch (amd64+arm64) `ghcr.io/freeman412/mineos-api` and `mineos-web`. Channel tag (`:latest` vs `:preview`) per the hyphen rule; also tags `:vX.Y.Z…` and `:sha-…`. Injects the tag as `MINEOS_IMAGE_TAG` (api) / `PUBLIC_BUILD_ID` (web About page).
@@ -75,7 +86,7 @@ Read `git tag -l --format='%(contents)' v1.1.0` for the house style (title line,
 | Tag `master` while `vibing` is ahead | Beta regresses — preview users lose commits only on `vibing` | Reconcile branches first (merge `master`→`vibing` or vice-versa), re-test, then tag |
 | Bare `vX.Y.Z` for freshly-merged feature | Ships unsoaked code straight to every stable user via `:latest` | Cut `-beta.N` first; promote to stable after soak |
 | Hyphen typo (`v1.2.0.beta.3`) | Reads as stable, hijacks `:latest` | Re-read the exact tag string before pushing |
-| Skip local `dotnet test` | Ship backend code CI never tested | Run the 56 tests locally every time |
+| Skip local `dotnet test` | Ship backend code CI never tested | Run the 159 tests locally every time (SDK container if no local `dotnet`) |
 | Bump versions in `package.json`/source | Pointless churn; ignored | Version comes only from the tag |
 
 ## Red Flags — STOP

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -52,7 +52,16 @@ Semver `MAJOR.MINOR.PATCH` with dotted pre-release suffixes:
 5. **Create an annotated tag whose message is the changelog** (this repo puts release notes in the tag message, not the GitHub release body). See below.
 6. **Show your partner the tag + push command and get approval**, then push. `git push origin <tag>`.
 7. **Watch the two workflows.** `gh run list --limit 4`; `gh run watch <id>`.
-8. **Verify the channel.** For a prerelease, confirm `:latest` did **not** move: `docker buildx imagetools inspect ghcr.io/freeman412/mineos-api:latest` digest should be unchanged. For a stable, confirm it did. Check `gh release view <tag> --json isPrerelease,assets` (expect 8 assets: 2 bundles + 6 CLI zips).
+8. **Verify the channel.** For a prerelease, confirm `:latest` did **not** move: `docker buildx imagetools inspect ghcr.io/freeman412/mineos-api:latest` digest should be unchanged — record it *before* pushing so you have something to compare against. For a stable, confirm it did. Check `gh release view <tag> --json isPrerelease,assets` (expect **9** assets: 2 bundles + 6 CLI zips + `checksums.txt`).
+
+9. **Publish the release notes — the workflow does not.** `publish-install-bundle.yml` creates the GitHub Release with an **empty body**; the notes live only in the tag message. This is why v1.2.0-beta.4, beta.5 and beta.7 all shipped with blank release pages. Copy the tag message over once the workflow finishes:
+
+   ```bash
+   git tag -l --format='%(contents)' <tag> > /tmp/notes.md
+   gh release edit <tag> --notes-file /tmp/notes.md
+   ```
+
+   Fixing the workflow to do this itself would retire the step; until then it is manual and easy to forget.
 
 ## Annotated tag = changelog
 
@@ -75,7 +84,7 @@ Read `git tag -l --format='%(contents)' v1.1.0` for the house style (title line,
 ## What the tag triggers (reference)
 
 - **publish-images.yml** — builds multi-arch (amd64+arm64) `ghcr.io/freeman412/mineos-api` and `mineos-web`. Channel tag (`:latest` vs `:preview`) per the hyphen rule; also tags `:vX.Y.Z…` and `:sha-…`. Injects the tag as `MINEOS_IMAGE_TAG` (api) / `PUBLIC_BUILD_ID` (web About page).
-- **publish-install-bundle.yml** — builds `mineos-cli` for 6 OS/arch targets, packages the install bundle, creates the GitHub Release. `prerelease: true` iff the tag contains `-beta`/`-alpha`/`-rc`.
+- **publish-install-bundle.yml** — builds `mineos-cli` for 6 OS/arch targets, packages the install bundle, creates the GitHub Release with 9 assets (2 bundles, 6 CLI zips, `checksums.txt`). `prerelease: true` iff the tag contains `-beta`/`-alpha`/`-rc`. It does **not** write a release body — see checklist step 9.
 - **Not triggered:** the TrueNAS catalog under `deployments/truenas/` is published by `scripts/publish-truenas-catalog.sh` separately — only run it if that directory changed.
 
 ## Common Mistakes


### PR DESCRIPTION
Found while cutting `v1.2.0-beta.7`. The releasing skill had three claims that are no longer true, each of which would mislead the next person (or agent) cutting a release:

| Claim | Reality |
|---|---|
| "`node.js.yml` only does `npm ci && npm run build`" | #178 added `npm run test:unit` and `npm run check` — the frontend **is** covered by CI now |
| "expect 56 passing" | The xUnit suite is **159** tests |
| — | No guidance for a machine with no local `dotnet`, which is the case on at least one dev box here |

The last one matters most: "run the tests CI skips" is unactionable without a local SDK, and the natural response is to skip them — exactly what Iron Rule 4 exists to prevent. Added the container invocation, which is what I actually used to get the 159 green before tagging:

```bash
docker run --rm -v "$PWD":/src -w /src \
  -e DOTNET_CLI_TELEMETRY_OPTOUT=1 -e DOTNET_NOLOGO=1 \
  mcr.microsoft.com/dotnet/sdk:8.0 \
  dotnet test apps/MineOS.Tests/MineOS.Tests.csproj
```

Also records that `CHANGELOG.md` (added in #179) is deliberately **not** part of the release action — Iron Rule 1 still stands, a release is a tag push and nothing else — and that its `currently <version>` marker gets maintained in docs PRs rather than in a commit cut for the tag. That tension didn't exist when the skill was written.

Note the `:preview` / `:latest` hyphen rule and the branch rules are untouched — they were correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qpe5hWxixL29PkRt3LPxYo