### PR TITLE
fix(java): resolve a proxy's Java runtime from its jar's bytecode target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,27 @@ Pre-releases publish `:preview` Docker images and are not intended for productio
 
 ## [Unreleased]
 
-Nothing yet — the 1.2.0 line below is feature-complete and in testing.
+### Fixed
+
+- **Proxies pick a Java runtime that can actually load their jar.** Proxies were pinned to
+  Java 21, which was right when Velocity's floor was 21 and wrong once Velocity 4.x shipped
+  Java 25 bytecode: a 4.x proxy died before `main()` with `UnsupportedClassVersionError`
+  (class file 69 vs 65) in a restart loop. MineOS now reads the required version off the
+  jar's own `Main-Class` bytecode, so it tracks upstream automatically — Velocity 3.4.0
+  targets Java 17, 3.5.1 targets 21, 4.x targets 25. Game servers keep using the Minecraft
+  version, whose bootstrap launchers (paperclip, the Fabric installer) deliberately report
+  an ancient target and cannot be read this way.
+- **Java version tiers accept newer runtimes.** Each tier now falls forward when its exact
+  match is not installed, instead of resolving to whatever `java` happened to be on `PATH`.
+  Below Java 17 the exact match is still required, since legacy Minecraft genuinely breaks
+  on modern JVMs.
+
+### Changed
+
+- **The Java Binary field lists the runtimes the host actually has**, via a new
+  `GET /api/v1/host/java-runtimes`. It previously offered four hardcoded paths that named
+  amd64 and JRE directories on an image shipping arm64 JDKs, so every explicit choice
+  pointed at a binary that did not exist.
 
 ## [1.2.0] — in beta (currently `v1.2.0-beta.6`)
 

--- a/apps/MineOS.Api/Endpoints/HostEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/HostEndpoints.cs
@@ -396,6 +396,9 @@ public static class HostEndpoints
         host.MapGet("/groups", async (IHostService hostService, CancellationToken cancellationToken) =>
             Results.Ok(await hostService.GetGroupsAsync(cancellationToken)));
 
+        host.MapGet("/java-runtimes", async (IHostService hostService, CancellationToken cancellationToken) =>
+            Results.Ok(await hostService.GetJavaRuntimesAsync(cancellationToken)));
+
         return api;
     }
 

--- a/apps/MineOS.Application/Dtos/HostDtos.cs
+++ b/apps/MineOS.Application/Dtos/HostDtos.cs
@@ -59,4 +59,10 @@ public record IncrementEntryDto(DateTimeOffset Time, string Step, long? Size, lo
 
 public record HostUserDto(string Username, int Uid, int Gid, string Home);
 
+/// <summary>
+/// A Java runtime installed on the host, as offered in the server config UI.
+/// <paramref name="Major"/> is null when the version could not be determined.
+/// </summary>
+public record JavaRuntimeDto(string Path, int? Major, string Version, string Label, bool IsDefault);
+
 public record HostGroupDto(string GroupName, int Gid);

--- a/apps/MineOS.Application/Interfaces/IHostService.cs
+++ b/apps/MineOS.Application/Interfaces/IHostService.cs
@@ -12,4 +12,5 @@ public interface IHostService
     Task<IReadOnlyList<string>> GetLocalesAsync(CancellationToken cancellationToken);
     Task<IReadOnlyList<HostUserDto>> GetUsersAsync(CancellationToken cancellationToken);
     Task<IReadOnlyList<HostGroupDto>> GetGroupsAsync(CancellationToken cancellationToken);
+    Task<IReadOnlyList<JavaRuntimeDto>> GetJavaRuntimesAsync(CancellationToken cancellationToken);
 }

--- a/apps/MineOS.Infrastructure/Services/HostService.cs
+++ b/apps/MineOS.Infrastructure/Services/HostService.cs
@@ -265,6 +265,112 @@ public sealed class HostService : IHostService
         return Task.FromResult<IReadOnlyList<HostGroupDto>>(results);
     }
 
