### PR TITLE
fix(proxy): own the config directory created when securing a backend

### DIFF
--- a/apps/MineOS.Infrastructure/Services/ProxyForwardingService.cs
+++ b/apps/MineOS.Infrastructure/Services/ProxyForwardingService.cs
@@ -677,6 +677,33 @@ public class ProxyForwardingService : IProxyForwardingService
     }
 
     /// <summary>
+    /// <summary>
+    /// Creates a directory the server process must be able to write to, and makes sure it
+    /// is owned by the account the server runs as.
+    /// </summary>
+    /// <remarks>
+    /// Chowning only the file we write is not enough. This service runs as root inside the
+    /// API container while servers run as the unprivileged owner uid, so a directory it
+    /// creates is left root-owned and the server cannot create anything in it. Paper writes
+    /// paper-global.yml and paper-world-defaults.yml into config/ during startup: it fails
+    /// with AccessDeniedException, then dies on the missing world-defaults file it was
+    /// prevented from writing.
+    ///
+    /// This only bit brand-new servers secured before their first start, since a config/
+    /// left over from an earlier run already exists and is already owned correctly - which
+    /// is why it looked like an odd one-off rather than every proxy backend.
+    ///
+    /// The chown is unconditional rather than only-when-created, so an install already
+    /// holding a root-owned config/ repairs itself the next time forwarding is written.
+    /// </remarks>
+    private async Task EnsureOwnedDirectoryAsync(string directory, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(directory);
+        await OwnershipHelper.ChangeOwnershipAsync(
+            directory, _options.RunAsUid, _options.RunAsGid, _logger, cancellationToken);
+    }
+
+    /// <summary>
     /// Writes proxies.velocity into paper-global.yml, editing the existing tree in
     /// place. Paper's file carries well over a hundred keys we do not model, and
     /// regenerating it would silently discard every one of them.
@@ -685,7 +712,7 @@ public class ProxyForwardingService : IProxyForwardingService
         string serverName, string secret, CancellationToken cancellationToken)
     {
         var path = GetPaperGlobalPath(serverName);
-        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await EnsureOwnedDirectoryAsync(Path.GetDirectoryName(path)!, cancellationToken);
 
         var existingYaml = File.Exists(path)
             ? await File.ReadAllTextAsync(path, cancellationToken)
@@ -745,7 +772,7 @@ public class ProxyForwardingService : IProxyForwardingService
             model["hackOnlineMode"] = true;
         }
 
-        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await EnsureOwnedDirectoryAsync(Path.GetDirectoryName(path)!, cancellationToken);
         await File.WriteAllTextAsync(path, Toml.FromModel(model), cancellationToken);
         TryRestrictPermissions(path);
         await OwnershipHelper.ChangeOwnershipAsync(path, _options.RunAsUid, _options.RunAsGid, _logger, cancellationToken);


### PR DESCRIPTION
Found on a live install: a brand-new Paper backend attached to a proxy crashed on first start and could not be started again.

## Symptom

Two crashes that look unrelated. First start:

```
java.nio.file.AccessDeniedException: .../Server Loco/config/.6044357414740329-126250038paper-global.yml.tmp
...
java.lang.IllegalStateException: World defaults configuration file 'config/paper-world-defaults.yml' doesn't exist
```

Second start:

```
java.lang.IllegalStateException: Overworld settings missing
```

One cause. Paper writes `paper-global.yml` and `paper-world-defaults.yml` into `config/` during startup, fails on both, then dies on the missing world-defaults file it was just prevented from writing — leaving a half-created `world/` (level.dat, no regions) that makes every later start fail differently.

## Cause

`ProxyForwardingService` writes `config/paper-global.yml` when securing a backend for Velocity forwarding, and chowned the file but not the directory it had just created:

```csharp
Directory.CreateDirectory(Path.GetDirectoryName(path)!);   // root-owned
await File.WriteAllTextAsync(path, ...);
TryRestrictPermissions(path);
await OwnershipHelper.ChangeOwnershipAsync(path, ...);     // file only
```

The service runs as root in the API container; servers run as the unprivileged owner uid. The result on disk is a distinctive giveaway — directory root, file inside it correct:

```
drwxr-xr-x  2 root       root       config
-rw-------  1 minecraft  minecraft  config/paper-global.yml
```

`Host__OwnerUid`/`Gid` were 1000 and `minecraft` is uid 1000, so this is not a uid misconfiguration — it is a directory that nothing ever chowned.

## Why it looked like a one-off

Only a **brand-new server secured before its first start** is affected. Any server whose `config/` already exists from an earlier run is fine: it is already owned correctly and `CreateDirectory` is a no-op. On the nine-server install where this was found, exactly one server had it:

```
Airships Creative          config -> minecraft:minecraft
Create Mod                 config -> minecraft:minecraft
Freemancraft               config -> minecraft:minecraft
Lobby                      config -> minecraft:minecraft
...
Server Loco                config -> root:root          ← created + secured, never started
```

That is the main path of the proxy feature this beta line ships: create a backend, attach it to a proxy, start it.

## Fix

Both call sites go through a helper that creates the directory **and** chowns it to the owner uid. The chown is unconditional rather than only-when-created, so an install already carrying a root-owned `config/` repairs itself the next time forwarding is written, with no manual intervention.

The reasoning lives in a `<remarks>` block — "chown the file we wrote" looks complete on its own, which is how this was missed.

## Verification

Applied the equivalent repair on the affected install (`chown -R` on `config/`, moved the 48K stub `world/` aside) and started the server through the API:

```
=== AccessDenied count: 0
=== crash count: 0
[01:43:29] [Server thread/INFO]: Done (20.818s)! For help, type "help"
```

- `dotnet test mineos-sveltkit.sln` — **181 passing**, 0 failed

## Not covered by tests

No automated test. The defect is a real `chown(2)` against a real uid: `OwnershipHelper` shells out to `/bin/chown` and no-ops off Linux, so a test in the SDK container would assert nothing (it runs as a single uid, and asserting "CreateDirectory was called" would not have caught this). Verified against a live install instead, as above.