### PR TITLE
chore(skills): add server-page-ui and filesystem-ownership

### DIFF
--- a/.claude/skills/filesystem-ownership/SKILL.md
+++ b/.claude/skills/filesystem-ownership/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: filesystem-ownership
+description: Use when writing code in mineos-sveltekit that creates files or directories under the servers/backups/archives roots — config writers, profile installs, mod/plugin installs, imports, backups, or anything calling Directory.CreateDirectory or File.Write* on a server's data.
+---
+
+# File ownership under the servers root
+
+## The invariant
+
+**The API writes as root. Servers run as somebody else.**
+
+The API container runs as root; a server's JVM runs as the unprivileged owner uid
+(`Host__OwnerUid` / `Host__OwnerGid`, `HostOptions.RunAsUid` / `RunAsGid`, launched through
+`su`). So anything the API creates on disk is root-owned until it is explicitly chowned —
+and the server then cannot write it.
+
+Every file **and every directory** the API creates under the servers, backups or archives
+roots must be chowned to `RunAsUid`/`RunAsGid` via `OwnershipHelper`.
+
+## The trap: chowning the file is not enough
+
+This looks complete and is not:
+
+```csharp
+Directory.CreateDirectory(Path.GetDirectoryName(path)!);   // root-owned, never chowned
+await File.WriteAllTextAsync(path, contents, cancellationToken);
+await OwnershipHelper.ChangeOwnershipAsync(path, ...);      // the FILE only
+```
+
+The file ends up correct and the directory does not. A server can then read the directory
+but cannot create anything in it — including the temp file that atomic writers rename into
+place. Do this instead:
+
+```csharp
+var directory = Path.GetDirectoryName(path)!;
+Directory.CreateDirectory(directory);
+await OwnershipHelper.ChangeOwnershipAsync(directory, _options.RunAsUid, _options.RunAsGid, _logger, cancellationToken);
+await File.WriteAllTextAsync(path, contents, cancellationToken);
+await OwnershipHelper.ChangeOwnershipAsync(path, _options.RunAsUid, _options.RunAsGid, _logger, cancellationToken);
+```
+
+Chown **unconditionally**, not only when you just created the directory. Installs already
+carrying a wrongly-owned directory then repair themselves the next time the code runs,
+instead of needing a manual `chown` from every affected user.
+
+## Why it hides
+
+Only a **fresh** server is affected. Any server that has started once already has its
+directories, correctly owned, and `Directory.CreateDirectory` is a no-op on an existing
+path — so the bug is invisible on every machine that has been running a while, including
+yours. It appears on a brand-new server, which is exactly a new user's first experience.
+
+The on-disk fingerprint is unmistakable:
+
+```
+drwxr-xr-x  2 root       root       config
+-rw-------  1 minecraft  minecraft  config/paper-global.yml
+```
+
+Directory root, file inside it correct. If you see that pattern, some writer chowned its
+file and not its directory.
+
+## How it surfaces
+
+Not as a permissions error. A Minecraft server that cannot write its config dies with
+whatever comes *next* — a missing config file it was prevented from writing, then on the
+following start a different error again from the half-created world left behind. Two
+unrelated-looking crashes, one cause. When triaging a server that will not start, check
+ownership before believing the stack trace.
+
+## Testing
+
+There is no useful unit test for this. `OwnershipHelper` shells out to `chown` and no-ops
+off Linux, and the test container runs as a single uid — asserting "CreateDirectory was
+called" would not have caught any of it. Verify against a real container: create a server,
+touch the code path, and check `stat -c %U:%G` on what it wrote.