+    private const string JvmRoot = "/usr/lib/jvm";
+
+    /// <summary>
+    /// Lists the Java runtimes installed on the host by scanning <c>/usr/lib/jvm</c>.
+    /// </summary>
+    /// <remarks>
+    /// The config UI used to offer a hardcoded list of paths, which drifted from what the
+    /// image actually ships - it named amd64 and JRE directories on an image carrying
+    /// arm64 JDKs, so every explicit choice pointed at a binary that did not exist, and
+    /// newly added runtimes never appeared. Reading the directory keeps the two in step.
+    /// </remarks>
+    public Task<IReadOnlyList<JavaRuntimeDto>> GetJavaRuntimesAsync(CancellationToken cancellationToken)
+    {
+        // Always offer the PATH default first: it is what an empty java_binary resolves
+        // through, and it is the only entry guaranteed to exist.
+        var runtimes = new List<JavaRuntimeDto>
+        {
+            new("java", null, string.Empty, "Default (java on PATH)", true)
+        };
+
+        if (!Directory.Exists(JvmRoot))
+        {
+            return Task.FromResult<IReadOnlyList<JavaRuntimeDto>>(runtimes);
+        }
+
+        var found = new List<JavaRuntimeDto>();
+        foreach (var home in Directory.EnumerateDirectories(JvmRoot))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var binary = Path.Combine(home, "bin", "java");
+            if (!File.Exists(binary))
+            {
+                continue;
+            }
+
+            var version = ReadJavaVersion(home);
+            var major = ParseJavaMajor(version) ?? ParseJavaMajor(Path.GetFileName(home));
+            var label = major is null
+                ? Path.GetFileName(home)
+                : $"Java {major}{(string.IsNullOrEmpty(version) ? string.Empty : $" ({version})")}";
+
+            found.Add(new JavaRuntimeDto(binary, major, version, label, false));
+        }
+
+        runtimes.AddRange(found
+            .OrderByDescending(runtime => runtime.Major ?? int.MinValue)
+            .ThenBy(runtime => runtime.Path, StringComparer.Ordinal));
+
+        return Task.FromResult<IReadOnlyList<JavaRuntimeDto>>(runtimes);
+    }
+
+    /// <summary>Reads JAVA_VERSION from a JDK/JRE's release file, e.g. "25.0.4".</summary>
+    private static string ReadJavaVersion(string javaHome)
+    {
+        var releasePath = Path.Combine(javaHome, "release");
+        if (!File.Exists(releasePath))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            foreach (var line in File.ReadLines(releasePath))
+            {
+                if (line.StartsWith("JAVA_VERSION=", StringComparison.Ordinal))
+                {
+                    return line["JAVA_VERSION=".Length..].Trim().Trim('"');
+                }
+            }
+        }
+        catch
+        {
+            // Unreadable release file: fall back to the directory name.
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Java major from a version or directory name. Handles the legacy "1.8.0_502" form,
+    /// where the major is the second component, as well as "25.0.4" and "temurin-21-jdk".
+    /// </summary>
+    public static int? ParseJavaMajor(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var match = System.Text.RegularExpressions.Regex.Match(value, @"(\d+)");
+        if (!match.Success || !int.TryParse(match.Groups[1].Value, out var first))
+        {
+            return null;
+        }
+
+        // "1.8.0_502" means Java 8; anything else already leads with its major.
+        if (first == 1)
+        {
+            var second = System.Text.RegularExpressions.Regex.Match(value, @"1\.(\d+)");
+            return second.Success && int.TryParse(second.Groups[1].Value, out var legacy) ? legacy : null;
+        }
+
+        return first;
+    }
+
     private static Dictionary<string, string> TryReadProperties(string path)
     {
         var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO.Compression;
 using System.Security;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -52,8 +53,9 @@ public class ServerService : IServerService
 
     /// <summary>
     /// Returns the Java binary path appropriate for the given Minecraft version.
-    /// MC 1.26+ requires Java 25, 1.21-1.25 requires Java 21,
-    /// 1.17-1.20 requires Java 17 (falls back to 21), older requires Java 8.
+    /// MC 1.26+ needs Java 25, 1.21-1.25 needs 21, 1.17-1.20 needs 17, older needs 8.
+    /// Each tier accepts newer runtimes when its exact match is not installed, so a jar
+    /// that raises its floor keeps starting instead of failing to load.
     /// </summary>
     public static string ResolveJavaBinary(string? minecraftVersion)
     {
@@ -67,13 +69,17 @@ public class ServerService : IServerService
 
         // New versioning: 26.x+ (Minecraft dropped the "1." prefix)
         if (major >= 26)
-            return FindJavaBinary(25, 21);
+            return FindJavaBinary(JavaFallbackOrder(25));
 
         // Old versioning: 1.x.y
         if (major == 1 && parts.Length >= 2 && int.TryParse(parts[1], out var minor))
         {
-            if (minor >= 21) return FindJavaBinary(21);
-            if (minor >= 17) return FindJavaBinary(21, 17); // 17 preferred, 21 fallback
+            if (minor >= 21) return FindJavaBinary(JavaFallbackOrder(21));
+            if (minor >= 17) return FindJavaBinary(JavaFallbackOrder(17));
+
+            // No upward fallback below 17: legacy Minecraft genuinely breaks on modern
+            // JVMs (removed internals, stricter reflection), so a newer runtime is not a
+            // safe substitute the way it is for 17+.
             return FindJavaBinary(8);
         }
 
@@ -102,6 +108,120 @@ public class ServerService : IServerService
         }
 
         return "java"; // Fallback to PATH default
+    }
+
+    // Java majors we know how to look for on disk, ascending.
+    private static readonly int[] KnownJavaMajors = { 8, 11, 17, 21, 25 };
+
+    /// <summary>
+    /// Candidate Java majors for a jar needing <paramref name="required"/>: the exact
+    /// match first, then progressively newer runtimes, since a jar always loads on a
+    /// newer JVM than it was compiled for.
+    /// </summary>
+    private static int[] JavaFallbackOrder(int required) =>
+        new[] { required }
+            .Concat(KnownJavaMajors.Where(v => v > required))
+            .Distinct()
+            .ToArray();
+
+    /// <summary>
+    /// Reads the class file version of a jar's Main-Class and converts it to the minimum
+    /// Java major version needed to load it (class file 61 = Java 17, 65 = 21, 69 = 25).
+    /// Returns null when the jar cannot be inspected, so callers can fall back to a
+    /// version heuristic.
+    /// </summary>
+    public static int? DetectRequiredJavaFromJar(string jarPath)
+    {
+        try
+        {
+            if (!File.Exists(jarPath))
+                return null;
+
+            using var archive = ZipFile.OpenRead(jarPath);
+
+            var manifestEntry = archive.GetEntry("META-INF/MANIFEST.MF");
+            if (manifestEntry is null)
+                return null;
+
+            string manifest;
+            using (var reader = new StreamReader(manifestEntry.Open()))
+                manifest = reader.ReadToEnd();
+
+            // Manifest values wrap at 72 bytes and continue on a line starting with a
+            // single space; unfold before matching or Main-Class comes back truncated.
+            manifest = manifest.Replace("\r\n ", "").Replace("\n ", "").Replace("\r ", "");
+
+            var match = System.Text.RegularExpressions.Regex.Match(manifest, @"Main-Class:\s*(\S+)");
+            if (!match.Success)
+                return null;
+
+            var classEntry = archive.GetEntry(match.Groups[1].Value.Replace('.', '/') + ".class");
+            if (classEntry is null)
+                return null;
+
+            using var stream = classEntry.Open();
+            var header = new byte[8];
+            var read = 0;
+            while (read < header.Length)
+            {
+                var n = stream.Read(header, read, header.Length - read);
+                if (n <= 0)
+                    return null;
+                read += n;
+            }
+
+            // u4 magic 0xCAFEBABE, u2 minor_version, u2 major_version
+            if (header[0] != 0xCA || header[1] != 0xFE || header[2] != 0xBA || header[3] != 0xBE)
+                return null;
+
+            var classFileVersion = (header[6] << 8) | header[7];
+            if (classFileVersion < 45)
+                return null;
+
+            return classFileVersion - 44;
+        }
+        catch
+        {
+            // Unreadable, truncated, or not a zip - let the caller fall back.
+            return null;
+        }
+    }
+
+    // Velocity has required at least Java 17 since 3.0.0, so never resolve below it.
+    private const int ProxyJavaFloor = 17;
+
+    /// <summary>
+    /// Resolves a Java binary from the jar's own bytecode target, tracking upstream
+    /// automatically when a jar bumps its requirement. Returns null when the jar cannot
+    /// be inspected.
+    /// </summary>
+    /// <remarks>
+    /// PROXIES ONLY. This reads the class file version of the jar's Main-Class, which is
+    /// only meaningful when Main-Class is the real entry point - true for Velocity and
+    /// BungeeCord. Paper and Fabric server jars are bootstrap launchers whose Main-Class
+    /// (io.papermc.paperclip.Main, net.fabricmc.installer.ServerLauncher) is deliberately
+    /// compiled to an ancient target so it can print a friendly error on old JVMs: Paper
+    /// 1.21.11 reports class file 50 (Java 6) and Fabric reports 52 (Java 8), nowhere near
+    /// what the server actually needs. Java servers keep using the MC-version heuristic.
+    /// </remarks>
+    private string? ResolveJavaBinaryFromJar(string serverPath, string? jarFile, string serverName)
+    {
+        // Forge @argfile syntax points at argument files, not a jar we can read.
+        if (string.IsNullOrWhiteSpace(jarFile) || jarFile.TrimStart().StartsWith("@"))
+            return null;
+
+        var detected = DetectRequiredJavaFromJar(Path.Combine(serverPath, jarFile));
+        if (detected is null)
+            return null;
+
+        // Guard against a future bootstrap-style Main-Class dragging the choice down.
+        var required = Math.Max(detected.Value, ProxyJavaFloor);
+
+        var javaBinary = FindJavaBinary(JavaFallbackOrder(required));
+        _logger.LogInformation(
+            "Resolved Java binary for proxy {Server} from {JarFile} bytecode (needs Java {Required}): {JavaBinary}",
+            serverName, jarFile, required, javaBinary);
+        return javaBinary;
     }
 
     private string GetPropertiesPath(string name) =>
@@ -710,18 +830,28 @@ public class ServerService : IServerService
 
             // Read server config to build start arguments
             var config = await GetServerConfigAsync(name, cancellationToken);
-            var javaBinary = config.Java.JavaBinary;
+            string? javaBinary = config.Java.JavaBinary;
+            var jarFile = config.Java.JarFile;
             if (string.IsNullOrEmpty(javaBinary) || javaBinary == "java")
             {
                 if (isProxy)
                 {
-                    // Velocity requires Java 21+. The auto-detector keys off MC version,
-                    // but proxy jars have no MC version — pin to Java 21.
-                    javaBinary = ResolveJavaBinary("1.21");
-                    _logger.LogInformation("Resolved Java 21 binary for proxy {Server}: {JavaBinary}",
+                    // Proxy jars carry no MC version, so read the requirement off the jar
+                    // itself. Velocity's Main-Class IS the proxy, and its bytecode target
+                    // moves between releases: 3.4.0 targets Java 17, 3.5.1 targets 21,
+                    // 4.x targets 25. Anything pinned to one number breaks the others.
+                    javaBinary = ResolveJavaBinaryFromJar(serverPath, jarFile, name);
+                }
+
+                if (string.IsNullOrEmpty(javaBinary) && isProxy)
+                {
+                    // Unreadable jar: Java 21 has been the Velocity floor since 3.5.0,
+                    // and newer runtimes are accepted when 21 is absent.
+                    javaBinary = FindJavaBinary(JavaFallbackOrder(21));
+                    _logger.LogInformation("Fell back to Java 21+ binary for proxy {Server}: {JavaBinary}",
                         name, javaBinary);
                 }
-                else
+                else if (string.IsNullOrEmpty(javaBinary))
                 {
                     // Auto-detect Java version from the server's Minecraft version
                     string? mcVersion = null;
@@ -745,7 +875,6 @@ public class ServerService : IServerService
                         name, mcVersion ?? "unknown", javaBinary);
                 }
             }
-            var jarFile = config.Java.JarFile;
 
             _logger.LogInformation(
                 "Server config for {ServerName}: javaBinary={JavaBinary} jarFile={JarFile} xmx={Xmx} xms={Xms}",

--- a/apps/MineOS.Tests/Unit/JavaBinaryDetectionTests.cs
+++ b/apps/MineOS.Tests/Unit/JavaBinaryDetectionTests.cs
@@ -1,0 +1,148 @@
+using System.IO.Compression;
+using System.Text;
+using MineOS.Infrastructure.Services;
+
+namespace MineOS.Tests.Unit;
+
+/// <summary>
+/// Covers ServerService.DetectRequiredJavaFromJar, which answers "which Java major
+/// does this jar need?" by reading the class file version of its Main-Class.
+///
+/// This exists because proxies were pinned to Java 21 on the reasoning that Velocity
+/// required 21+. Velocity's bytecode target then moved: 3.4.0 targets Java 17, 3.5.1
+/// targets 21, and 4.x targets 25. A 4.x proxy launched on the pinned Java 21 dies
+/// before main() with UnsupportedClassVersionError (class file 69 vs 65), which is
+/// what happened once Velocity 4.x reached the top of the profile list.
+/// </summary>
+public class JavaBinaryDetectionTests
+{
+    // class file major = Java major + 44: 61 = Java 17, 65 = 21, 69 = 25.
+    [Theory]
+    [InlineData(61, 17)]
+    [InlineData(65, 21)]
+    [InlineData(69, 25)]
+    [InlineData(52, 8)]
+    public void ReadsJavaMajorFromMainClassBytecode(int classFileVersion, int expectedJava)
+    {
+        var jar = WriteJar("com.example.Main", classFileVersion);
+        try
+        {
+            Assert.Equal(expectedJava, ServerService.DetectRequiredJavaFromJar(jar));
+        }
+        finally
+        {
+            File.Delete(jar);
+        }
+    }
+
+    [Fact]
+    public void UnfoldsManifestContinuationLines()
+    {
+        // Manifest values wrap at 72 bytes onto a line starting with one space. Without
+        // unfolding, Main-Class comes back truncated and the class entry is never found.
+        var main = "com.velocitypowered.proxy.bootstrap.SomeVeryLongEntryPointClassName";
+        var jar = WriteJar(main, 69, foldManifestAt: 40);
+        try
+        {
+            Assert.Equal(25, ServerService.DetectRequiredJavaFromJar(jar));
+        }
+        finally
+        {
+            File.Delete(jar);
+        }
+    }
+
+    [Fact]
+    public void ReturnsNullWhenJarIsMissing()
+    {
+        Assert.Null(ServerService.DetectRequiredJavaFromJar("/nonexistent/velocity.jar"));
+    }
+
+    [Fact]
+    public void ReturnsNullWhenFileIsNotAZip()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".jar");
+        File.WriteAllText(path, "not a jar");
+        try
+        {
+            Assert.Null(ServerService.DetectRequiredJavaFromJar(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ReturnsNullWhenManifestHasNoMainClass()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".jar");
+        using (var archive = ZipFile.Open(path, ZipArchiveMode.Create))
+        using (var writer = new StreamWriter(archive.CreateEntry("META-INF/MANIFEST.MF").Open()))
+            writer.Write("Manifest-Version: 1.0\r\n\r\n");
+        try
+        {
+            Assert.Null(ServerService.DetectRequiredJavaFromJar(path));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ReturnsNullWhenMainClassIsNotAClassFile()
+    {
+        // No 0xCAFEBABE magic: refuse to guess rather than return a bogus major.
+        var jar = WriteJar("com.example.Main", classFileVersion: 69, corruptMagic: true);
+        try
+        {
+            Assert.Null(ServerService.DetectRequiredJavaFromJar(jar));
+        }
+        finally
+        {
+            File.Delete(jar);
+        }
+    }
+
+    /// <summary>Builds a minimal jar with a Main-Class stub at the given class file version.</summary>
+    private static string WriteJar(
+        string mainClass,
+        int classFileVersion,
+        int? foldManifestAt = null,
+        bool corruptMagic = false)
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".jar");
+
+        var value = $"Main-Class: {mainClass}";
+        var manifest = new StringBuilder("Manifest-Version: 1.0\r\n");
+        if (foldManifestAt is { } width && value.Length > width)
+        {
+            manifest.Append(value[..width]).Append("\r\n");
+            for (var i = width; i < value.Length; i += width - 1)
+                manifest.Append(' ').Append(value.Substring(i, Math.Min(width - 1, value.Length - i))).Append("\r\n");
+        }
+        else
+        {
+            manifest.Append(value).Append("\r\n");
+        }
+        manifest.Append("\r\n");
+
+        using var archive = ZipFile.Open(path, ZipArchiveMode.Create);
+
+        using (var writer = new StreamWriter(archive.CreateEntry("META-INF/MANIFEST.MF").Open()))
+            writer.Write(manifest.ToString());
+
+        // u4 magic, u2 minor_version, u2 major_version - all the detector reads.
+        var header = new byte[]
+        {
+            corruptMagic ? (byte)0x00 : (byte)0xCA, 0xFE, 0xBA, 0xBE,
+            0x00, 0x00,
+            (byte)(classFileVersion >> 8), (byte)(classFileVersion & 0xFF)
+        };
+        using (var stream = archive.CreateEntry(mainClass.Replace('.', '/') + ".class").Open())
+            stream.Write(header, 0, header.Length);
+
+        return path;
+    }
+}

--- a/apps/MineOS.Tests/Unit/JavaRuntimeListingTests.cs
+++ b/apps/MineOS.Tests/Unit/JavaRuntimeListingTests.cs
@@ -1,0 +1,34 @@
+using MineOS.Infrastructure.Services;
+
+namespace MineOS.Tests.Unit;
+
+/// <summary>
+/// Covers HostService.ParseJavaMajor, which turns a JDK's reported version or its
+/// install directory name into a Java major for the Java Binary picker's labels.
+///
+/// The awkward case is Java 8, which reports itself as "1.8.0_502": the leading 1 is
+/// the old product version, so the major is the second component. Every other release
+/// since Java 9 leads with its major.
+/// </summary>
+public class JavaRuntimeListingTests
+{
+    [Theory]
+    // JAVA_VERSION as written in a JDK's release file.
+    [InlineData("25.0.4", 25)]
+    [InlineData("21.0.12", 21)]
+    [InlineData("17.0.9", 17)]
+    [InlineData("1.8.0_502", 8)]
+    // Directory names, used when the release file is missing or unreadable.
+    [InlineData("temurin-25-jdk-arm64", 25)]
+    [InlineData("temurin-21-jdk-amd64", 21)]
+    [InlineData("temurin-8-jre-arm64", 8)]
+    [InlineData("java-17-openjdk-amd64", 17)]
+    // Nothing usable: label falls back to the directory name rather than inventing one.
+    [InlineData("openjdk", null)]
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    public void ParsesJavaMajor(string? value, int? expected)
+    {
+        Assert.Equal(expected, HostService.ParseJavaMajor(value));
+    }
+}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -4,6 +4,7 @@ import type {
 	ServerSummary,
 	Profile,
 	ArchiveEntry,
+	JavaRuntime,
 	MineOSMeta,
 	CurseForgeSearchResult,
 	CurseForgeMod
@@ -97,6 +98,10 @@ export function getHostServers(fetcher: Fetcher) {
 
 export function getHostProfiles(fetcher: Fetcher) {
 	return apiFetch<Profile[]>(fetcher, '/api/host/profiles');
+}
+
+export function getHostJavaRuntimes(fetcher: Fetcher) {
+	return apiFetch<JavaRuntime[]>(fetcher, '/api/host/java-runtimes');
 }
 
 export function getHostImports(fetcher: Fetcher) {

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -139,6 +139,15 @@ export type BungeeConfig = {
 	servers: Record<string, BungeeBackend>;
 };
 
+/** A Java runtime installed on the host, as offered in the Java Binary field. */
+export type JavaRuntime = {
+	path: string;
+	major: number | null;
+	version: string;
+	label: string;
+	isDefault: boolean;
+};
+
 export type JavaConfig = {
 	javaBinary: string;
 	javaXmx: number;

--- a/apps/web/src/lib/components/server/JavaConfigPanel.svelte
+++ b/apps/web/src/lib/components/server/JavaConfigPanel.svelte
@@ -54,6 +54,16 @@
 
 	let loading = $state(false);
 	let selectedProfile = $state(config.minecraft.profile ?? '');
+
+	// Suggestions for the Java Binary field, read from the host at load time. Empty if
+	// the lookup failed - the field stays free text, so a blank list is not an error.
+	const javaRuntimes = $derived(data.javaRuntimes?.data ?? []);
+	const javaRuntimeLabels = $derived(
+		javaRuntimes
+			.filter((runtime) => !runtime.isDefault)
+			.map((runtime) => runtime.label)
+			.join(', ')
+	);
 	let lastServerName = data.serverName;
 
 	const javaTweaksPresets = [
@@ -214,13 +224,14 @@
 								list="java-binary-options"
 							/>
 							<datalist id="java-binary-options">
-								<option value="java"></option>
-								<option value="/usr/lib/jvm/temurin-8-jre/bin/java"></option>
-								<option value="/usr/lib/jvm/java-17-openjdk-amd64/bin/java"></option>
-								<option value="/usr/lib/jvm/temurin-21-jre/bin/java"></option>
+								{#each javaRuntimes as runtime (runtime.path)}
+									<option value={runtime.path} label={runtime.label}></option>
+								{/each}
 							</datalist>
 							<p class="field-hint">
-								Use <code>java</code> for the default runtime or set a full path to target Java 8/17/21.
+								Leave blank to let MineOS pick a runtime that matches the jar. Set a full path
+								only to override it.{#if javaRuntimeLabels}
+									Installed: {javaRuntimeLabels}.{/if}
 							</p>
 						</div>
 

--- a/apps/web/src/lib/loads/javaConfig.ts
+++ b/apps/web/src/lib/loads/javaConfig.ts
@@ -1,4 +1,9 @@
-import { getHostProfiles, getServerConfig, updateServerConfig } from '$lib/api/client';
+import {
+	getHostJavaRuntimes,
+	getHostProfiles,
+	getServerConfig,
+	updateServerConfig
+} from '$lib/api/client';
 import { fail } from '@sveltejs/kit';
 
 type LoadEvent = { params: { name: string }; fetch: typeof globalThis.fetch };
@@ -12,6 +17,9 @@ type ActionEvent = LoadEvent & { request: Request };
 export async function loadJavaConfig({ params, fetch }: LoadEvent) {
 	const config = await getServerConfig(fetch, params.name);
 	const profiles = await getHostProfiles(fetch);
+	// Offered as suggestions in the Java Binary field. Read from the host rather than
+	// hardcoded, so newly installed runtimes show up and removed ones stop being offered.
+	const javaRuntimes = await getHostJavaRuntimes(fetch);
 	let jarFiles: string[] = [];
 	let forgeArgFiles: string[] = [];
 	let jarFilesError: string | null = null;
@@ -58,6 +66,7 @@ export async function loadJavaConfig({ params, fetch }: LoadEvent) {
 	return {
 		config,
 		profiles,
+		javaRuntimes,
 		serverName: params.name,
 		jarFiles: {
 			data: jarFiles,

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -66,13 +66,16 @@ The API container includes the following Minecraft server management dependencie
 - **tar**: For compressed archive creation (.tar.gz)
 - **screen**: For managing server processes
 - **rsync**: For file synchronization (used in Phase 4 profiles)
-- **openjdk-17-jre-headless**: Default Java runtime
-- **temurin-21-jre**: Modern Java runtime (Paper 1.21+)
+- **temurin-25-jdk**: Default Java runtime (`JAVA_HOME`); required by Velocity 4.x
+- **temurin-21-jdk**: Paper 1.21+ and Velocity 3.5.x
 - **temurin-8-jre**: Legacy Java 8 support
 
 ## Tips
 
 - Need a shell in the other service? Use `Dev Containers: Attach to Running Container...`
 - If port 5173 or 5078 is in use, update `.devcontainer/docker-compose.yml` and re-open.
-- To target a specific runtime, set `java_binary` in the server config (or the Advanced page) to a full path
-  like `/usr/lib/jvm/temurin-21-jre/bin/java` or `/usr/lib/jvm/temurin-8-jre/bin/java`.
+- Leave `java_binary` blank and MineOS picks a runtime for you: proxies from the jar's own bytecode
+  target, game servers from the Minecraft version. Set it only to override that choice.
+- To target a specific runtime, set `java_binary` in the server config (or the Advanced page) to a full
+  path. The Java Binary field suggests what is actually installed, read from the host at page load;
+  paths are arch-suffixed, e.g. `/usr/lib/jvm/temurin-25-jdk-arm64/bin/java`.


### PR DESCRIPTION
## The bug

Velocity 4.x proxies restart-loop and never start:

```
Error: LinkageError occurred while loading main class com.velocitypowered.proxy.Velocity
java.lang.UnsupportedClassVersionError: com/velocitypowered/proxy/Velocity has been compiled
by a more recent version of the Java Runtime (class file version 69.0), this version of the
Java Runtime only recognizes class file versions up to 65.0
```

`ServerService` pinned proxies to Java 21, with a comment explaining why:

```csharp
// Velocity requires Java 21+. The auto-detector keys off MC version,
// but proxy jars have no MC version — pin to Java 21.
javaBinary = ResolveJavaBinary("1.21");
```

That was correct when written. It stopped being correct when Velocity's bytecode target moved:

| Velocity | class file | requires |
|---|---|---|
| 3.4.0-566 | 61 | Java 17 |
| 3.5.1-615 | 65 | Java 21 |
| 4.1.0-22 | **69** | **Java 25** |

`ProfileService` lists proxy versions live from `fill.papermc.io` and takes `builds/latest` per version, so 4.x now sits at the top of the picker. Velocity 4.0.0 released 2026-07-14 and 4.1.0 on 2026-08-24. Anyone creating a proxy since then got Java 25 bytecode handed a Java 21 runtime. Installs whose proxy jar predates 4.x kept working, which is why this looks like an upgrade-only failure — the variable is the jar on disk, not the MineOS version.

The image has shipped `temurin-25-jdk` all along (`JAVA_HOME` and `/usr/bin/java` both point at it). Nothing could select it: the launcher passes an absolute path, and the UI's Java Binary field offered four hardcoded paths, three of which name amd64/JRE directories that do not exist on an arm64 JDK image.

## The fix

Read the required version off the jar's own `Main-Class` bytecode. Exact, and it tracks upstream with no config migration — every `server.config` has `java_binary=` empty, so resolution runs fresh on each start. Ship the image and existing proxies pick the right JVM with zero user action.

**Proxies only.** Paper and Fabric server jars are bootstrap launchers whose `Main-Class` is deliberately compiled to an ancient target so it can print a readable error on an old JVM:

```
fabric-server-mc.1.21.1-loader.0.19.3.jar -> Java 8   (net.fabricmc.installer.ServerLauncher)
paper-1.21.11-132.jar                     -> Java 6   (io.papermc.paperclip.Main)
velocity-4.1.0-22.jar                     -> Java 25  (com.velocitypowered.proxy.Velocity)
```

Applying detection to those would have downgraded every game server, so they keep using the Minecraft version. A Java 17 floor guards the proxy path in case Velocity ever adopts a bootstrap too. The reasoning is in a `<remarks>` block on the method so it does not get simplified back out.

Also: each version tier now accepts newer runtimes when its exact match is absent, instead of falling through to whatever `java` is on `PATH`. Below Java 17 the exact match is still required — legacy Minecraft genuinely breaks on modern JVMs.

## Second commit: the picker reads the host

New `GET /api/v1/host/java-runtimes` scans `/usr/lib/jvm` and reads `JAVA_VERSION` from each runtime's `release` file. The field is populated from it instead of a static list that drifted from the image:

```
java                                        Default (java on PATH)
/usr/lib/jvm/temurin-25-jdk-arm64/bin/java  Java 25 (25.0.4)
/usr/lib/jvm/temurin-21-jdk-arm64/bin/java  Java 21 (21.0.12)
/usr/lib/jvm/temurin-8-jre-arm64/bin/java   Java 8 (1.8.0_502)
```

Java 8 reports `1.8.0_502` — the leading `1` is the old product version, so the major is the second component. That case has tests. `docs/devcontainer.md` had the same stale paths and is corrected.

## Verification

Built the API image from this branch and ran it against a scratch instance with the failing jar:

```
INF Resolved Java binary for proxy proxytest from velocity-4.1.0-22.jar
    bytecode (needs Java 25): /usr/lib/jvm/temurin-25-jdk-arm64/bin/java
[INFO]: Listening on /[0:0:0:0:0:0:0:0]:25565
[INFO]: Done (0.41s)!
```

Paper regression check on the same instance, confirming the proxies-only scoping:

```
INF Auto-resolved Java binary for papertest (MC 1.21.11): .../temurin-21-jdk-arm64/bin/java
[bootstrap] Running Java 21 (OpenJDK 64-Bit Server VM 21.0.12+8 ...)
```

Java 21, not the Java 6 its paperclip bootstrap reports. No `UnsupportedClassVersionError` in either log.

- `dotnet test mineos-sveltkit.sln` — **181 passing**, 0 failed (20 new: bytecode detection incl. folded manifests, missing/non-zip/bad-magic jars; version parsing incl. the `1.8.0_502` form)
- `npm run test:unit` — 84 passing
- `npm run check` — 0 errors
- `npm run build` — clean