### PR TITLE
fix(servers): slug the clone and import directories too

### DIFF
--- a/apps/MineOS.Infrastructure/Services/ImportService.cs
+++ b/apps/MineOS.Infrastructure/Services/ImportService.cs
@@ -81,7 +81,11 @@ public sealed class ImportService : IImportService
             throw new FileNotFoundException($"Import file '{filename}' not found");
         }
 
-        var serverPath = Path.Combine(GetServersPath(), serverName);
+        // The requested name is the label; the directory is a slug of it, matching how
+        // servers are created and cloned. Without this an import could still put a space
+        // on disk and break the guarantee everywhere else upholds.
+        var directoryName = ServerService.GenerateServerDirectoryName(serverName);
+        var serverPath = Path.Combine(GetServersPath(), directoryName);
         if (Directory.Exists(serverPath))
         {
             throw new InvalidOperationException($"Server '{serverName}' already exists");
@@ -144,6 +148,19 @@ public sealed class ImportService : IImportService
                 }
             }
 
+            // Give the import the label that was asked for. Its directory is a slug, so
+            // without this the UI could only ever show "my-import-7f3a". Any display name
+            // carried inside the archive is overwritten: the importer named this copy.
+            var importedConfigPath = Path.Combine(serverPath, "server.config");
+            if (File.Exists(importedConfigPath))
+            {
+                var sections = IniParser.ParseWithSections(
+                    await File.ReadAllTextAsync(importedConfigPath, cancellationToken));
+                sections["display"] = new Dictionary<string, string> { ["name"] = serverName };
+                await File.WriteAllTextAsync(
+                    importedConfigPath, IniParser.WriteWithSections(sections), cancellationToken);
+            }
+
             OwnershipHelper.TrySetOwnership(
                 serverPath,
                 _options.RunAsUid,
@@ -151,7 +168,9 @@ public sealed class ImportService : IImportService
                 _logger,
                 recursive: true);
 
-            _logger.LogInformation("Imported server {ServerName} from {Filename}", serverName, filename);
+            _logger.LogInformation(
+                "Imported server {ServerName} ({DisplayName}) from {Filename}",
+                directoryName, serverName, filename);
             return serverPath;
         }
         catch

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -686,7 +686,11 @@ public class ServerService : IServerService
             throw new DirectoryNotFoundException($"Server '{sourceName}' not found");
         }
 
-        var targetPath = GetServerPath(newName);
+        // Same rule as creating one: what the user typed is the label, the directory is
+        // a slug. Without this a clone could still put a space (or worse) on disk, which
+        // would quietly make the "new directories are slugs" guarantee untrue.
+        var targetDirectory = GenerateServerDirectoryName(newName);
+        var targetPath = GetServerPath(targetDirectory);
         if (Directory.Exists(targetPath))
         {
             throw new InvalidOperationException($"Server '{newName}' already exists");
@@ -705,38 +709,39 @@ public class ServerService : IServerService
             "crash-reports"
         });
 
-        var backupPath = GetBackupPath(newName);
-        var archivePath = GetArchivePath(newName);
+        var backupPath = GetBackupPath(targetDirectory);
+        var archivePath = GetArchivePath(targetDirectory);
         Directory.CreateDirectory(backupPath);
         Directory.CreateDirectory(archivePath);
 
-        var propertiesPath = GetPropertiesPath(newName);
+        var propertiesPath = GetPropertiesPath(targetDirectory);
         if (File.Exists(propertiesPath))
         {
-            var properties = await GetServerPropertiesAsync(newName, cancellationToken);
+            var properties = await GetServerPropertiesAsync(targetDirectory, cancellationToken);
             var usedPorts = await GetUsedPortsAsync(excludeName: null, cancellationToken);
             var defaultPort = GetNextAvailablePort(usedPorts, 25565);
             properties["server-port"] = defaultPort.ToString();
-            await UpdateServerPropertiesAsync(newName, properties, cancellationToken);
+            await UpdateServerPropertiesAsync(targetDirectory, properties, cancellationToken);
         }
 
         // A clone is its own identity — don't carry over the source's label (issue #180).
-        var cloneConfigPath = GetConfigPath(newName);
+        var cloneConfigPath = GetConfigPath(targetDirectory);
         if (File.Exists(cloneConfigPath))
         {
             var cloneContent = await File.ReadAllTextAsync(cloneConfigPath, cancellationToken);
             var cloneSections = IniParser.ParseWithSections(cloneContent);
-            if (cloneSections.Remove("display"))
-            {
-                await File.WriteAllTextAsync(cloneConfigPath, IniParser.WriteWithSections(cloneSections), cancellationToken);
-            }
+            // A clone must never claim to be its source (issue #180), but it does need a
+            // label of its own — its directory is a slug, so without one the UI could
+            // only show "my-clone-7f3a". The name typed for the copy is that label.
+            cloneSections["display"] = new Dictionary<string, string> { ["name"] = newName };
+            await File.WriteAllTextAsync(cloneConfigPath, IniParser.WriteWithSections(cloneSections), cancellationToken);
         }
 
         OwnershipHelper.TrySetOwnership(targetPath, _options.RunAsUid, _options.RunAsGid, _logger, recursive: true);
         OwnershipHelper.TrySetOwnership(backupPath, _options.RunAsUid, _options.RunAsGid, _logger, recursive: true);
         OwnershipHelper.TrySetOwnership(archivePath, _options.RunAsUid, _options.RunAsGid, _logger, recursive: true);
 
