### PR TITLE
feat(proxy): choose backends when setting up a proxy, instead of taking them all

### DIFF
--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -462,20 +462,26 @@ public class ServerService : IServerService
             await File.WriteAllTextAsync(configPath, IniParser.WriteWithSections(proxyConfig), cancellationToken);
 
             var proxyKind = NormalizeProxyKind(request.ProxyKind);
-            var backends = await DiscoverJavaBackendsAsync(request.Name, cancellationToken);
 
             if (proxyKind == "velocity")
             {
-                // Pre-populate velocity.toml with sibling Java backends so the proxy
-                // does something out of the box. The user can edit/reorder them via
-                // the Properties tab.
+                // A new proxy starts with no backends. Registering every sibling server
+                // automatically looked helpful and was not: attaching a backend is a
+                // security operation - attachServerToProxy installs the forwarding mod
+                // and secures identity - and writing names straight into the config does
+                // none of that, so the proxy came up fronting servers that cannot verify
+                // who a forwarded player claims to be. MineOS then reported those very
+                // backends as Unverifiable in its own exposure table.
+                //
+                // It also guessed which one players land on (the alphabetically first),
+                // and on a host running several Minecraft versions most of the routes it
+                // wrote could never work for a given client. Attach is a deliberate,
+                // one-at-a-time action from the proxies page; leave it to that.
                 var initialConfig = VelocityConfigDefaults(exists: true) with
                 {
                     Bind = $"0.0.0.0:{defaultPort}",
-                    Servers = backends,
-                    Try = backends.Count > 0
-                        ? new List<string> { backends.Keys.First() }
-                        : new List<string>()
+                    Servers = new Dictionary<string, string>(),
+                    Try = new List<string>()
                 };
                 var tomlPath = Path.Combine(serverPath, "velocity.toml");
                 await WriteVelocityTomlAsync(tomlPath, initialConfig, cancellationToken);
@@ -484,17 +490,14 @@ public class ServerService : IServerService
             {
                 // BungeeCord — bootstrap config.yml in its YAML schema.
                 // BungeeCord refuses to start with an empty servers: map
-                // ("IllegalArgumentException: No servers defined"), so when no
-                // sibling Java backends exist we seed the same placeholder
-                // BungeeCord itself ships in its default config.yml.
-                var bungeeBackends = backends.Count > 0
-                    ? backends.ToDictionary(
-                        kv => kv.Key,
-                        kv => new BungeeBackendDto(kv.Value, "&1Backend server", false))
-                    : new Dictionary<string, BungeeBackendDto>
-                    {
-                        ["lobby"] = new("127.0.0.1:25565", "&1Just another BungeeCord - Forced Host", false)
-                    };
+                // ("IllegalArgumentException: No servers defined"), so it gets the same
+                // placeholder BungeeCord itself ships in its default config.yml. This is
+                // a stub to satisfy the parser, not a real backend: attaching one is a
+                // deliberate action from the proxies page. See the Velocity branch above.
+                var bungeeBackends = new Dictionary<string, BungeeBackendDto>
+                {
+                    ["lobby"] = new("127.0.0.1:25565", "&1Just another BungeeCord - Forced Host", false)
+                };
                 var initialConfig = BungeeConfigDefaults(exists: true) with
                 {
                     Host = $"0.0.0.0:{defaultPort}",
@@ -1466,60 +1469,6 @@ public class ServerService : IServerService
             if (value is string s)
                 result[key] = s;
         }
-        return result;
-    }
-
-    private async Task<Dictionary<string, string>> DiscoverJavaBackendsAsync(
-        string excludeName, CancellationToken cancellationToken)
-    {
-        var result = new Dictionary<string, string>();
-        var serversPath = Path.Combine(_options.BaseDirectory, _options.ServersPathSegment);
-        if (!Directory.Exists(serversPath))
-        {
-            return result;
-        }
-
-        foreach (var dir in Directory.EnumerateDirectories(serversPath).OrderBy(d => Path.GetFileName(d), StringComparer.OrdinalIgnoreCase))
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            var serverName = Path.GetFileName(dir);
-            if (string.IsNullOrWhiteSpace(serverName) ||
-                serverName.Equals(excludeName, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            // Skip non-Java backends. Bedrock (UDP, different protocol) and proxies
-            // (a proxy fronting another proxy is not a sensible default).
-            var typeFile = Path.Combine(dir, ServerTypeFile);
-            if (File.Exists(typeFile))
-            {
-                var marker = (await File.ReadAllTextAsync(typeFile, cancellationToken)).Trim();
-                if (marker.Equals("bedrock", StringComparison.OrdinalIgnoreCase) ||
-                    marker.Equals("proxy", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-            }
-
-            var propertiesPath = Path.Combine(dir, "server.properties");
-            if (!File.Exists(propertiesPath))
-            {
-                continue;
-            }
-
-            var content = await File.ReadAllTextAsync(propertiesPath, cancellationToken);
-            var props = IniParser.ParseSimple(content);
-            if (!props.TryGetValue("server-port", out var portValue) ||
-                !int.TryParse(portValue, out var port) ||
-                port < 1 || port > 65535)
-            {
-                continue;
-            }
-
-            result[serverName] = $"127.0.0.1:{port}";
-        }
-
         return result;
     }
 
@@ -2599,19 +2548,16 @@ public class ServerService : IServerService
                     cancellationToken);
             }
 
-            var backends = await DiscoverJavaBackendsAsync(name, cancellationToken);
-
             if (kind == "velocity")
             {
                 var tomlPath = GetVelocityTomlPath(name);
                 if (!File.Exists(tomlPath))
                 {
+                    // No backends by default — see CreateServerAsync for why.
                     var initialConfig = VelocityConfigDefaults(exists: true) with
                     {
-                        Servers = backends,
-                        Try = backends.Count > 0
-                            ? new List<string> { backends.Keys.First() }
-                            : new List<string>()
+                        Servers = new Dictionary<string, string>(),
+                        Try = new List<string>()
                     };
                     await WriteVelocityTomlAsync(tomlPath, initialConfig, cancellationToken);
                 }
@@ -2622,15 +2568,12 @@ public class ServerService : IServerService
                 if (!File.Exists(yamlPath))
                 {
                     // See CreateServerAsync — BungeeCord requires at least one
-                    // entry in servers: or it fails to start.
-                    var bungeeBackends = backends.Count > 0
-                        ? backends.ToDictionary(
-                            kv => kv.Key,
-                            kv => new BungeeBackendDto(kv.Value, "&1Backend server", false))
-                        : new Dictionary<string, BungeeBackendDto>
-                        {
-                            ["lobby"] = new("127.0.0.1:25565", "&1Just another BungeeCord - Forced Host", false)
-                        };
+                    // entry in servers: or it fails to start, so this placeholder is a
+                    // parser stub rather than a real backend.
+                    var bungeeBackends = new Dictionary<string, BungeeBackendDto>
+                    {
+                        ["lobby"] = new("127.0.0.1:25565", "&1Just another BungeeCord - Forced Host", false)
+                    };
                     var initialConfig = BungeeConfigDefaults(exists: true) with
                     {
                         Servers = bungeeBackends,

--- a/apps/web/src/routes/(app)/servers/new/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/new/+page.svelte
@@ -36,6 +36,15 @@
 	const availableProxies = $derived(
 		(data.servers.data ?? []).filter((s) => s.serverType === 'proxy').map((s) => s.name)
 	);
+
+	// Game servers that can go behind a new proxy. Bedrock cannot sit behind a Java
+	// proxy, and a proxy fronting a proxy is not a sensible default.
+	const attachableBackends = $derived(
+		(data.servers.data ?? [])
+			.filter((s) => s.serverType !== 'proxy' && s.serverType !== 'bedrock')
+			.map((s) => s.name)
+	);
+	let selectedBackends = $state<string[]>([]);
 	// Proxies, Bedrock, and clones can't be backends, so only offer attaching
 	// for the categories that can.
 	const attachableCategories: ReadonlySet<string> = new Set(['vanilla', 'plugins', 'mods']);
@@ -104,6 +113,26 @@
 			onStep: (label) => (simpleStepText = label)
 		});
 		return result.ok ? null : result.error;
+	}
+
+	/**
+	 * Register the chosen game servers behind a freshly created proxy, reusing the
+	 * same attach path the Proxies page uses so each one gets verified forwarding
+	 * rather than just a name written into the config. Returns a warning per server
+	 * that could not be attached; the proxy itself is already created either way.
+	 */
+	async function attachChosenBackends(proxyName: string): Promise<string[]> {
+		const failures: string[] = [];
+		for (const backend of selectedBackends) {
+			simpleStepText = `Attaching ${backend}...`;
+			const result = await attachServerToProxy(fetch, {
+				serverName: backend,
+				proxyName,
+				onStep: (label) => (simpleStepText = label)
+			});
+			if (!result.ok) failures.push(`${backend}: ${result.error}`);
+		}
+		return failures;
 	}
 
 	function selectCategory(cat: ServerCategory) {
@@ -221,6 +250,22 @@
 		// earlier would let the install overwrite the secured configs.
 		pendingAttachName =
 			!isProxy && attachProxy && attachableCategories.has(category ?? '') ? name : '';
+
+		// A proxy has no installer step, so anything picked to sit behind it can be
+		// wired straight away. Failures are reported but do not fail the create — the
+		// proxy exists, and the servers can be attached from the Proxies page instead.
+		if (isProxy && selectedBackends.length > 0) {
+			attaching = true;
+			try {
+				const failures = await attachChosenBackends(name);
+				if (failures.length > 0) {
+					attachNotice = `Proxy created, but some servers could not be attached — ${failures.join('; ')}`;
+				}
+				await invalidateAll();
+			} finally {
+				attaching = false;
+			}
+		}
 
 		// For modloaders, trigger installation
 		if (implementation === 'forge' && selectedForgeVersion) {
@@ -509,6 +554,9 @@
 				}
 				{attachProxy}
 				onattachchange={(v) => (attachProxy = v)}
+				backends={proxyMode ? attachableBackends : []}
+				{selectedBackends}
+				onbackendschange={(v) => (selectedBackends = v)}
 				onchange={(v) => (serverName = v)}
 				oncreate={createServer}
 				onback={goBackFromName}

--- a/apps/web/src/routes/(app)/servers/new/steps/ServerName.svelte
+++ b/apps/web/src/routes/(app)/servers/new/steps/ServerName.svelte
@@ -6,12 +6,35 @@
 		proxies?: string[];
 		attachProxy?: string;
 		onattachchange?: (proxyName: string) => void;
+		/** Game servers that can be put behind this proxy (proxy flow only). */
+		backends?: string[];
+		selectedBackends?: string[];
+		onbackendschange?: (names: string[]) => void;
 		onchange: (name: string) => void;
 		oncreate: () => void;
 		onback: () => void;
 	}
 
-	let { value, error, isProxy = false, proxies = [], attachProxy = '', onattachchange, onchange, oncreate, onback }: Props = $props();
+	let {
+		value,
+		error,
+		isProxy = false,
+		proxies = [],
+		attachProxy = '',
+		onattachchange,
+		backends = [],
+		selectedBackends = [],
+		onbackendschange,
+		onchange,
+		oncreate,
+		onback
+	}: Props = $props();
+
+	function toggleBackend(name: string, checked: boolean) {
+		onbackendschange?.(
+			checked ? [...selectedBackends, name] : selectedBackends.filter((n) => n !== name)
+		);
+	}
 
 	const namePattern = /^[a-zA-Z0-9][a-zA-Z0-9 _\-\.]{0,63}$/;
 	const isValid = $derived(namePattern.test(value.trim()) && !value.includes('..'));
@@ -42,6 +65,29 @@
 		{/if}
 	</div>
 
+	{#if isProxy && backends.length > 0}
+		<div class="attach-group">
+			<span class="attach-label">Put servers behind it?</span>
+			<div class="backend-list">
+				{#each backends as backendName (backendName)}
+					<label class="backend-option">
+						<input
+							type="checkbox"
+							checked={selectedBackends.includes(backendName)}
+							onchange={(e) => toggleBackend(backendName, e.currentTarget.checked)}
+						/>
+						<span>{backendName}</span>
+					</label>
+				{/each}
+			</div>
+			<p class="attach-hint">
+				Each server you pick is registered with the proxy and set up for verified forwarding,
+				exactly as attaching it later would. Leave them all unchecked to attach servers yourself
+				from the Proxies page.
+			</p>
+		</div>
+	{/if}
+
 	{#if proxies.length > 0}
 		<div class="attach-group">
 			<label class="attach-label" for="attach-proxy">Behind a proxy?</label>
@@ -66,6 +112,32 @@
 </div>
 
 <style>
+	.backend-list {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		max-height: 220px;
+		overflow-y: auto;
+	}
+	.backend-option {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 8px 12px;
+		border-radius: 10px;
+		border: 1px solid rgba(62, 69, 100, 0.6);
+		background: rgba(19, 24, 40, 0.7);
+		cursor: pointer;
+		font-size: 14px;
+	}
+	.backend-option:hover {
+		border-color: rgba(106, 176, 76, 0.5);
+	}
+	.backend-option input {
+		accent-color: var(--mc-grass);
+		cursor: pointer;
+	}
+
 	.step {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
## What it did

Creating a proxy silently registered **every** Java server on the host and picked the landing server alphabetically (`ServerService.cs:465`, and again when converting a server to a proxy at `:2602`):

```csharp
var backends = await DiscoverJavaBackendsAsync(request.Name, cancellationToken);
Servers = backends,
Try = backends.Count > 0 ? new List<string> { backends.Keys.First() } : new List<string>()
```

On a nine-server host, a new proxy came up fronting all nine, landing players on whichever sorted first.

## Why it was there — and why the mechanism was still wrong

The concern was real: a Velocity proxy with no backends **kicks every player** with "no available servers", so a freshly created proxy looks broken. The author was fixing a bad first run.

But three things make auto-population the wrong tool:

1. **Attaching a backend is a security operation.** `attachServerToProxy` installs the forwarding mod and secures identity; writing a name into `velocity.toml` does neither. The proxy came up fronting servers that cannot verify who a forwarded player claims to be — and MineOS's own exposure table (#164) then reported those same backends as `Unverifiable`. The product manufactured the warnings it displays.
2. **It guessed the landing server**, by `OrderBy(name, OrdinalIgnoreCase).First()`.
3. **Mixed versions.** On a host running several Minecraft versions, most of the routes it wrote could never work for any given client.

"Empty state looks broken" is a UI problem. It deserved a UI answer, not a config write.

## What it does now

The proxy setup flow lists eligible game servers — not proxies, not Bedrock — as checkboxes, and attaches each ticked one through **the existing `attachServerToProxy` path**. That's the same code the Proxies page uses, so a backend attached at setup is secured identically to one attached later. There is no second, weaker attach path to keep in sync.

Nothing ticked means an empty proxy, which is now a deliberate choice rather than an accident.

An attach failure no longer fails the create: the proxy exists, the failure is reported, and those servers can be attached from the Proxies page.

**BungeeCord** still gets its single placeholder `lobby` entry — it refuses to start with an empty `servers:` map (`IllegalArgumentException: No servers defined`). The comment now says plainly that this is a parser stub, not a backend.

`DiscoverJavaBackendsAsync` had no other callers and is removed (−54 lines); the candidate list comes from the servers the web app already loads.

## Verification

- `dotnet test mineos-sveltkit.sln` — **210 passing**, 0 failed
- `npm run test:unit` — 84 passing
- `npm run check` — 0 errors, no new warnings
- `npm run build` — clean

No test locked in the old behaviour (I checked before removing it), and the new path is UI-driven over an already-tested helper — `proxyAttach.test.ts` covers `attachServerToProxy` itself. The wizard interaction is worth a manual pass: create a proxy with two servers ticked and confirm both land in `[servers]` **and** show as secured in the backend table.