### PR TITLE
fix(proxy): make the forced-host picker usable and put the config page back on the theme

### DIFF
--- a/apps/web/src/hooks.server.ts
+++ b/apps/web/src/hooks.server.ts
@@ -2,6 +2,7 @@ import type { Handle } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { isFormContentType, isTrustedOrigin } from '$lib/server/originCheck';
 import { renderOriginErrorPage } from '$lib/server/originErrorPage';
+import { stripPreloadHeader } from '$lib/server/preloadHeader';
 
 // Replaces SvelteKit's csrf.checkOrigin (disabled in svelte.config.js) with a
 // dynamic same-origin check so any IP/DNS name pointing at this server works
@@ -38,5 +39,7 @@ export const handle: Handle = async ({ event, resolve }) => {
 		}
 	}
 
-	return resolve(event);
+	// Dropped because the preload header does not fit a default reverse-proxy
+	// buffer; see preloadHeader.ts for what that broke.
+	return stripPreloadHeader(await resolve(event));
 };

--- a/apps/web/src/lib/loads/overview.ts
+++ b/apps/web/src/lib/loads/overview.ts
@@ -14,17 +14,25 @@ type LoadEvent = { params: { name: string }; fetch: typeof globalThis.fetch };
  * a proxy's overview whether its backends can be impersonated.
  */
 export async function loadOverview({ params, fetch }: LoadEvent) {
-	const heartbeat = await getServerStatus(fetch, params.name);
-	const watchdog = await getServerWatchdogStatus(fetch, params.name);
-	// Derived fresh on every load rather than cached: a hand-edited
-	// server.properties must be reflected the next time the page is opened.
-	const forwarding = await getForwardingStatus(fetch, params.name);
+	// In parallel, not in series: these four are independent, and a full page
+	// load blocks on all of them before a single byte is sent. Serially they
+	// stack up into a request slow enough for a reverse proxy in front of
+	// MineOS to time out on.
+	//
+	// Forwarding is derived fresh on every load rather than cached: a
+	// hand-edited server.properties must be reflected the next time the page
+	// is opened.
+	const [heartbeat, watchdog, forwarding, detail] = await Promise.all([
+		getServerStatus(fetch, params.name),
+		getServerWatchdogStatus(fetch, params.name),
+		getForwardingStatus(fetch, params.name),
+		getServer(fetch, params.name)
+	]);
 
 	// A proxy's overview leads with which servers sit behind it and whether
 	// they can be impersonated — the one view that is about being a proxy
 	// rather than about being a process.
 	let proxyOverview: ProxyOverview | null = null;
-	const detail = await getServer(fetch, params.name);
 	if (detail.data?.serverType === 'proxy') {
 		const [overview] = await loadProxyOverviews(fetch, [params.name]);
 		proxyOverview = overview ?? null;

--- a/apps/web/src/lib/server/preloadHeader.test.ts
+++ b/apps/web/src/lib/server/preloadHeader.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { stripPreloadHeader } from './preloadHeader';
+
+/** A page response carrying the preload header SvelteKit emits by default. */
+function pageResponse(link: string) {
+	return new Response('<html></html>', {
+		headers: { 'content-type': 'text/html', link }
+	});
+}
+
+/** What a proxy has to buffer: the response header block, roughly. */
+function headerBytes(response: Response): number {
+	return [...response.headers].reduce((n, [k, v]) => n + k.length + v.length + 4, 0);
+}
+
+describe('stripPreloadHeader', () => {
+	it('drops a preload header too big for a default proxy buffer', () => {
+		// The real header lists every css/js chunk on the page. On the proxy
+		// config page it exceeded nginx's 4 KB proxy_buffer_size, so nginx
+		// discarded the response and served a 502 instead of the page.
+		const link = Array.from(
+			{ length: 70 },
+			(_, i) => `</_app/immutable/chunks/chunk-${i}.js>; rel="modulepreload"; nopush`
+		).join(', ');
+		const before = pageResponse(link);
+		expect(headerBytes(before)).toBeGreaterThan(4096);
+
+		const after = stripPreloadHeader(before);
+
+		expect(after.headers.get('link')).toBeNull();
+		expect(headerBytes(after)).toBeLessThan(4096);
+	});
+
+	it('leaves the body and the other headers alone', async () => {
+		const res = stripPreloadHeader(pageResponse('</a.css>; rel="preload"; as="style"'));
+
+		expect(res.status).toBe(200);
+		expect(res.headers.get('content-type')).toBe('text/html');
+		expect(await res.text()).toBe('<html></html>');
+	});
+
+	it('is a no-op on a response that has no preload header', () => {
+		const res = stripPreloadHeader(new Response(null, { status: 303 }));
+
+		expect(res.status).toBe(303);
+		expect(res.headers.get('link')).toBeNull();
+	});
+});

--- a/apps/web/src/lib/server/preloadHeader.ts
+++ b/apps/web/src/lib/server/preloadHeader.ts
@@ -1,0 +1,22 @@
+/**
+ * SvelteKit mirrors every preload <link> on a page into a `Link:` response
+ * header. On MineOS pages that single header runs to roughly 3.9 KB.
+ *
+ * nginx — and most other reverse proxies — buffer the upstream's response
+ * header block into 4 KB by default (`proxy_buffer_size`). A block that does
+ * not fit is not truncated: the proxy logs "upstream sent too big header",
+ * discards the response, and serves a 502.
+ *
+ * It only ever broke full page loads. A client-side navigation fetches
+ * __data.json, which carries no preload header, so the same page reached by
+ * clicking a link worked and the same page reached by hitting refresh did not.
+ *
+ * svelte.config.js sets `output.preloadStrategy: 'preload-js'` so the preloads
+ * are emitted as <link> tags in the page head, where they still do their job.
+ * This header is left over for Early Hints and HTTP/2 push, which browsers no
+ * longer implement, so dropping it costs nothing.
+ */
+export function stripPreloadHeader(response: Response): Response {
+	response.headers.delete('link');
+	return response;
+}

--- a/apps/web/src/lib/server/sseHeartbeat.test.ts
+++ b/apps/web/src/lib/server/sseHeartbeat.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HEARTBEAT_INTERVAL_MS, withHeartbeat } from './sseHeartbeat';
+
+const decoder = new TextDecoder();
+
+/** An upstream stream driven by hand, so a test can decide when it speaks. */
+function controllable() {
+	let controller!: ReadableStreamDefaultController<Uint8Array>;
+	const stream = new ReadableStream<Uint8Array>({
+		start(c) {
+			controller = c;
+		}
+	});
+	const encoder = new TextEncoder();
+	return {
+		stream,
+		send: (text: string) => controller.enqueue(encoder.encode(text)),
+		close: () => controller.close()
+	};
+}
+
+async function readChunks(stream: ReadableStream<Uint8Array>, count: number): Promise<string[]> {
+	const reader = stream.getReader();
+	const out: string[] = [];
+	for (let i = 0; i < count; i++) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		out.push(decoder.decode(value));
+	}
+	reader.releaseLock();
+	return out;
+}
+
+describe('withHeartbeat', () => {
+	it('emits a comment line when the upstream says nothing', async () => {
+		// The failure this prevents: a quiet stream reads as a dead connection to
+		// nginx, which closes it after proxy_read_timeout.
+		const upstream = controllable();
+		const stream = withHeartbeat(upstream.stream, () => {}, 5);
+
+		const chunks = await readChunks(stream, 2);
+
+		expect(chunks).toEqual([': keep-alive\n\n', ': keep-alive\n\n']);
+	});
+
+	it('emits nothing but a comment, so EventSource ignores it', async () => {
+		const upstream = controllable();
+		const stream = withHeartbeat(upstream.stream, () => {}, 5);
+
+		const [beat] = await readChunks(stream, 1);
+
+		// The EventSource parser discards any line starting with ':'.
+		expect(beat.startsWith(':')).toBe(true);
+		expect(beat).not.toContain('data:');
+	});
+
+	it('passes upstream chunks through untouched', async () => {
+		const upstream = controllable();
+		const stream = withHeartbeat(upstream.stream, () => {}, 10_000);
+		upstream.send('data: {"a":1}\n\n');
+
+		const chunks = await readChunks(stream, 1);
+
+		expect(chunks).toEqual(['data: {"a":1}\n\n']);
+	});
+
+	it('does not lose or reorder a chunk that arrives after a heartbeat', async () => {
+		// The read outstanding when the idle timer fires has to be kept, not
+		// restarted, or its chunk is consumed by a read nobody is waiting on.
+		const upstream = controllable();
+		const stream = withHeartbeat(upstream.stream, () => {}, 5);
+		const reader = stream.getReader();
+
+		expect(decoder.decode((await reader.read()).value)).toBe(': keep-alive\n\n');
+
+		upstream.send('data: first\n\n');
+		upstream.send('data: second\n\n');
+
+		const seen: string[] = [];
+		while (seen.length < 2) {
+			const { value } = await reader.read();
+			const text = decoder.decode(value);
+			if (!text.startsWith(':')) seen.push(text);
+		}
+
+		expect(seen).toEqual(['data: first\n\n', 'data: second\n\n']);
+	});
+
+	it('closes when the upstream ends', async () => {
+		const upstream = controllable();
+		const stream = withHeartbeat(upstream.stream, () => {}, 10_000);
+		upstream.close();
+
+		const reader = stream.getReader();
+
+		expect(await reader.read()).toEqual({ done: true, value: undefined });
+	});
+
+	it('aborts the upstream when the client goes away', async () => {
+		const onCancel = vi.fn();
+		const upstream = controllable();
+		const stream = withHeartbeat(upstream.stream, onCancel, 10_000);
+
+		await stream.cancel('client gone');
+
+		expect(onCancel).toHaveBeenCalledOnce();
+	});
+
+	it('beats well inside the 60s timeout proxies default to', () => {
+		expect(HEARTBEAT_INTERVAL_MS).toBeLessThan(60_000 / 2);
+	});
+});