-        _logger.LogInformation("Cloned server {SourceServer} to {TargetServer}", sourceName, newName);
+        _logger.LogInformation("Cloned server {SourceServer} to {TargetServer} ({DisplayName})", sourceName, targetDirectory, newName);
         try
         {
             await _telemetryService.ReportLifecycleEventAsync("server_created", new { clone = true }, cancellationToken);
@@ -747,7 +752,7 @@ public class ServerService : IServerService
         }
         _telemetryReportTrigger.RequestImmediateReport();
 
-        return await GetServerAsync(newName, cancellationToken);
+        return await GetServerAsync(targetDirectory, cancellationToken);
     }
 
     public async Task DeleteServerAsync(string name, CancellationToken cancellationToken)

--- a/apps/MineOS.Tests/Integration/ServerDisplayNameTests.cs
+++ b/apps/MineOS.Tests/Integration/ServerDisplayNameTests.cs
@@ -239,10 +239,23 @@ public class ServerDisplayNameTests : IClassFixture<MineOsWebApplicationFactory>
         var cloneName = UniqueName("dn-clone");
         using var cloneRequest = AuthRequest(HttpMethod.Post, $"/api/v1/servers/{source}/clone", token,
             JsonContent.Create(new { newName = cloneName }));
-        Assert.Equal(HttpStatusCode.OK, (await _client.SendAsync(cloneRequest)).StatusCode);
+        var cloneResponse = await _client.SendAsync(cloneRequest);
+        Assert.Equal(HttpStatusCode.OK, cloneResponse.StatusCode);
 
-        using var getRequest = AuthRequest(HttpMethod.Get, $"/api/v1/servers/{cloneName}", token);
+        // The clone lives under a slug of the name it was given, like any new server.
+        var clone = await cloneResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var cloneDirectory = clone.GetProperty("name").GetString()!;
+        Assert.NotEqual(cloneName, cloneDirectory);
+
+        using var getRequest = AuthRequest(HttpMethod.Get, $"/api/v1/servers/{cloneDirectory}", token);
         var json = await (await _client.SendAsync(getRequest)).Content.ReadFromJsonAsync<JsonElement>();
-        Assert.Equal(JsonValueKind.Null, json.GetProperty("displayName").ValueKind);
+
+        // The point of this test: a copy must never claim to be its source. It used to
+        // assert null, which was right when a clone's directory was its name and needed
+        // no label. With a slug directory it needs one, so it takes the name it was
+        // created with — its own, never "Original Label".
+        var displayName = json.GetProperty("displayName").GetString();
+        Assert.Equal(cloneName, displayName);
+        Assert.NotEqual("Original Label", displayName);
     }
 }


### PR DESCRIPTION
Completes #192, which covered only the create path.

## The hole

#192 established that a new server's directory is a slug and the typed name is a label. Clone and import never got the memo:

```csharp
CloneServerAsync:                   GetServerPath(newName)
ImportService.CreateServerFrom...:  Path.Combine(GetServersPath(), serverName)
```

Cloning to `My New Clone` still produced `servers/My New Clone/`. So the guarantee was untrue within an hour of shipping, and the process-detection bug class that motivated the whole change (#187 — screen session names truncating at the first space) came back through a different door.

Found by grepping every path that creates a directory under the servers root, rather than by assuming create was the only one.

## The fix

Both derive the directory through `GenerateServerDirectoryName` and store the typed name as the display name, exactly as create does.

**Clone narrows an earlier rule rather than breaking it.** #180 specified that clones start unlabeled so a copy never claims to be its source. That was right *while a clone's directory was its name* — a label would have been redundant. With a slug directory it needs one, so it takes the name it was created with: its own, never the source's. `Clone_Does_Not_Inherit_Display_Name` now asserts the clone's label equals the name it was given **and** is not the source's, so it still fails on the behaviour it was written to catch.

**Import** overwrites any display name carried inside the archive — whoever imported the copy named it.

## Verification

`dotnet test mineos-sveltkit.sln` — **231 passing**, 0 failed.

The one failure this caused was `Clone_Does_Not_Inherit_Display_Name`, which is the test doing its job: it addressed the clone by the name it passed in, and that is precisely the assumption this change invalidates.