### PR TITLE
fix(servers): stop concurrent start requests launching a server twice

### DIFF
--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Security;
@@ -757,7 +758,53 @@ public class ServerService : IServerService
         );
     }
 
+    /// <summary>
+    /// Serializes starts per server. Entries are keyed by server name and never removed:
+    /// a SemaphoreSlim is a few dozen bytes and the set is bounded by how many servers
+    /// have ever been started, which is far cheaper than the alternative of disposing a
+    /// gate somebody is currently holding.
+    /// </summary>
+    /// <remarks>
+    /// Static on purpose. IServerService is registered scoped, so every caller that can
+    /// race here - the start endpoint, WatchdogService, StartupServerService and
+    /// CronSchedulerService - resolves its own ServerService instance. A per-instance
+    /// gate would be uncontended and would serialize nothing.
+    /// </remarks>
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> StartGates =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Starts a server, refusing if it is already running.
+    /// </summary>
+    /// <remarks>
+    /// The whole body runs under a per-server gate because the "already running" check is
+    /// a check-then-act. A freshly launched screen session does not appear in the process
+    /// table instantly, and the work between the check and the launch is not trivial - it
+    /// reads server.config, resolves a Java binary (which opens and inspects the jar) and
+    /// chowns the log directory. Two callers arriving inside that window both saw "not
+    /// running" and both launched. On a proxy the loser dies with EADDRINUSE, which is
+    /// noisy but harmless; on a game server it means two JVMs writing one world directory,
+    /// which is how region files get corrupted.
+    ///
+    /// The gate is held through VerifyServerStartedAsync, not just the launch, so it is
+    /// released only once the process is actually observable. Releasing at the screen call
+    /// would reopen the same window a few hundred milliseconds later.
+    /// </remarks>
     public async Task StartServerAsync(string name, CancellationToken cancellationToken)
+    {
+        var gate = StartGates.GetOrAdd(name, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken);
+        try
+        {
+            await StartServerCoreAsync(name, cancellationToken);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private async Task StartServerCoreAsync(string name, CancellationToken cancellationToken)
     {
         _logger.LogInformation("StartServerAsync requested for {ServerName}", name);
         var isRunning = await _processManager.IsServerRunningAsync(name, cancellationToken);
@@ -1020,6 +1067,14 @@ public class ServerService : IServerService
         throw new TimeoutException($"Server '{name}' did not stop within {timeoutSeconds} seconds");
     }
 
+    /// <summary>
+    /// Stops a server and starts it again.
+    /// </summary>
+    /// <remarks>
+    /// Must not take the start gate itself. It composes StartServerAsync, which takes the
+    /// gate, and SemaphoreSlim is not reentrant - holding it here would deadlock against
+    /// the call below.
+    /// </remarks>
     public async Task RestartServerAsync(string name, CancellationToken cancellationToken)
     {
         await StopServerAsync(name, 300, cancellationToken);

--- a/apps/MineOS.Tests/Unit/ServerStartConcurrencyTests.cs
+++ b/apps/MineOS.Tests/Unit/ServerStartConcurrencyTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MineOS.Application.Interfaces;
+using MineOS.Application.Options;
+using MineOS.Infrastructure.Services;
+using Moq;
+
+namespace MineOS.Tests.Unit;
+
+/// <summary>
+/// Covers the per-server gate around ServerService.StartServerAsync.
+///
+/// The "is it already running?" guard is a check-then-act. A freshly launched screen
+/// session does not appear in the process table instantly, and the work between the
+/// check and the launch is not trivial, so two callers arriving inside that window
+/// both saw "not running" and both launched. Four callers can race: the start
+/// endpoint, WatchdogService, StartupServerService and CronSchedulerService.
+///
+/// Observed in the wild as two "Launching Serverloco" stamps 9ms apart, the second
+/// Velocity instance dying with EADDRINUSE on a port its own twin had taken. On a
+/// game server the same race puts two JVMs on one world directory.
+///
+/// These tests assert on the ordering of the running-check itself rather than on a
+/// launch, so they do not need `screen` on PATH: both calls fail after the check, and
+/// what matters is that the second never enters while the first is still inside.
+/// </summary>
+public class ServerStartConcurrencyTests
+{
+    [Fact]
+    public async Task SecondStartWaitsWhileTheFirstIsStillChecking()
+    {
+        var firstEntered = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+        var entries = 0;
+
+        var processManager = new Mock<IProcessManager>();
+        processManager
+            .Setup(m => m.IsServerRunningAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                if (Interlocked.Increment(ref entries) == 1)
+                {
+                    firstEntered.SetResult();
+                    await release.Task;
+                }
+                return false;
+            });
+
+        var service = CreateService(processManager.Object);
+
+        // Unique name: the gate is static and keyed by server name.
+        const string name = "gate-test-waits";
+        var first = Swallow(service.StartServerAsync(name, CancellationToken.None));
+        await firstEntered.Task;
+
+        var second = Swallow(service.StartServerAsync(name, CancellationToken.None));
+
+        // The first caller is parked inside the guard. Without the gate the second
+        // would sail into the same check and both would go on to launch.
+        await Task.Delay(100);
+        Assert.Equal(1, Volatile.Read(ref entries));
+
+        release.SetResult();
+        await Task.WhenAll(first, second);
+        Assert.Equal(2, Volatile.Read(ref entries));
+    }
+
+    [Fact]
+    public async Task DifferentServersAreNotBlockedByEachOther()
+    {
+        // The gate is per server: one slow start must not stall every other server.
+        var firstEntered = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+        var otherEntered = new TaskCompletionSource();
+
+        var processManager = new Mock<IProcessManager>();
+        processManager
+            .Setup(m => m.IsServerRunningAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string server, CancellationToken _) =>
+            {
+                if (server == "gate-test-slow")
+                {
+                    firstEntered.SetResult();
+                    await release.Task;
+                }
+                else
+                {
+                    otherEntered.TrySetResult();
+                }
+                return false;
+            });
+
+        var service = CreateService(processManager.Object);
+
+        var slow = Swallow(service.StartServerAsync("gate-test-slow", CancellationToken.None));
+        await firstEntered.Task;
+
+        var other = Swallow(service.StartServerAsync("gate-test-other", CancellationToken.None));
+
+        // Completes while the slow server is still holding its own gate.
+        await otherEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        release.SetResult();
+        await Task.WhenAll(slow, other);
+    }
+
+    /// <summary>
+    /// The calls fail once past the guard - no server directory, no screen on PATH.
+    /// Only the ordering of the guard itself is under test.
+    /// </summary>
+    private static async Task Swallow(Task task)
+    {
+        try
+        {
+            await task;
+        }
+        catch
+        {
+            // Expected.
+        }
+    }
+
+    private static ServerService CreateService(IProcessManager processManager)
+    {
+        var options = Options.Create(new HostOptions
+        {
+            BaseDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName())
+        });
+
+        return new ServerService(
+            processManager,
+            options,
+            NullLogger<ServerService>.Instance,
+            Mock.Of<ITelemetryService>(),
+            Mock.Of<ITelemetryReportTrigger>());
+    }
+}


