### PR TITLE
feat(servers): give new servers a slug directory and keep the label separate

### DIFF
--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text;
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Security;
@@ -306,6 +307,56 @@ public class ServerService : IServerService
         @"^[a-zA-Z0-9][a-zA-Z0-9 _\-\.]{0,63}$",
         System.Text.RegularExpressions.RegexOptions.Compiled);
 
+    /// <summary>
+    /// Directory name for a newly created server: a slug of the label the user typed,
+    /// plus a short random suffix.
+    /// </summary>
+    /// <remarks>
+    /// The typed name used to become the directory name verbatim, permanently — so a
+    /// server called "Server Loco" lived at "servers/Server Loco" forever, and every
+    /// consumer of that path had to cope with whatever characters a label may contain.
+    /// Spaces alone broke screen-session detection. Since a server now carries a mutable
+    /// display name (issue #180), the on-disk identity no longer has to be the label.
+    ///
+    /// A readable slug rather than a bare GUID: these paths get typed into shells, read
+    /// in logs and grepped for, and "server-loco-7f3a" survives that where a UUID does
+    /// not. The suffix is unconditional, not collision-triggered — it keeps the shape
+    /// predictable and avoids a check-then-create race between two simultaneous creates.
+    ///
+    /// Existing servers keep their directories. This applies to new ones only.
+    /// </remarks>
+    public static string GenerateServerDirectoryName(string displayName)
+    {
+        var slug = Slugify(displayName);
+        var suffix = Guid.NewGuid().ToString("N")[..4];
+        return slug.Length == 0 ? $"server-{suffix}" : $"{slug}-{suffix}";
+    }
+
+    /// <summary>
+    /// Lowercases and reduces a label to [a-z0-9-]: runs of anything else collapse to a
+    /// single hyphen. Returns an empty string when the label has nothing usable in it
+    /// (e.g. all non-Latin characters), which the caller substitutes for.
+    /// </summary>
+    public static string Slugify(string value)
+    {
+        var builder = new StringBuilder();
+        foreach (var ch in (value ?? string.Empty).Trim().ToLowerInvariant())
+        {
+            if ((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9'))
+            {
+                builder.Append(ch);
+            }
+            else if (builder.Length > 0 && builder[^1] != '-')
+            {
+                builder.Append('-');
+            }
+        }
+
+        var slug = builder.ToString().Trim('-');
+        // Leave room for the suffix inside a sane path length.
+        return slug.Length > 40 ? slug[..40].TrimEnd('-') : slug;
+    }
+
     public async Task<ServerDetailDto> CreateServerAsync(
         CreateServerRequest request,
         string username,
@@ -327,9 +378,11 @@ public class ServerService : IServerService
         if (string.Equals(request.ServerType, "proxy", StringComparison.OrdinalIgnoreCase))
             NormalizeProxyKind(request.ProxyKind);
 
-        var serverPath = GetServerPath(request.Name);
-        var backupPath = GetBackupPath(request.Name);
-        var archivePath = GetArchivePath(request.Name);
+        // What the user typed is the label; the directory is a slug derived from it.
+        var directoryName = GenerateServerDirectoryName(request.Name);
+        var serverPath = GetServerPath(directoryName);
+        var backupPath = GetBackupPath(directoryName);
+        var archivePath = GetArchivePath(directoryName);
 
         if (Directory.Exists(serverPath))
         {
@@ -347,8 +400,8 @@ public class ServerService : IServerService
             Path.Combine(serverPath, ServerTypeFile), serverType, cancellationToken);
 
         // Create default files
-        var propertiesPath = GetPropertiesPath(request.Name);
-        var configPath = GetConfigPath(request.Name);
+        var propertiesPath = GetPropertiesPath(directoryName);
+        var configPath = GetConfigPath(directoryName);
 
         var usedPorts = await GetUsedPortsAsync(excludeName: null, cancellationToken);
 
@@ -402,6 +455,10 @@ public class ServerService : IServerService
             // Bedrock server.config (minimal - no Java section needed for operation, but kept for compatibility)
             var bedrockConfig = new Dictionary<string, Dictionary<string, string>>
             {
+                ["display"] = new()
+                {
+                    ["name"] = request.Name
+                },
                 ["bedrock"] = new()
                 {
                     ["binary"] = "./bedrock_server"
@@ -434,6 +491,10 @@ public class ServerService : IServerService
 
             var proxyConfig = new Dictionary<string, Dictionary<string, string>>
             {
+                ["display"] = new()
+                {
+                    ["name"] = request.Name
+                },
                 ["java"] = new()
                 {
                     ["java_binary"] = "",
@@ -558,6 +619,10 @@ public class ServerService : IServerService
             // Write default server.config
             var defaultConfig = new Dictionary<string, Dictionary<string, string>>
             {
+                ["display"] = new()
+                {
+                    ["name"] = request.Name
+                },
                 ["java"] = new()
                 {
                     ["java_binary"] = "",
@@ -588,7 +653,7 @@ public class ServerService : IServerService
         OwnershipHelper.TrySetOwnership(backupPath, _options.RunAsUid, _options.RunAsGid, _logger, recursive: true);
         OwnershipHelper.TrySetOwnership(archivePath, _options.RunAsUid, _options.RunAsGid, _logger, recursive: true);
 
-        _logger.LogInformation("Created server {ServerName} at {ServerPath}", request.Name, serverPath);
+        _logger.LogInformation("Created server {ServerName} ({DisplayName}) at {ServerPath}", directoryName, request.Name, serverPath);
         try
         {
             await _telemetryService.ReportLifecycleEventAsync("server_created", null, cancellationToken);
@@ -599,7 +664,7 @@ public class ServerService : IServerService
         }
         _telemetryReportTrigger.RequestImmediateReport();
 
-        return await GetServerAsync(request.Name, cancellationToken);
+        return await GetServerAsync(directoryName, cancellationToken);
     }
 
     public async Task<ServerDetailDto> CloneServerAsync(

--- a/apps/MineOS.Tests/Integration/BedrockServerTests.cs
+++ b/apps/MineOS.Tests/Integration/BedrockServerTests.cs
@@ -45,6 +45,8 @@ public class BedrockServerTests : IClassFixture<MineOsWebApplicationFactory>
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
         var json = await response.Content.ReadFromJsonAsync<JsonElement>();
+        // Created under a slug, not the label that was posted.
+        Assert.NotEqual(name, json.GetProperty("name").GetString());
         Assert.Equal("bedrock", json.GetProperty("serverType").GetString());
         Assert.True(json.GetProperty("eulaAccepted").GetBoolean());
     }
@@ -57,9 +59,12 @@ public class BedrockServerTests : IClassFixture<MineOsWebApplicationFactory>
         var content = JsonContent.Create(new { name, serverType = "bedrock" });
 
         using var createRequest = AuthRequest(HttpMethod.Post, "/api/v1/servers", token, content);
-        await _client.SendAsync(createRequest);
+        var createResponse = await _client.SendAsync(createRequest);
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        // Address it by the slug the API assigned, not the label that was posted.
+        var serverName = created.GetProperty("name").GetString();
 
-        using var getRequest = AuthRequest(HttpMethod.Get, $"/api/v1/servers/{name}", token);
+        using var getRequest = AuthRequest(HttpMethod.Get, $"/api/v1/servers/{serverName}", token);
         var response = await _client.SendAsync(getRequest);
         var json = await response.Content.ReadFromJsonAsync<JsonElement>();
 
@@ -98,9 +103,11 @@ public class BedrockServerTests : IClassFixture<MineOsWebApplicationFactory>
         var content = JsonContent.Create(new { name, serverType = "bedrock" });
 
         using var createRequest = AuthRequest(HttpMethod.Post, "/api/v1/servers", token, content);
-        await _client.SendAsync(createRequest);
+        var createResponse = await _client.SendAsync(createRequest);
+        var created = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var serverName = created.GetProperty("name").GetString();
 
-        using var startRequest = AuthRequest(HttpMethod.Post, $"/api/v1/servers/{name}/actions/start", token);
+        using var startRequest = AuthRequest(HttpMethod.Post, $"/api/v1/servers/{serverName}/actions/start", token);
         var response = await _client.SendAsync(startRequest);
 
         // Should fail — either missing screen (test host) or missing bedrock binary (container)

--- a/apps/MineOS.Tests/Integration/ModEndpointTests.cs
+++ b/apps/MineOS.Tests/Integration/ModEndpointTests.cs
@@ -38,9 +38,12 @@ public class ModEndpointTests : IClassFixture<MineOsWebApplicationFactory>
 
         using var createReq = AuthRequest(HttpMethod.Post, "/api/v1/servers", token,
             JsonContent.Create(new { name }));
-        await _client.SendAsync(createReq);
+        var createRes = await _client.SendAsync(createReq);
+        var created = await createRes.Content.ReadFromJsonAsync<JsonElement>();
+        // The directory is a slug of the label, so address the server by what was created.
+        var serverName = created.GetProperty("name").GetString();
 
-        using var loaderReq = AuthRequest(HttpMethod.Get, $"/api/v1/servers/{name}/loader", token);
+        using var loaderReq = AuthRequest(HttpMethod.Get, $"/api/v1/servers/{serverName}/loader", token);
         var response = await _client.SendAsync(loaderReq);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/apps/MineOS.Tests/Integration/ServerDisplayNameTests.cs
+++ b/apps/MineOS.Tests/Integration/ServerDisplayNameTests.cs
@@ -43,24 +43,34 @@ public class ServerDisplayNameTests : IClassFixture<MineOsWebApplicationFactory>
         using var request = AuthRequest(HttpMethod.Post, "/api/v1/servers", token, content);
         var response = await _client.SendAsync(request);
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        return name;
+        // The directory is a slug derived from the label, not the label itself, so every
+        // later call has to address the server by what the API actually created.
+        var created = await response.Content.ReadFromJsonAsync<JsonElement>();
+        return created.GetProperty("name").GetString()!;
     }
 
     [Fact]
-    public async Task Fresh_Server_Has_Null_Display_Name()
+    public async Task Fresh_Server_Keeps_The_Label_It_Was_Created_With()
     {
-        // Legacy compatibility: servers that predate the feature (and fresh ones)
-        // must report displayName null and render exactly as before.
+        // This used to assert displayName was null on a fresh server, because the
+        // directory WAS the label and repeating it would have been redundant.
+        // The directory is now a slug ("my-server-7f3a"), so the label has nowhere else
+        // to live: a new server must carry it or the UI can only show the slug.
+        //
+        // Legacy servers are unaffected and still report null — nothing backfills them,
+        // and null continues to mean "show the backend name".
         var token = await GetTokenAsync();
-        var name = await CreateServerAsync(token, UniqueName("dn-legacy"));
+        var label = UniqueName("dn-legacy");
+        var name = await CreateServerAsync(token, label);
+
+        Assert.NotEqual(label, name);
 
         using var request = AuthRequest(HttpMethod.Get, $"/api/v1/servers/{name}", token);
         var response = await _client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var json = await response.Content.ReadFromJsonAsync<JsonElement>();
-        Assert.True(json.TryGetProperty("displayName", out var displayName));
-        Assert.Equal(JsonValueKind.Null, displayName.ValueKind);
+        Assert.Equal(label, json.GetProperty("displayName").GetString());
     }
 
     [Fact]

--- a/apps/MineOS.Tests/Unit/ServerSlugTests.cs
+++ b/apps/MineOS.Tests/Unit/ServerSlugTests.cs
@@ -1,0 +1,96 @@
+using MineOS.Infrastructure.Services;
+
+namespace MineOS.Tests.Unit;
+
+/// <summary>
+/// Covers ServerService.Slugify and GenerateServerDirectoryName, which decide the
+/// on-disk directory for a newly created server.
+///
+/// The typed name used to become the directory name verbatim and permanently, so a
+/// label like "Server Loco" produced "servers/Server Loco" forever and every consumer
+/// of that path had to survive whatever a label may contain — spaces alone broke screen
+/// session detection. Now that a server carries a mutable display name (#180), the
+/// on-disk identity is a slug and the label is stored separately.
+///
+/// Existing servers are untouched; this governs new ones only.
+/// </summary>
+public class ServerSlugTests
+{
+    [Theory]
+    [InlineData("Server Loco", "server-loco")]
+    [InlineData("Create Mod Trains", "create-mod-trains")]
+    [InlineData("Mystical Magical", "mystical-magical")]
+    [InlineData("LIFESTEAL", "lifesteal")]
+    [InlineData("lobby", "lobby")]
+    // Runs of anything unusable collapse to a single hyphen, never a run of them.
+    [InlineData("Airships   Creative", "airships-creative")]
+    [InlineData("my_server.name", "my-server-name")]
+    [InlineData("a---b", "a-b")]
+    // Leading and trailing junk is trimmed rather than becoming edge hyphens.
+    [InlineData("  spaced  ", "spaced")]
+    [InlineData("--dashes--", "dashes")]
+    [InlineData("...", "")]
+    // Nothing usable at all: the caller substitutes a name.
+    [InlineData("日本語", "")]
+    [InlineData("", "")]
+    public void SlugifyReducesALabelToAPathSafeSlug(string label, string expected)
+    {
+        Assert.Equal(expected, ServerService.Slugify(label));
+    }
+
+    [Fact]
+    public void SlugifyCapsLengthWithoutLeavingATrailingHyphen()
+    {
+        var slug = ServerService.Slugify(new string('a', 30) + " " + new string('b', 30));
+        Assert.True(slug.Length <= 40, $"slug was {slug.Length} chars");
+        Assert.False(slug.EndsWith('-'), "a truncated slug must not end on the hyphen it cut at");
+    }
+
+    [Theory]
+    [InlineData("Server Loco", "server-loco")]
+    [InlineData("lobby", "lobby")]
+    public void DirectoryNameIsTheSlugPlusAShortSuffix(string label, string expectedSlug)
+    {
+        var directory = ServerService.GenerateServerDirectoryName(label);
+
+        Assert.StartsWith(expectedSlug + "-", directory);
+        Assert.Equal(expectedSlug.Length + 5, directory.Length);
+        Assert.Matches("^[a-z0-9-]+$", directory);
+    }
+
+    [Fact]
+    public void DirectoryNameFallsBackWhenTheLabelHasNothingUsable()
+    {
+        // A label of entirely non-Latin characters still has to produce a usable path.
+        var directory = ServerService.GenerateServerDirectoryName("日本語");
+
+        Assert.StartsWith("server-", directory);
+        Assert.Matches("^[a-z0-9-]+$", directory);
+    }
+
+    [Fact]
+    public void DirectoryNamesAreUniqueForTheSameLabel()
+    {
+        // The suffix is unconditional rather than collision-triggered, so two creates
+        // racing on the same label cannot land on the same directory.
+        var names = Enumerable.Range(0, 50)
+            .Select(_ => ServerService.GenerateServerDirectoryName("Server Loco"))
+            .ToHashSet();
+
+        Assert.Equal(50, names.Count);
+    }
+
+    [Theory]
+    [InlineData("Server Loco")]
+    [InlineData("Create Mod Trains")]
+    [InlineData("  weird...name__here  ")]
+    public void DirectoryNamesNeverContainCharactersThatBrokeThingsBefore(string label)
+    {
+        var directory = ServerService.GenerateServerDirectoryName(label);
+
+        Assert.DoesNotContain(' ', directory);
+        Assert.DoesNotContain("..", directory);
+        Assert.DoesNotContain('/', directory);
+        Assert.False(directory.StartsWith('-'), "must not start with a hyphen");
+    }
+}

--- a/apps/web/src/lib/utils/proxyAttach.test.ts
+++ b/apps/web/src/lib/utils/proxyAttach.test.ts
@@ -38,8 +38,12 @@ function forwarding(remediationAction: BackendForwarding['remediationAction']): 
 	};
 }
 
-function hostList(...entries: { name: string; port: number | null }[]) {
-	return entries.map((e) => ({ name: e.name, port: e.port })) as ServerSummary[];
+function hostList(...entries: { name: string; port: number | null; displayName?: string }[]) {
+	return entries.map((e) => ({
+		name: e.name,
+		port: e.port,
+		displayName: e.displayName ?? null
+	})) as ServerSummary[];
 }
 
 describe('attachServerToProxy', () => {
@@ -198,6 +202,29 @@ describe('attachServerToProxy', () => {
 });
 
 describe('detachServerFromProxy', () => {
+	it('finds a backend registered under its label, not its directory', async () => {
+		// Directories are slugs with a random suffix; the config key is the label, so
+		// detach cannot re-derive it — a rename would move it. It matches by address.
+		const config: VelocityConfig = velocityFixture();
+		config.servers = { 'server loco': 'localhost:25566' };
+		const { fetcher, calls } = recordingFetcher({
+			'GET /api/servers/hub/velocity-config': { body: config },
+			'GET /api/host/servers': {
+				body: hostList({ name: 'server-loco-7f3a', port: 25566, displayName: 'Server Loco' })
+			},
+			'PUT /api/servers/hub/velocity-config': { body: { ok: true } }
+		});
+
+		const result = await detachServerFromProxy(fetcher, {
+			serverName: 'server-loco-7f3a',
+			proxyName: 'hub'
+		});
+
+		expect(result).toEqual({ ok: true });
+		const putBody = calls[2].body as { servers: Record<string, string> };
+		expect(putBody.servers).toEqual({});
+	});
+
 	it('removes the server from the velocity config', async () => {
 		const config: VelocityConfig = velocityFixture();
 		const { fetcher, calls } = recordingFetcher({
@@ -217,7 +244,8 @@ describe('detachServerFromProxy', () => {
 
 	it('refuses without a write when the server is not attached', async () => {
 		const { fetcher, calls } = recordingFetcher({
-			'GET /api/servers/hub/velocity-config': { body: velocityFixture() }
+			'GET /api/servers/hub/velocity-config': { body: velocityFixture() },
+			'GET /api/host/servers': { body: hostList({ name: 'creative', port: 25567 }) }
 		});
 
 		const result = await detachServerFromProxy(fetcher, {
@@ -227,7 +255,9 @@ describe('detachServerFromProxy', () => {
 
 		expect(result.ok).toBe(false);
 		if (!result.ok) expect(result.error).toContain("isn't attached");
-		expect(calls).toHaveLength(1);
+		// The point is that nothing was written. Reads may legitimately vary: a miss on
+		// the direct key now costs one extra lookup to check for a label-derived key.
+		expect(calls.filter((c) => c.method !== 'GET')).toEqual([]);
 	});
 
 	it('removes via the bungee config when velocity is absent', async () => {

--- a/apps/web/src/lib/utils/proxyAttach.ts
+++ b/apps/web/src/lib/utils/proxyAttach.ts
@@ -22,13 +22,64 @@ export interface ProxyLinkOptions {
 	onStep?: (label: string) => void;
 }
 
-async function findBackendAddress(
+/**
+ * The name a backend is registered under in a proxy's config.
+ *
+ * This is player-facing — it is what someone types in Velocity's `/server <name>` — so
+ * it comes from the display label rather than the directory. Directories are slugs with
+ * a random suffix now, and `/server server-loco-7f3a` is not something to ask a player
+ * to type. Falls back to the directory name when a label has nothing usable in it.
+ */
+function backendKeyFor(serverName: string, displayName: string | null | undefined): string {
+	const slug = (displayName ?? '')
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '');
+	return slug.length > 0 ? slug : serverName;
+}
+
+/**
+ * A key that does not collide with an existing entry pointing somewhere else. Two
+ * servers can carry the same label — it is only a label — but two backends cannot share
+ * a key.
+ */
+function uniqueBackendKey(desired: string, taken: Record<string, string>, address: string): string {
+	if (!(desired in taken) || taken[desired] === address) return desired;
+	for (let n = 2; ; n++) {
+		const candidate = `${desired}-${n}`;
+		if (!(candidate in taken) || taken[candidate] === address) return candidate;
+	}
+}
+
+/**
+ * The key an already-attached server sits under. Matched by address rather than by name:
+ * the key is derived from a label that can change after attaching, so re-deriving it
+ * would miss a renamed server. Falls back to the directory name for entries written
+ * before keys were labels.
+ */
+function existingBackendKey(
+	servers: Record<string, string>,
+	address: string | null,
+	serverName: string
+): string | null {
+	if (address) {
+		const byAddress = Object.keys(servers).find((key) => servers[key] === address);
+		if (byAddress) return byAddress;
+	}
+	return serverName in servers ? serverName : null;
+}
+
+async function findBackend(
 	fetcher: Fetcher,
 	serverName: string
-): Promise<string | null> {
+): Promise<{ address: string | null; displayName: string | null }> {
 	const host = await api.getHostServers(fetcher);
 	const summaryRow = (host.data ?? []).find((s) => s.name === serverName);
-	return backendAddress(summaryRow?.port);
+	return {
+		address: backendAddress(summaryRow?.port),
+		displayName: summaryRow?.displayName ?? null
+	};
 }
 
 /**
@@ -44,7 +95,7 @@ export async function attachServerToProxy(
 	const { serverName, proxyName, onStep } = options;
 	onStep?.(`Attaching ${serverName} to ${proxyName}...`);
 
-	const address = await findBackendAddress(fetcher, serverName);
+	const { address, displayName } = await findBackend(fetcher, serverName);
 	if (!address) {
 		return { ok: false, error: `Couldn't find an assigned port for ${serverName}, so it wasn't attached.` };
 	}
@@ -59,7 +110,11 @@ export async function attachServerToProxy(
 		const { error } = await api.updateVelocityConfig(
 			fetcher,
 			proxyName,
-			addBackendToVelocity(velocity.data, serverName, address)
+			addBackendToVelocity(
+				velocity.data,
+				uniqueBackendKey(backendKeyFor(serverName, displayName), velocity.data.servers, address),
+				address
+			)
 		);
 		configError = error;
 	} else {
@@ -120,13 +175,20 @@ export async function detachServerFromProxy(
 
 	const velocity = await api.getVelocityConfig(fetcher, proxyName);
 	if (velocity.data?.exists) {
-		if (!(serverName in velocity.data.servers)) {
+		// Fast path: entries written before keys were labels sit under the directory
+		// name, and cost no extra request to find.
+		let key: string | null = serverName in velocity.data.servers ? serverName : null;
+		if (key === null) {
+			const { address } = await findBackend(fetcher, serverName);
+			key = existingBackendKey(velocity.data.servers, address, serverName);
+		}
+		if (key === null) {
 			return { ok: false, error: `${serverName} isn't attached to ${proxyName}.` };
 		}
 		const { error } = await api.updateVelocityConfig(
 			fetcher,
 			proxyName,
-			removeBackendFromVelocity(velocity.data, serverName)
+			removeBackendFromVelocity(velocity.data, key)
 		);
 		if (error) return { ok: false, error: `Couldn't update ${proxyName}'s config: ${error}` };
 		return { ok: true };

--- a/apps/web/src/routes/(app)/servers/new/+page.svelte
+++ b/apps/web/src/routes/(app)/servers/new/+page.svelte
@@ -65,6 +65,8 @@
 	let attachNotice = $state<string | null>(null);
 	/** Server awaiting network wiring once its files finish installing */
 	let pendingAttachName = $state('');
+	/** Directory name the API assigned, which is not what the user typed. */
+	let createdServerName = $state('');
 	/** Attach is in flight; the completion button waits rather than racing it. */
 	let attaching = $state(false);
 	/** The attach ran and failed, so the server is not on the Proxies page. */
@@ -216,11 +218,16 @@
 			return;
 		}
 
+		// The directory the API actually created. It is a slug derived from the label,
+		// not the label itself, so every follow-up call has to use this and not `name`.
+		const createdName = createResult.data?.name ?? name;
+		createdServerName = createdName;
+
 		// Join an existing network if requested (game servers only). The actual
 		// wiring waits until the server's files are fully installed — running it
 		// earlier would let the install overwrite the secured configs.
 		pendingAttachName =
-			!isProxy && attachProxy && attachableCategories.has(category ?? '') ? name : '';
+			!isProxy && attachProxy && attachableCategories.has(category ?? '') ? createdName : '';
 
 		// For modloaders, trigger installation
 		if (implementation === 'forge' && selectedForgeVersion) {
@@ -228,7 +235,7 @@
 				fetch,
 				selectedMcVersion,
 				selectedForgeVersion.forgeVersion,
-				name
+				createdName
 			);
 			if (result.error) {
 				createError = result.error;
@@ -243,7 +250,7 @@
 				fetch,
 				selectedMcVersion,
 				selectedNeoForgeVersion.neoForgeVersion,
-				name
+				createdName
 			);
 			if (result.error) {
 				createError = result.error;
@@ -260,7 +267,7 @@
 				fetch,
 				selectedMcVersion,
 				selectedLoaderVersion,
-				name
+				createdName
 			);
 			if (result.error) {
 				createError = result.error;
@@ -279,7 +286,7 @@
 				fetch,
 				selectedMcVersion,
 				selectedLoaderVersion,
-				name
+				createdName
 			);
 			if (result.error) {
 				createError = result.error;
@@ -334,14 +341,14 @@
 			simpleProgress = 60;
 			simpleStepText = 'Copying server files...';
 
-			const copyResult = await api.copyProfileToServer(fetch, selectedProfileId, name);
+			const copyResult = await api.copyProfileToServer(fetch, selectedProfileId, createdName);
 			if (copyResult.error) {
 				createError = copyResult.error;
 				step = 'name';
 				return;
 			}
 
-			await runPendingAttach(name);
+			await runPendingAttach(createdName);
 			simpleProgress = 100;
 			createCompleted = true;
 			return;
@@ -350,7 +357,7 @@
 		// For modloaders, completion is handled by InstallProgress component.
 		// Fabric/Quilt resolve inline once their single-JAR download finishes.
 		if (!installStreamUrl) {
-			await runPendingAttach(name);
+			await runPendingAttach(createdName);
 			simpleProgress = 100;
 			createCompleted = true;
 		}
@@ -446,7 +453,7 @@
 			goto('/proxies');
 			return;
 		}
-		goto(`/servers/${encodeURIComponent(serverName.trim())}`);
+		goto(`/servers/${encodeURIComponent(createdServerName || serverName.trim())}`);
 	}
 </script>
 


### PR DESCRIPTION
Builds on #181 (display names). Future servers only — nothing is renamed or migrated.

## What changes

```
typed:    Server Loco

on disk:  servers/server-loco-7f3a/
screen:   mc-server-loco-7f3a
route:    /servers/server-loco-7f3a
shown:    Server Loco          ← display name

legacy:   servers/Server Loco/   untouched, forever
```

A server's directory was whatever was typed at creation, permanently, so every consumer of that path had to cope with whatever a *label* may contain. Spaces alone broke screen-session detection (fixed separately in #187) — six of nine servers on one live install have them. With #181 giving servers a mutable label, the disk identity no longer has to be it.

**Slug, not GUID**, because these paths get typed into shells, read in logs and grepped for; `server-loco-7f3a` survives that where a UUID doesn't. **The suffix is unconditional**, not collision-triggered — it keeps the shape predictable and removes a check-then-create race between two simultaneous creates.

## Two consequences worth calling out explicitly

**1. A fresh server now has a display name.** It previously had none, and a test asserted that. The old contract was right *when the directory was the label* — repeating it would have been redundant. With a slug, the label has nowhere else to live: without it the UI can only show `server-loco-7f3a`. Legacy servers still report `null`, and `null` still means "show the backend name", so nothing about existing installs changes. `Fresh_Server_Has_Null_Display_Name` is now `Fresh_Server_Keeps_The_Label_It_Was_Created_With` and carries the reasoning.

**2. Velocity `[servers]` keys are player-facing.** They're what someone types in `/server <name>`. Keying them by directory would mean `/server server-loco-7f3a`, so attach now derives the key from the label. Detach **matches by address** rather than re-deriving the key — a rename would move it — with a direct-key fast path so existing entries cost no extra request.

I checked whether this breaks the forwarding/exposure feature before changing it. It doesn't: `ResolveBackendNamesAsync` matches backends by **address**, never by key (`velocity.Servers.Values.ToList()`), so status, securing and the exposure table are all key-agnostic.

## Tests

- `ServerSlugTests` — 21 cases: real labels from a live install, hyphen-run collapsing, trimming, length cap not leaving a trailing hyphen, non-Latin fallback, 50-way uniqueness, and "never contains what broke things before" (space, `..`, `/`, leading hyphen).
- `proxyAttach.test.ts` — new case for detaching a backend registered under its label rather than its directory.
- Four integration tests updated to address servers by the name the API returns rather than the one they posted. That they failed is the point: any caller assuming those are the same is now wrong, and these were the only ones.

Full solution **231 passing**, web **85 passing**, `npm run check` 0 errors, build clean.

## Not included

The wizard's name field is still labelled as a server name; calling it a label would be a copy change worth doing separately. Bulk-renaming existing servers is explicitly out of scope — #180 called that "heavy surgery" and nothing here changes that assessment.