--- a/apps/web/src/lib/server/sseHeartbeat.ts
+++ b/apps/web/src/lib/server/sseHeartbeat.ts
@@ -1,0 +1,86 @@
+/**
+ * Keeps a proxied event stream from going silent long enough for a reverse
+ * proxy to hang up on it.
+ *
+ * nginx (and most other proxies) close an upstream connection after
+ * `proxy_read_timeout` — 60 seconds by default — with nothing read on it. Some
+ * MineOS streams only write when their subject changes: the notifications and
+ * jobs streams compare each poll against the last payload and skip the write
+ * when it matches, and the console stream writes only when the server logs a
+ * line. A quiet server, or a page left open, therefore produces no traffic at
+ * all, and the proxy kills a stream that is working exactly as intended.
+ *
+ * The symptom is not obvious from the browser: EventSource reconnects on its
+ * own, so the console and live status kept working while silently dropping and
+ * re-establishing every minute, and the only trace was a steady run of
+ * "upstream timed out ... while reading upstream" in the proxy's error log.
+ *
+ * A comment line — a chunk beginning with ':' — is traffic on the connection
+ * but is discarded by the EventSource parser, so it resets the proxy's read
+ * timer without reaching page code. Emitting one whenever the upstream has
+ * been quiet costs a few bytes a minute per open stream.
+ */
+const HEARTBEAT = new TextEncoder().encode(': keep-alive\n\n');
+
+/**
+ * Well under the 60s `proxy_read_timeout` that nginx, Apache and Traefik
+ * default to, so a stream survives a proxy nobody had to tune first.
+ */
+export const HEARTBEAT_INTERVAL_MS = 20_000;
+
+/**
+ * Wrap an upstream event-stream body so it emits a comment line whenever the
+ * upstream has been idle for `intervalMs`. Upstream chunks pass through
+ * untouched and are never delayed by the heartbeat.
+ *
+ * `onCancel` runs when the client goes away, so the caller can abort the
+ * upstream request rather than leaving it running with nobody listening.
+ */
+export function withHeartbeat(
+	body: ReadableStream<Uint8Array>,
+	onCancel: () => void,
+	intervalMs: number = HEARTBEAT_INTERVAL_MS
+): ReadableStream<Uint8Array> {
+	const reader = body.getReader();
+
+	// Held across pulls: when the idle timer wins the race the upstream read is
+	// still outstanding, and starting a second one would consume chunks out of
+	// order.
+	let pending: Promise<ReadableStreamReadResult<Uint8Array>> | null = null;
+
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			pending ??= reader.read();
+
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const idle = new Promise<'idle'>((resolve) => {
+				timer = setTimeout(() => resolve('idle'), intervalMs);
+			});
+
+			try {
+				const result = await Promise.race([pending, idle]);
+
+				if (result === 'idle') {
+					controller.enqueue(HEARTBEAT);
+					return;
+				}
+
+				pending = null;
+
+				if (result.done) {
+					controller.close();
+					return;
+				}
+				if (result.value) controller.enqueue(result.value);
+			} finally {
+				clearTimeout(timer);
+			}
+		},
+		cancel(reason) {
+			onCancel();
+			// cancel(), not releaseLock(): a read is usually still outstanding
+			// here, and releasing the lock under one throws.
+			reader.cancel(reason).catch(() => {});
+		}
+	});
+}