--- a/.claude/skills/server-page-ui/SKILL.md
+++ b/.claude/skills/server-page-ui/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: server-page-ui
+description: Use when adding, moving or restyling anything on a server or proxy detail page in mineos-sveltekit — page header, tabs, status chips, title-row actions, or a new panel/tab under /servers/[name] or /proxies/[name].
+---
+
+# Server & proxy detail pages
+
+## The one thing to know
+
+**`/servers/[name]` and `/proxies/[name]` are the same UI.** Both route layouts are
+five-line delegates to a single shared component:
+
+```svelte
+<script lang="ts">
+	import ServerShell from '$lib/components/server/ServerShell.svelte';
+	let { data, children } = $props();
+</script>
+
+<ServerShell {data}>{@render children()}</ServerShell>
+```
+
+Chrome — header, title row, status badge, tabs, icon uploader, heartbeat stream — lives in
+`ServerShell.svelte`. The route layouts hold none of it.
+
+## Where your change goes
+
+| Adding | Goes in |
+|---|---|
+| Header content, a title-row action, a chip | `lib/components/server/ServerShell.svelte` |
+| A whole tab/panel | `lib/components/server/<Thing>Panel.svelte`, plus a route folder with a thin `+page.svelte` |
+| A tab entry | `lib/utils/serverTabs.ts` (`buildTabs`) |
+| Data every panel needs | `lib/components/server/panelData.ts` (`ServerPanelData`) |
+
+Panels type their props as `ServerPanelData`, **not** a route's generated `./$types`. They
+are shared by two routes, so no single route's generated types describe them.
+
+## Editing the shell is editing both pages
+
+A change to `ServerShell` shows up on proxies as well as game servers. That is usually
+what you want — a proxy is a server — but decide it deliberately rather than discovering
+it. If something must be servers-only, branch on `server?.serverType` inside the shell
+(`isProxy` is already derived there); do not fork the component.
+
+## The trap
+
+This shell was extracted after the detail pages already existed. Any branch cut before the
+extraction still contains the old ~700-line inline layout, and git will merge it back
+without complaining — the route layout is a file both sides legitimately edited. The result
+silently reverts the extraction, or drops whatever the branch added to the header.
+
+Two feature branches hit this already. Both needed the same handling:
+
+1. Take the **thin** route layout (the five-line delegate).
+2. Port the branch's header/title-row work into `ServerShell` by hand.
+3. Check whether the ported UI should appear on proxies too, and say so in the PR.
+
+If you are rebasing a long-lived branch that touches `servers/[name]/+layout.svelte`,
+expect this and budget for a manual port, not a merge.
+
+## Before you push
+
+`npm run check` from `apps/web` catches an unused CSS selector when markup moves out from
+under its styles — a reliable signal that a port left something behind.


### PR DESCRIPTION
Two contributor skills covering invariants that are invisible in review. Both are drawn from bugs that reached a live install rather than from theory.

The three existing skills (`releasing`, `local-lab`, `community-issue-triage`) are all **process** skills — how to do a task. These are the other kind: **what this codebase assumes**, which is what a diff cannot show you.

## `server-page-ui`

`/servers/[name]` and `/proxies/[name]` are both five-line delegates to a shared `ServerShell`. Header, tabs, status chips and title-row actions live in the component; the route layouts hold none of it, and a change to the shell lands on both pages.

The trap it documents: any branch cut before that extraction still contains the old ~700-line inline layout, and git merges it back **without a conflict marker on the interesting part** — the route layout is a file both sides legitimately edited. The result silently reverts the extraction or drops the branch's header work.

Two branches have hit this. One was resolved by hand (take the thin layout, port the header work into `ServerShell`); another open branch has the same conflict pending against a much larger diff. The skill spells out the port procedure and says to expect it when rebasing anything touching that layout.

## `filesystem-ownership`

The API container writes as root; servers run as `RunAsUid` via `su`. So every file **and directory** the API creates under the servers root needs chowning — and chowning only the file you wrote looks complete:

```csharp
Directory.CreateDirectory(Path.GetDirectoryName(path)!);   // root-owned, never chowned
await File.WriteAllTextAsync(path, ...);
await OwnershipHelper.ChangeOwnershipAsync(path, ...);      // the FILE only
```

Why it hides: only a **brand-new** server is affected. Existing servers already have their directories and `CreateDirectory` is a no-op, so it is invisible on any machine that has been running a while — and appears on a new user's first server.

It also documents the on-disk fingerprint (directory root, file inside it correct), the fact that it surfaces as an unrelated-looking crash rather than a permissions error, and why there is no useful unit test for it.

## On rot

Both state invariants and reasoning, not counts or file inventories. The releasing skill had to be corrected twice for quoting a test count that went stale on the next PR — a stale number teaches the reader to shrug at a mismatch, which is the one signal worth acting on. Neither of these quotes a number that changes.

Docs only — no product code.