### PR DESCRIPTION
## The bug

Reported from a live instance — two launches 9ms apart, the second Velocity dying on a port its own twin had just taken:

```
[2026-08-25T00:58:10.3938345+00:00] Launching Serverloco
[2026-08-25T00:58:10.3847225+00:00] Launching Serverloco
...
[00:58:12 INFO]: Listening on /[0:0:0:0:0:0:0:0]:25565
[00:58:12 INFO]: Done (0.91s)!
[00:58:12 ERROR]: Can't bind to /0.0.0.0:25565
io.netty.channel.unix.Errors$NativeIoException: bind(..) failed with error(-98): Address already in use
```

`StartServerAsync` guards with a check-then-act:

```csharp
var isRunning = await _processManager.IsServerRunningAsync(name, cancellationToken);
if (isRunning)
{
    throw new InvalidOperationException($"Server '{name}' is already running");
}
```

Nothing serializes the window between that check and the screen session becoming visible in the process table — and the window is not narrow, because the path in between reads `server.config`, resolves a Java binary (which now opens and inspects the jar), and creates and chowns the log directory. Two callers inside that window both pass the guard and both launch.

Four callers can race, and they don't coordinate — each resolves its own `ServerService`, since `IServerService` is registered scoped:

- `ServerEndpoints` — the API action
- `WatchdogService` — restarts what it believes has died
- `StartupServerService` — the `[onreboot] start` path
- `CronSchedulerService` — scheduled starts

In the reported case the watchdog almost certainly raced a manual start: the proxy *had* just crashed, so the watchdog moved at the same moment the user did.

## Reproduced against the published image

Four concurrent `POST /api/v1/servers/{name}/actions/start` on a Velocity proxy:

| | launch stamps | HTTP | EADDRINUSE |
|---|---|---|---|
| `ghcr.io/freeman412/mineos-api:preview` (beta.8) | **4** | 4× `200` | **6** |
| this branch | **1** | 1× `200`, 3× `409` | **0** |

Four JVMs, from four requests the API accepted without complaint.

## Why it matters more than the symptom suggests

On a proxy the loser prints a stack trace and exits — noisy, harmless. On a **game server** the same race puts two JVMs on one world directory. Two writers to the same region files is how worlds get corrupted, silently. The proxy symptom is the benign face of the bug.

## The fix

A per-server `SemaphoreSlim` held across the whole start.

- **Held through `VerifyServerStartedAsync`**, not just the launch. That method already polls up to 10s for the process to appear, so releasing at the `screen -dmS` call would reopen the same window a few hundred milliseconds later, when the second caller's check would still see nothing in the process table.
- **Static**, because `IServerService` is scoped — a per-instance gate would be uncontended and would serialize nothing. This is called out in the code, since it's the kind of thing that looks like a needless `static` later.
- **`RestartServerAsync` deliberately does not take it.** It composes `StopServerAsync` + `StartServerAsync`, and `SemaphoreSlim` is not reentrant, so holding it there would deadlock. Also called out in the code.
- Gate entries are keyed by name and never removed: a semaphore is a few dozen bytes, and the set is bounded by servers ever started — cheaper than the hazard of disposing a gate someone is holding.

## Tests

`ServerStartConcurrencyTests` — two tests asserting on the ordering of the running-check itself, so they need no `screen` on PATH:

1. a second start cannot enter the guard while the first is still inside it
2. a slow start on one server does not block a different server (the gate is per server, not global)

**Both were checked against a bypassed gate: test 1 fails without the fix** (2 entries where 1 is expected) and passes with it. It is a real regression test, not a vacuous one.

Full solution: **183 passing**, 0 failed.

## Not covered

The full launch path isn't exercised in tests — it shells out to `screen`, which isn't in the SDK container, and making the suite depend on it would be environment-dependent. That path is covered by the manual four-request reproduction above instead.

A start racing a **stop** is still unserialized; `StopServerAsync` doesn't take the gate. Deliberately out of scope: stop holds for up to 300s, so sharing the gate would make a start block that long, and it needs its own think. Filed here as a known gap rather than fixed silently.