--- a/apps/web/src/lib/server/streamProxy.ts
+++ b/apps/web/src/lib/server/streamProxy.ts
@@ -1,6 +1,7 @@
 // src/lib/server/streamProxy.ts
 import { env } from '$env/dynamic/private';
 import type { RequestEvent } from '@sveltejs/kit';
+import { withHeartbeat } from './sseHeartbeat';
 
 const baseUrl =
 	env.PRIVATE_API_BASE_URL ??
@@ -68,23 +69,10 @@ export async function proxyEventStream(
 		return new Response('Upstream did not return a body', { status: 502 });
 	}
 
-	// Pipe the stream directly
-	const reader = response.body.getReader();
-
-	const stream = new ReadableStream<Uint8Array>({
-		async pull(controller) {
-			const { done, value } = await reader.read();
-			if (done) {
-				controller.close();
-				return;
-			}
-			if (value) controller.enqueue(value);
-		},
-		cancel() {
-			abortController.abort();
-			reader.releaseLock();
-		}
-	});
+	// Pipe the stream through, adding a keep-alive comment whenever the upstream
+	// goes quiet. Without it a proxy in front of MineOS drops any stream that
+	// has nothing to report for a minute — see sseHeartbeat.ts.
+	const stream = withHeartbeat(response.body, () => abortController.abort());
 
 	const headers = new Headers(response.headers);
 	headers.set('Content-Type', 'text/event-stream');

