### PR TITLE
fix: screen session names with spaces, and the proxy config editor wiping itself on save

### DIFF
--- a/apps/MineOS.Infrastructure/Services/ProcessManager.cs
+++ b/apps/MineOS.Infrastructure/Services/ProcessManager.cs
@@ -11,8 +11,7 @@ public partial class ProcessManager : IProcessManager
     private const string PROC_PATH = "/proc";
     private const string ScreenCommand = "screen";
 
-    [GeneratedRegex(@"screen[^S]+S mc-([^\s]+)", RegexOptions.IgnoreCase)]
-    private static partial Regex ScreenRegex();
+    private const string ScreenSessionPrefix = "mc-";
 
     // Matches the full argument when cmdline is split by \0
     [GeneratedRegex(@"^-Dmineos\.server=(.+)$", RegexOptions.IgnoreCase)]
@@ -25,6 +24,55 @@ public partial class ProcessManager : IProcessManager
     public ProcessManager(ILogger<ProcessManager> _logger)
     {
         this._logger = _logger;
+    }
+
+    /// <summary>
+    /// The MineOS server name of a screen session process, or null if this is not one.
+    /// </summary>
+    /// <remarks>
+    /// Reads the argument that follows screen's -S flag verbatim, rather than pattern
+    /// matching the command line. /proc gives arguments NUL-separated, and joining them
+    /// to run a regex over the result destroys the only argument boundary that exists -
+    /// which is why the previous "mc-([^\s]+)" registered a server named "Server Loco"
+    /// under "Server", leaving its real name looking permanently stopped.
+    ///
+    /// The session name follows any flag group ending in S: screen accepts both -S and
+    /// combined forms like -dmS. Lowercase -s is a different flag (shell) and is not
+    /// matched, which the case-sensitive check preserves.
+    ///
+    /// argv[0] must be screen itself. A detached session renames itself to SCREEN, hence
+    /// the case-insensitive compare. Requiring it also rejects the su process that
+    /// launched it, whose whole command sits in one -c argument and would otherwise be
+    /// scanned as though it were screen's own arguments.
+    /// </remarks>
+    public static string? TryGetScreenSessionName(IReadOnlyList<string> cmdlineArgs)
+    {
+        if (cmdlineArgs.Count < 3)
+        {
+            return null;
+        }
+
+        var program = Path.GetFileName(cmdlineArgs[0]);
+        if (!string.Equals(program, ScreenCommand, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        for (var i = 1; i < cmdlineArgs.Count - 1; i++)
+        {
+            var arg = cmdlineArgs[i];
+            if (arg.Length < 2 || arg[0] != '-' || !arg.EndsWith('S'))
+            {
+                continue;
+            }
+
+            var session = cmdlineArgs[i + 1];
+            return session.StartsWith(ScreenSessionPrefix, StringComparison.Ordinal)
+                ? session[ScreenSessionPrefix.Length..]
+                : null;
+        }
+
+        return null;
     }
 
     public Dictionary<string, ServerProcessInfo> GetServerProcesses()
@@ -53,18 +101,15 @@ public partial class ProcessManager : IProcessManager
                 var cmdlineRaw = File.ReadAllText(cmdlinePath);
                 // Split by null bytes to get individual arguments
                 var cmdlineArgs = cmdlineRaw.Split('\0', StringSplitOptions.RemoveEmptyEntries);
-                // Also create joined version for screen regex (which matches across args)
-                var cmdlineJoined = string.Join(" ", cmdlineArgs);
 
-                // Check for screen session (uses joined cmdline)
-                var screenMatch = ScreenRegex().Match(cmdlineJoined);
-                if (screenMatch.Success)
+                // Check for screen session
+                var screenSession = TryGetScreenSessionName(cmdlineArgs);
+                if (screenSession != null)
                 {
-                    var serverName = screenMatch.Groups[1].Value;
-                    if (!servers.ContainsKey(serverName))
-                        servers[serverName] = new ServerProcessInfo(null, null);
+                    if (!servers.ContainsKey(screenSession))
+                        servers[screenSession] = new ServerProcessInfo(null, null);
 
-                    servers[serverName] = servers[serverName] with { ScreenPid = int.Parse(pidStr) };
+                    servers[screenSession] = servers[screenSession] with { ScreenPid = int.Parse(pidStr) };
                     continue;
                 }
 

--- a/apps/MineOS.Tests/Unit/ScreenSessionNameTests.cs
+++ b/apps/MineOS.Tests/Unit/ScreenSessionNameTests.cs
@@ -1,0 +1,100 @@
+using MineOS.Infrastructure.Services;
+
+namespace MineOS.Tests.Unit;
+
+/// <summary>
+/// Covers ProcessManager.TryGetScreenSessionName, which answers "which MineOS server is
+/// this screen process running?" from a process's /proc cmdline arguments.
+///
+/// This exists because the previous implementation joined the NUL-separated arguments
+/// with spaces and matched "mc-([^\s]+)" over the result, which truncates at the first
+/// space. A server named "Server Loco" was recorded under "Server", so its own name
+/// never appeared in the process table: MineOS reported it stopped while it ran, and
+/// stop/kill looked for a screen PID filed under a server that does not exist.
+/// </summary>
+public class ScreenSessionNameTests
+{
+    [Fact]
+    public void ReadsASessionNameContainingSpaces()
+    {
+        // The regression: everything after the first space used to be discarded.
+        var args = new[] { "SCREEN", "-dmS", "mc-Server Loco", "bash", "-lc", "exec java -jar paper.jar" };
+        Assert.Equal("Server Loco", ProcessManager.TryGetScreenSessionName(args));
+    }
+
+    [Theory]
+    [InlineData("mc-serverloco", "serverloco")]
+    [InlineData("mc-Server Loco", "Server Loco")]
+    [InlineData("mc-my server with many spaces", "my server with many spaces")]
+    [InlineData("mc-hub", "hub")]
+    public void ReadsTheSessionNameVerbatim(string session, string expected)
+    {
+        var args = new[] { "SCREEN", "-dmS", session, "bash" };
+        Assert.Equal(expected, ProcessManager.TryGetScreenSessionName(args));
+    }
+
+    [Theory]
+    // A detached session renames itself to SCREEN; both spellings and a full path count.
+    [InlineData("SCREEN")]
+    [InlineData("screen")]
+    [InlineData("/usr/bin/screen")]
+    public void AcceptsHoweverScreenNamesItself(string program)
+    {
+        var args = new[] { program, "-dmS", "mc-hub", "bash" };
+        Assert.Equal("hub", ProcessManager.TryGetScreenSessionName(args));
+    }
+
+    [Theory]
+    // -S on its own, and combined flag groups ending in S.
+    [InlineData("-S")]
+    [InlineData("-dmS")]
+    [InlineData("-dS")]
+    public void FindsTheNameAfterAnyFlagGroupEndingInS(string flag)
+    {
+        var args = new[] { "screen", flag, "mc-hub", "bash" };
+        Assert.Equal("hub", ProcessManager.TryGetScreenSessionName(args));
+    }
+
+    [Fact]
+    public void IgnoresTheSuProcessThatLaunchedScreen()
+    {
+        // su carries the entire command in one -c argument. Scanning it as though the
+        // pieces were separate arguments would file a second, bogus PID for the server.
+        var args = new[]
+        {
+            "/bin/su", "-", "minecraft", "-c",
+            "screen -dmS 'mc-Server Loco' bash -lc 'exec java -jar paper.jar'"
+        };
+        Assert.Null(ProcessManager.TryGetScreenSessionName(args));
+    }
+
+    [Fact]
+    public void IgnoresScreenSessionsThatAreNotMineOsServers()
+    {
+        var args = new[] { "SCREEN", "-dmS", "my-own-session", "bash" };
+        Assert.Null(ProcessManager.TryGetScreenSessionName(args));
+    }
+
+    [Fact]
+    public void IgnoresLowercaseDashS()
+    {
+        // -s is screen's shell flag, not the session name.
+        var args = new[] { "screen", "-s", "mc-hub", "bash" };
+        Assert.Null(ProcessManager.TryGetScreenSessionName(args));
+    }
+
+    [Fact]
+    public void IgnoresEverythingElse()
+    {
+        Assert.Null(ProcessManager.TryGetScreenSessionName(new[] { "java", "-jar", "paper.jar" }));
+        Assert.Null(ProcessManager.TryGetScreenSessionName(new[] { "screen" }));
+        Assert.Null(ProcessManager.TryGetScreenSessionName(Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void IgnoresAFlagWithNoArgumentAfterIt()
+    {
+        var args = new[] { "screen", "-list", "-dmS" };
+        Assert.Null(ProcessManager.TryGetScreenSessionName(args));
+    }
+}

--- a/apps/web/src/routes/(app)/proxies/[name]/proxy-config/+page.svelte
+++ b/apps/web/src/routes/(app)/proxies/[name]/proxy-config/+page.svelte
@@ -65,6 +65,33 @@
 		}
 	});
 
+	// Backend names defined above, for the try-order and forced-host pickers. Derived so
+	// renaming a backend immediately re-offers it under its new name.
+	const backendNames = $derived(
+		serverEntries.map((e) => e.name.trim()).filter((n) => n.length > 0)
+	);
+
+	/**
+	 * Options for a picker whose current value may not (yet) be a defined backend —
+	 * a name typed before the backend existed, or one whose backend was renamed. Keeping
+	 * the stale value as an option means opening the page cannot silently rewrite config
+	 * that is already on disk.
+	 */
+	function optionsFor(current: string): string[] {
+		const value = current.trim();
+		return value.length > 0 && !backendNames.includes(value)
+			? [value, ...backendNames]
+			: backendNames;
+	}
+
+	/** Forced hosts are stored as a comma-separated string; the picker works in names. */
+	function splitServers(value: string): string[] {
+		return value
+			.split(',')
+			.map((s) => s.trim())
+			.filter((s) => s.length > 0);
+	}
+
 	function buildForcedHostsObject(): Record<string, string[]> {
 		const result: Record<string, string[]> = {};
 		for (const e of forcedHostEntries) {
@@ -196,7 +223,10 @@
 		use:enhance={() => {
 			saving = true;
 			return async ({ update }) => {
-				await update();
+				// reset: false — the default resets the form element, which blanks every
+				// dynamically rendered backend/try/forced-host row on a successful save.
+				// The values were written; the editor just erased itself in front of you.
+				await update({ reset: false });
 				await invalidateAll();
 				saving = false;
 				initial = JSON.parse(JSON.stringify(buildSubmitConfig()));
@@ -330,8 +360,7 @@
 				<button class="btn btn-secondary" type="button" onclick={addTry}>+ Add</button>
 			</div>
 			<p class="card-description">
-				Server names to try in order when a player joins or gets kicked from a backend. Names must
-				match entries above.
+				Backends to try in order when a player joins or gets kicked from a backend.
 			</p>
 			{#if tryList.length === 0}
 				<p class="empty">No try list configured.</p>
@@ -339,7 +368,12 @@
 				<div class="try-rows">
 					{#each tryList as name, i}
 						<div class="try-row">
-							<input type="text" placeholder="Backend name" bind:value={tryList[i]} />
+							<select bind:value={tryList[i]}>
+								<option value="">Select a backend…</option>
+								{#each optionsFor(name) as backend (backend)}
+									<option value={backend}>{backend}</option>
+								{/each}
+							</select>
 							<button
 								class="btn btn-icon"
 								type="button"
@@ -359,7 +393,7 @@
 			</div>
 			<p class="card-description">
 				Route players to specific backends based on the hostname they connect with.
-				Servers is a comma-separated list of backend names from above (tried in order).
+				Select one or more backends from above; they are tried in order.
 			</p>
 			{#if forcedHostEntries.length === 0}
 				<p class="empty">No forced hosts configured.</p>
@@ -372,11 +406,22 @@
 								placeholder="hostname (e.g. lobby.example.com)"
 								bind:value={entry.hostname}
 							/>
-							<input
-								type="text"
-								placeholder="servers (e.g. lobby, fallback)"
-								bind:value={entry.servers}
-							/>
+							<select
+								multiple
+								size={Math.min(Math.max(backendNames.length, 2), 5)}
+								value={splitServers(entry.servers)}
+								onchange={(event) => {
+									entry.servers = [...event.currentTarget.selectedOptions]
+										.map((option) => option.value)
+										.join(', ');
+								}}
+							>
+								{#each optionsFor(splitServers(entry.servers)[0] ?? '') as backend (backend)}
+									<option value={backend} selected={splitServers(entry.servers).includes(backend)}>
+										{backend}
+									</option>
+								{/each}
+							</select>
 							<button
 								class="btn btn-icon"
 								type="button"
@@ -587,7 +632,8 @@
 	}
 
 	.server-row input,
-	.try-row input {
+	.server-row select,
+	.try-row select {
 		padding: 0.35rem 0.55rem;
 		background: var(--input-bg, #1f2937);
 		border: 1px solid var(--border-color, #374151);


### PR DESCRIPTION
Two bugs found while debugging a live instance.

## 1. Server names containing a space break process detection

`ProcessManager.GetServerProcesses` joined the NUL-separated `/proc` cmdline arguments with spaces, then pattern-matched the result:

```csharp
[GeneratedRegex(@"screen[^S]+S mc-([^\s]+)", RegexOptions.IgnoreCase)]
```

`[^\s]+` truncates at the first space:

```
SCREEN -dmS mc-Server Loco bash ...   ->  "Server"
SCREEN -dmS mc-serverloco bash ...    ->  "serverloco"
```

Space-free names worked, which is why nobody noticed. For any other name the server was filed under a name that doesn't exist, so its own name never appeared in the process table: MineOS reports it stopped while it runs, and stop/kill hunt for a screen PID under a phantom server. An unreliable "is it running?" also feeds `WatchdogService`.

The Java-process branch immediately below already handled this and says so:

```csharp
// Check each argument individually to handle server names with spaces
```

So one of the two paths was fixed previously and the screen path was missed. This brings it in line: read the argument after screen's `-S` verbatim instead of pattern-matching a re-joined string. The arguments arrive already separated; joining them destroyed the only boundary that existed.

Requiring `argv[0]` to be screen also rejects the `su` process that launched it, whose entire command sits in one `-c` argument and would otherwise be scanned as if its pieces were screen's own arguments.

**Tests:** 16 cases — the space regression, `SCREEN`/`screen`/full path, `-S` and combined `-dmS`/`-dS`, the su false positive, non-MineOS sessions, lowercase `-s`, and malformed input. Verified the old regex genuinely produces `"Server"` for `mc-Server Loco`, so the headline test covers a real defect.

## 2. The proxy config editor wipes itself on save

Reported as "I added a forced host, saved, and it erased them" — then "it did save after I refreshed". Both are true: the write succeeded, the editor blanked.

```js
return async ({ update }) => {
    await update();          // defaults to reset: true
```

`update()` defaults to resetting the form element. Backends, try-order and forced hosts are all dynamically rendered rows, so a successful save blanked every one of them — indistinguishable from the save having failed. Two other pages in this repo already pass `{ reset: false }`:

```
JavaConfigPanel.svelte:205:              await update({ reset: false });
servers/[name]/config/+page.svelte:397:  await update({ reset: false });
```

Fixed the same way.

### Backend pickers

Also makes backend selection a picker instead of free text, which matches what the data is: try-order entries and forced-host targets must name a backend defined in the section above, and hand-typing them silently produces a config Velocity cannot route. Try order becomes a single select; forced hosts a multi-select over the same names.

A value that isn't a defined backend is preserved as an option rather than dropped — a backend renamed, or referenced before being added, would otherwise be silently rewritten just by opening the page.

## Not a bug: Velocity 4 and velocity.toml

I suspected Velocity 4.x's config migration was eating these entries. It isn't. Round-tripping a MineOS-written config through Velocity 4.1.0:

```diff
-config-version = "2.7"
+config-version = "2.8"
 [servers] / [forced-hosts]   unchanged
+[packet-limiter]             new section, defaults
```

`servers`, `try` and `forced-hosts` all survive. MineOS's round-trip writer is compatible with Velocity 4.

## Verification

- `dotnet test mineos-sveltkit.sln` — **195 passing**, 0 failed
- `npm run test:unit` — 84 passing
- `npm run check` — 0 errors, no new warnings
- `npm run build` — clean