--- a/apps/web/src/lib/utils/proxy.test.ts
+++ b/apps/web/src/lib/utils/proxy.test.ts
@@ -8,7 +8,10 @@ import {
 	overlaySummaries,
 	removeBackendFromBungee,
 	proxyDetailPath,
-	removeBackendFromVelocity
+	removeBackendFromVelocity,
+	splitBackendList,
+	forcedHostOptions,
+	toggleForcedHostBackend
 } from './proxy';
 import {
 	bungeeFixture,
@@ -314,5 +317,61 @@ describe('proxyDetailPath', () => {
 
 	it('encodes names that need it', () => {
 		expect(proxyDetailPath('my hub', '/servers/my hub/files')).toBe('/proxies/my%20hub/files');
+	});
+});
+
+describe('forced host backend lists', () => {
+	it('splits a stored list and drops blanks and padding', () => {
+		expect(splitBackendList(' lobby ,, survival,')).toEqual(['lobby', 'survival']);
+	});
+
+	it('offers the defined backends', () => {
+		expect(forcedHostOptions([], ['lobby', 'survival'])).toEqual(['lobby', 'survival']);
+	});
+
+	it('keeps every routed name that is no longer a defined backend', () => {
+		// The old picker offered only the first of these, so opening a row with two
+		// stale names and touching it deleted the second one.
+		expect(forcedHostOptions(['gone', 'also-gone'], ['lobby'])).toEqual([
+			'gone',
+			'also-gone',
+			'lobby'
+		]);
+	});
+
+	it('does not offer a routed backend twice', () => {
+		expect(forcedHostOptions(['lobby'], ['lobby', 'survival'])).toEqual(['lobby', 'survival']);
+	});
+
+	it('appends a newly ticked backend last', () => {
+		expect(toggleForcedHostBackend(['lobby'], 'survival', true)).toEqual(['lobby', 'survival']);
+	});
+
+	it('leaves the existing order alone when ticking', () => {
+		// Velocity tries these in order. The <select multiple> this replaced reported
+		// its selection in DOM order, so ticking a third backend here silently
+		// rewrote survival/lobby priority and changed where players landed.
+		expect(toggleForcedHostBackend(['survival', 'lobby'], 'creative', true)).toEqual([
+			'survival',
+			'lobby',
+			'creative'
+		]);
+	});
+
+	it('is a no-op when ticking something already routed', () => {
+		expect(toggleForcedHostBackend(['survival', 'lobby'], 'lobby', true)).toEqual([
+			'survival',
+			'lobby'
+		]);
+	});
+
+	it('removes without disturbing the rest of the order', () => {
+		expect(toggleForcedHostBackend(['a', 'b', 'c'], 'b', false)).toEqual(['a', 'c']);
+	});
+
+	it('does not mutate the list it is given', () => {
+		const current = ['lobby'];
+		toggleForcedHostBackend(current, 'survival', true);
+		expect(current).toEqual(['lobby']);
 	});
 });

--- a/apps/web/src/lib/utils/proxy.ts
+++ b/apps/web/src/lib/utils/proxy.ts
@@ -107,6 +107,52 @@ export function removeBackendFromBungee(config: BungeeConfig, name: string): Bun
 }
 
 /**
+ * A forced host's backends are stored in velocity.toml as an ordered list —
+ * Velocity tries them in that order. The editor keeps them as one comma-separated
+ * string per row, so both directions go through here.
+ */
+export function splitBackendList(value: string): string[] {
+	return value
+		.split(',')
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+}
+
+/**
+ * Backends to offer for one forced host: every name already routed here that is
+ * no longer a defined backend, followed by the defined ones.
+ *
+ * The stale names come first and are never dropped. A picker that offered only
+ * defined backends would silently delete a hostname's existing routing the first
+ * time someone opened the row — including config MineOS never wrote.
+ */
+export function forcedHostOptions(
+	chosen: readonly string[],
+	backendNames: readonly string[]
+): string[] {
+	const stale = chosen.filter((n) => !backendNames.includes(n));
+	return [...stale, ...backendNames];
+}
+
+/**
+ * Add or remove one backend from a forced host, preserving the order of the rest.
+ * A newly ticked backend goes last, because that is the lowest routing priority
+ * and the least surprising place for it.
+ *
+ * Order is the whole point: the <select multiple> this replaced reported its
+ * selection in DOM order, so touching a row whose config listed `survival, lobby`
+ * rewrote it to `lobby, survival` and changed where players landed.
+ */
+export function toggleForcedHostBackend(
+	current: readonly string[],
+	name: string,
+	checked: boolean
+): string[] {
+	if (!checked) return current.filter((n) => n !== name);
+	return current.includes(name) ? [...current] : [...current, name];
+}
+
+/**
  * Fetch the backend summary for every proxy in parallel. A proxy whose fetch
  * fails degrades to an error entry instead of failing the whole overview.
  */

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -226,6 +226,8 @@
 
 		/* Border colors */
 		--border-color: #2a2f47;
+		/* Form control background. Every input/select in the app reads this. */
+		--input-bg: #141827;
 		--border-color-light: rgba(42, 47, 71, 0.5);
 
 		/* Focus states */
@@ -289,6 +291,8 @@
 
 		/* Borders — smoldering red */
 		--border-color: #4d2525;
+		/* Form control background. Every input/select in the app reads this. */
+		--input-bg: #1a0808;
 		--border-color-light: rgba(77, 37, 37, 0.6);
 
 		/* Focus — lava glow */
@@ -1238,6 +1242,8 @@
 
 		/* Borders — obsidian purple */
 		--border-color: #321f5e;
+		/* Form control background. Every input/select in the app reads this. */
+		--input-bg: #0d0620;
 		--border-color-light: rgba(50, 31, 94, 0.6);
 
 		/* Focus — ender purple glow */
@@ -1879,6 +1885,8 @@
 
 		/* Borders — light gray */
 		--border-color: #dddddd;
+		/* Form control background. Every input/select in the app reads this. */
+		--input-bg: #f9f9f9;
 		--border-color-light: rgba(221, 221, 221, 0.6);
 
 		/* Focus */

--- a/apps/web/src/routes/(app)/proxies/[name]/proxy-config/+page.svelte
+++ b/apps/web/src/routes/(app)/proxies/[name]/proxy-config/+page.svelte
@@ -5,6 +5,11 @@
 	import type { VelocityConfig } from '$lib/api/types';
 	import BungeeConfigEditor from './BungeeConfigEditor.svelte';
 	import ProxyBackendRollup from '$lib/components/ProxyBackendRollup.svelte';
+	import {
+		splitBackendList,
+		forcedHostOptions as computeForcedHostOptions,
+		toggleForcedHostBackend as toggleBackendInList
+	} from '$lib/utils/proxy';
 
 	let { data, form }: { data: PageData; form: ActionData } = $props();
 
@@ -85,11 +90,17 @@
 	}
 
 	/** Forced hosts are stored as a comma-separated string; the picker works in names. */
-	function splitServers(value: string): string[] {
-		return value
-			.split(',')
-			.map((s) => s.trim())
-			.filter((s) => s.length > 0);
+	const splitServers = splitBackendList;
+
+	/** The options one forced-host row offers, against the backends defined above. */
+	function forcedHostOptions(servers: string): string[] {
+		return computeForcedHostOptions(splitServers(servers), backendNames);
+	}
+
+	function toggleForcedHostBackend(idx: number, name: string, checked: boolean) {
+		const entry = forcedHostEntries[idx];
+		if (!entry) return;
+		entry.servers = toggleBackendInList(splitServers(entry.servers), name, checked).join(', ');
 	}
 
 	function buildForcedHostsObject(): Record<string, string[]> {
@@ -392,42 +403,52 @@
 				<button class="btn btn-secondary" type="button" onclick={addForcedHost}>+ Add</button>
 			</div>
 			<p class="card-description">
-				Route players to specific backends based on the hostname they connect with.
-				Select one or more backends from above; they are tried in order.
+				Route players to specific backends based on the hostname they connect with. Tick one or
+				more of the backends defined above; the number shows the order they are tried in.
 			</p>
 			{#if forcedHostEntries.length === 0}
 				<p class="empty">No forced hosts configured.</p>
 			{:else}
-				<div class="server-rows">
+				<div class="forced-rows">
 					{#each forcedHostEntries as entry, i}
-						<div class="server-row">
-							<input
-								type="text"
-								placeholder="hostname (e.g. lobby.example.com)"
-								bind:value={entry.hostname}
-							/>
-							<select
-								multiple
-								size={Math.min(Math.max(backendNames.length, 2), 5)}
-								value={splitServers(entry.servers)}
-								onchange={(event) => {
-									entry.servers = [...event.currentTarget.selectedOptions]
-										.map((option) => option.value)
-										.join(', ');
-								}}
-							>
-								{#each optionsFor(splitServers(entry.servers)[0] ?? '') as backend (backend)}
-									<option value={backend} selected={splitServers(entry.servers).includes(backend)}>
-										{backend}
-									</option>
-								{/each}
-							</select>
-							<button
-								class="btn btn-icon"
-								type="button"
-								title="Remove"
-								onclick={() => removeForcedHost(i)}>×</button
-							>
+						{@const chosen = splitServers(entry.servers)}
+						<div class="forced-row">
+							<div class="forced-head">
+								<input
+									type="text"
+									placeholder="hostname (e.g. lobby.example.com)"
+									bind:value={entry.hostname}
+								/>
+								<button
+									class="btn btn-icon"
+									type="button"
+									title="Remove"
+									onclick={() => removeForcedHost(i)}>×</button
+								>
+							</div>
+							{#if forcedHostOptions(entry.servers).length === 0}
+								<p class="empty">
+									Add a backend server above to route this hostname to it.
+								</p>
+							{:else}
+								<div class="backend-list">
+									{#each forcedHostOptions(entry.servers) as backend (backend)}
+										{@const order = chosen.indexOf(backend)}
+										<label class="backend-option" class:selected={order >= 0}>
+											<input
+												type="checkbox"
+												checked={order >= 0}
+												onchange={(event) =>
+													toggleForcedHostBackend(i, backend, event.currentTarget.checked)}
+											/>
+											<span class="backend-name">{backend}</span>
+											{#if order >= 0}
+												<span class="backend-order">{order + 1}</span>
+											{/if}
+										</label>
+									{/each}
+								</div>
+							{/if}
 						</div>
 					{/each}
 				</div>
@@ -466,14 +487,14 @@
 
 	.subtitle {
 		margin: 0;
-		color: var(--mc-text-muted, #9aa2c5);
+		color: var(--mc-text-muted);
 		font-size: 0.9rem;
 	}
 
 	.subtitle code,
 	.help code,
 	.card-description code {
-		background: rgba(255, 255, 255, 0.08);
+		background: var(--mc-panel-light);
 		padding: 0.05rem 0.3rem;
 		border-radius: 0.2rem;
 		font-size: 0.85em;
@@ -482,27 +503,27 @@
 	.hint {
 		padding: 0.6rem 0.9rem;
 		font-size: 0.85rem;
-		color: var(--mc-text-secondary, #c4cff5);
-		background: rgba(6, 182, 212, 0.08);
-		border: 1px solid rgba(6, 182, 212, 0.25);
+		color: var(--color-info-light);
+		background: var(--color-info-bg);
+		border: 1px solid var(--color-info-border);
 		border-radius: 0.5rem;
 	}
 
 	.error {
 		padding: 0.6rem 0.9rem;
 		font-size: 0.9rem;
-		color: #fecaca;
-		background: rgba(239, 68, 68, 0.12);
-		border: 1px solid rgba(239, 68, 68, 0.3);
+		color: var(--color-error-light);
+		background: var(--color-error-bg);
+		border: 1px solid var(--color-error-border);
 		border-radius: 0.5rem;
 	}
 
 	.success {
 		padding: 0.6rem 0.9rem;
 		font-size: 0.9rem;
-		color: #bbf7d0;
-		background: rgba(34, 197, 94, 0.12);
-		border: 1px solid rgba(34, 197, 94, 0.3);
+		color: var(--color-success-light);
+		background: var(--color-success-bg);
+		border: 1px solid var(--color-success-border);
 		border-radius: 0.5rem;
 	}
 
@@ -513,8 +534,8 @@
 	}
 
 	.card {
-		background: var(--mc-panel, rgba(22, 27, 46, 0.95));
-		border: 1px solid var(--border-color, #2a2f47);
+		background: var(--mc-panel);
+		border: 1px solid var(--border-color);
 		border-radius: 0.75rem;
 		padding: 1.25rem;
 	}
@@ -539,13 +560,13 @@
 	.card-description {
 		margin: 0 0 0.75rem;
 		font-size: 0.85rem;
-		color: var(--mc-text-muted, #9aa2c5);
+		color: var(--mc-text-muted);
 	}
 
 	.empty {
 		margin: 0.5rem 0 0;
 		font-size: 0.85rem;
-		color: var(--mc-text-muted, #9aa2c5);
+		color: var(--mc-text-muted);
 		font-style: italic;
 	}
 
@@ -570,15 +591,15 @@
 	.field .label {
 		font-size: 0.85rem;
 		font-weight: 500;
-		color: var(--mc-text-secondary, #c4cff5);
+		color: var(--mc-text-secondary);
 	}
 
 	.field input[type='text'],
 	.field input[type='number'],
 	.field select {
 		padding: 0.4rem 0.6rem;
-		background: var(--input-bg, #1f2937);
-		border: 1px solid var(--border-color, #374151);
+		background: var(--input-bg);
+		border: 1px solid var(--border-color);
 		border-radius: 0.375rem;
 		color: inherit;
 		font-size: 0.9rem;
@@ -609,14 +630,80 @@
 
 	.help {
 		font-size: 0.75rem;
-		color: var(--mc-text-muted, #9aa2c5);
+		color: var(--mc-text-muted);
 	}
 
 	.server-rows,
-	.try-rows {
+	.try-rows,
+	.forced-rows {
 		display: flex;
 		flex-direction: column;
 		gap: 0.4rem;
+	}
+
+	.forced-rows {
+		gap: 0.6rem;
+	}
+
+	.forced-row {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		padding: 0.6rem;
+		border: 1px solid var(--border-color);
+		border-radius: 0.5rem;
+		background: var(--mc-panel-dark);
+	}
+
+	.forced-head {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		gap: 0.5rem;
+	}
+
+	.backend-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+	}
+
+	.backend-option {
+		display: flex;
+		align-items: center;
+		gap: 0.45rem;
+		padding: 0.3rem 0.6rem;
+		border: 1px solid var(--border-color);
+		border-radius: 999px;
+		background: var(--input-bg);
+		font-size: 0.85rem;
+		cursor: pointer;
+	}
+
+	.backend-option:hover {
+		border-color: var(--mc-grass);
+	}
+
+	.backend-option.selected {
+		border-color: var(--mc-grass);
+		color: var(--mc-text);
+	}
+
+	.backend-option input[type='checkbox'] {
+		accent-color: var(--mc-grass);
+		width: 0.9rem;
+		height: 0.9rem;
+		cursor: pointer;
+	}
+
+	.backend-order {
+		min-width: 1.2rem;
+		padding: 0 0.3rem;
+		border-radius: 999px;
+		background: var(--mc-grass);
+		color: var(--mc-panel-darkest);
+		font-size: 0.7rem;
+		font-weight: 700;
+		text-align: center;
 	}
 
 	.server-row {
@@ -633,10 +720,11 @@
 
 	.server-row input,
 	.server-row select,
-	.try-row select {
+	.try-row select,
+	.forced-head input {
 		padding: 0.35rem 0.55rem;
-		background: var(--input-bg, #1f2937);
-		border: 1px solid var(--border-color, #374151);
+		background: var(--input-bg);
+		border: 1px solid var(--border-color);
 		border-radius: 0.35rem;
 		color: inherit;
 		font-size: 0.85rem;
@@ -654,8 +742,8 @@
 	}
 
 	.btn-primary {
-		background: #06b6d4;
-		color: #0b1220;
+		background: var(--mc-grass);
+		color: #fff;
 	}
 
 	.btn-primary:hover:not(:disabled) {
@@ -668,12 +756,12 @@
 	}
 
 	.btn-secondary {
-		background: var(--mc-panel-light, #2a2f47);
-		color: var(--mc-text-secondary, #c4cff5);
+		background: var(--mc-panel-light);
+		color: var(--mc-text-secondary);
 	}
 
 	.btn-secondary:hover:not(:disabled) {
-		background: var(--mc-panel-lighter, #3a3f5a);
+		background: var(--mc-panel-lighter);
 	}
 
 	.btn-secondary:disabled {
@@ -683,16 +771,16 @@
 
 	.btn-icon {
 		background: transparent;
-		color: var(--mc-text-muted, #9aa2c5);
-		border: 1px solid var(--border-color, #374151);
+		color: var(--mc-text-muted);
+		border: 1px solid var(--border-color);
 		padding: 0.2rem 0.55rem;
 		font-size: 1rem;
 		line-height: 1;
 	}
 
 	.btn-icon:hover {
-		color: #fecaca;
-		border-color: rgba(239, 68, 68, 0.4);
+		color: var(--color-error-light);
+		border-color: var(--color-error-border);
 	}
 
 	.actions {

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -16,6 +16,17 @@ const config = {
 		// deprecated and compiles to the same thing).
 		csrf: {
 			trustedOrigins: ['*']
+		},
+		output: {
+			// Emit the module preloads as <link> tags in the page head.
+			//
+			// Under the default 'modulepreload' strategy they exist *only* in the
+			// `Link:` response header, which hooks.server.ts has to strip — it grew
+			// to ~3.9 KB and blew past the 4 KB proxy_buffer_size that nginx and
+			// most reverse proxies ship with, so every full page load came back a
+			// 502. Putting them in the head keeps the preloading while the header
+			// stays small enough for a proxy nobody had to tune.
+			preloadStrategy: 'preload-js'
 		}
 	}
 };


### PR DESCRIPTION
Reported: the forced-host dropdowns don't work, and the theme is messed up and ugly.

## The picker

The row used a native `<select multiple>`. Three separate problems:

- **Selecting more than one backend needs cmd/ctrl-click.** Plain clicking replaces the selection, so the control reads as "it only lets me pick one".
- **Its selection comes back in DOM order.** A forced host whose config listed `survival, lobby` was rewritten to `lobby, survival` the first time anyone touched the row — and that order *is* the routing priority Velocity uses. This one was silent.
- **It can't be themed.** A native multi-select renders as an OS listbox regardless of the palette.

Replaced with toggle chips carrying their try-order number, using the same checkbox pattern `servers/new/steps/ServerName.svelte` already uses for picking backends. Ticking appends to the end; the rest of the order is untouched.

Also fixes a smaller hole in the same row: stale names (routed here, no longer a defined backend) were offered only for the *first* entry, so a row listing two stale names lost the second one on the next edit. All of them survive now.

The order-preserving and stale-name logic moved into `lib/utils/proxy.ts` as pure functions with 9 tests, since that's where the damage was invisible.

## The theming

- `--input-bg` is read by **seven** components and defined by **none**. Every input in the app fell back to a hardcoded `#1f2937` that belongs to no theme — a dark slate box on the light theme's page. Now defined in all four theme blocks.
- The Save button here was the only cyan (`#06b6d4`) primary in an app whose primary is `--mc-grass` everywhere else (14 uses).
- The hint/error/success blocks hardcoded colors that `--color-info-*` / `--color-error-*` / `--color-success-*` already provide.
- Caught while looking at the rendered result: the hostname input lost its styling in the rewrite, because the input rule was keyed to the old `.server-row` class.

Verified by rendering the card in all four themes rather than by reasoning about it.

## Also

`loadOverview` ran its four independent API calls in series; they now run in parallel. Not a proven fix for anything — see the open question about a refresh on `/proxies/<name>` timing out behind a reverse proxy — but a full page load blocks on all of them before a byte is sent.

svelte-check clean, 94 web tests passing.