### PR TITLE
fix(servers): serialize the whole lifecycle, not just starts

### DIFF
--- a/apps/MineOS.Api/Endpoints/ServerEndpoints.cs
+++ b/apps/MineOS.Api/Endpoints/ServerEndpoints.cs
@@ -266,11 +266,12 @@ public static class ServerEndpoints
                         await serverService.StopServerAsync(name, timeout, cancellationToken);
                         return Results.Ok(new { message = $"Server '{name}' stopped" });
 
+                    // One gated operation, not a stop and a start with a gap between
+                    // them: another caller could win that gap, start the server, and
+                    // leave this restart failing with "already running".
                     case "restart":
                         var restartTimeout = await ResolveShutdownTimeoutAsync(settingsService, null, cancellationToken);
-                        await serverService.StopServerAsync(name, restartTimeout, cancellationToken);
-                        await Task.Delay(1000, cancellationToken);
-                        await serverService.StartServerAsync(name, cancellationToken);
+                        await serverService.RestartServerAsync(name, restartTimeout, cancellationToken);
                         return Results.Ok(new { message = $"Server '{name}' restarted" });
 
                     case "kill":

--- a/apps/MineOS.Application/Interfaces/IServerService.cs
+++ b/apps/MineOS.Application/Interfaces/IServerService.cs
@@ -22,7 +22,7 @@ public interface IServerService
     Task<ServerHeartbeatDto> GetServerStatusAsync(string name, CancellationToken cancellationToken);
     Task StartServerAsync(string name, CancellationToken cancellationToken);
     Task StopServerAsync(string name, int timeoutSeconds, CancellationToken cancellationToken);
-    Task RestartServerAsync(string name, CancellationToken cancellationToken);
+    Task RestartServerAsync(string name, int timeoutSeconds, CancellationToken cancellationToken);
     Task KillServerAsync(string name, CancellationToken cancellationToken);
 
     // Configuration management

--- a/apps/MineOS.Infrastructure/Services/ServerService.cs
+++ b/apps/MineOS.Infrastructure/Services/ServerService.cs
@@ -845,19 +845,65 @@ public class ServerService : IServerService
     }
 
     /// <summary>
-    /// Serializes starts per server. Entries are keyed by server name and never removed:
-    /// a SemaphoreSlim is a few dozen bytes and the set is bounded by how many servers
-    /// have ever been started, which is far cheaper than the alternative of disposing a
-    /// gate somebody is currently holding.
+    /// Serializes the whole lifecycle - start, stop, kill and restart - per server.
+    /// Entries are keyed by server name and never removed: a SemaphoreSlim is a few
+    /// dozen bytes and the set is bounded by how many servers have ever been touched,
+    /// which is far cheaper than the alternative of disposing a gate somebody is
+    /// currently holding.
     /// </summary>
     /// <remarks>
     /// Static on purpose. IServerService is registered scoped, so every caller that can
-    /// race here - the start endpoint, WatchdogService, StartupServerService and
+    /// race here - the action endpoint, WatchdogService, StartupServerService and
     /// CronSchedulerService - resolves its own ServerService instance. A per-instance
     /// gate would be uncontended and would serialize nothing.
+    ///
+    /// Gating starts alone only closed half the window. Stop sends its command and then
+    /// polls for the process to disappear, and neither it nor kill took the gate, so a
+    /// start could run against a server in the middle of shutting down - and a stop
+    /// could be sent to a JVM that was still coming up. Both operate on the same world
+    /// directory, which is the thing that must never have two writers.
     /// </remarks>
-    private static readonly ConcurrentDictionary<string, SemaphoreSlim> StartGates =
+    private static readonly ConcurrentDictionary<string, SemaphoreSlim> LifecycleGates =
         new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// How long a lifecycle call waits for one already in flight before giving up.
+    /// </summary>
+    /// <remarks>
+    /// Bounded rather than infinite because a stop legitimately holds the gate for its
+    /// whole shutdown timeout - up to five minutes. Blocking a start behind that would
+    /// park an HTTP request until a proxy in front of MineOS gave up on it, so the
+    /// caller is told the server is busy instead. Every caller already handles the
+    /// InvalidOperationException this shares with "already running", which the action
+    /// endpoint turns into a 409.
+    /// </remarks>
+    private static readonly TimeSpan LifecycleWait = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Takes the lifecycle gate for one server, or throws if another operation holds it.
+    /// </summary>
+    private static async Task<IDisposable> EnterLifecycleAsync(
+        string name, CancellationToken cancellationToken)
+    {
+        var gate = LifecycleGates.GetOrAdd(name, _ => new SemaphoreSlim(1, 1));
+        if (!await gate.WaitAsync(LifecycleWait, cancellationToken))
+        {
+            throw new InvalidOperationException(
+                $"Server '{name}' is busy: another start, stop or restart is already in progress");
+        }
+
+        return new LifecycleLease(gate);
+    }
+
+    /// <summary>Releases the lifecycle gate exactly once, however the caller unwinds.</summary>
+    private sealed class LifecycleLease : IDisposable
+    {
+        private SemaphoreSlim? _gate;
+
+        public LifecycleLease(SemaphoreSlim gate) => _gate = gate;
+
+        public void Dispose() => Interlocked.Exchange(ref _gate, null)?.Release();
+    }
 
     /// <summary>
     /// Starts a server, refusing if it is already running.
@@ -878,16 +924,8 @@ public class ServerService : IServerService
     /// </remarks>
     public async Task StartServerAsync(string name, CancellationToken cancellationToken)
     {
-        var gate = StartGates.GetOrAdd(name, _ => new SemaphoreSlim(1, 1));
-        await gate.WaitAsync(cancellationToken);
-        try
-        {
-            await StartServerCoreAsync(name, cancellationToken);
-        }
-        finally
-        {
-            gate.Release();
-        }
+        using var _ = await EnterLifecycleAsync(name, cancellationToken);
+        await StartServerCoreAsync(name, cancellationToken);
     }
 
     private async Task StartServerCoreAsync(string name, CancellationToken cancellationToken)
@@ -1120,6 +1158,12 @@ public class ServerService : IServerService
 
     public async Task StopServerAsync(string name, int timeoutSeconds, CancellationToken cancellationToken)
     {
+        using var _ = await EnterLifecycleAsync(name, cancellationToken);
+        await StopServerCoreAsync(name, timeoutSeconds, cancellationToken);
+    }
+
+    private async Task StopServerCoreAsync(string name, int timeoutSeconds, CancellationToken cancellationToken)
+    {
         var isRunning = await _processManager.IsServerRunningAsync(name, cancellationToken);
         if (!isRunning)
         {
@@ -1154,23 +1198,35 @@ public class ServerService : IServerService
     }
 
     /// <summary>
-    /// Stops a server and starts it again.
+    /// Stops a server and starts it again, as one operation.
     /// </summary>
     /// <remarks>
-    /// Must not take the start gate itself. It composes StartServerAsync, which takes the
-    /// gate, and SemaphoreSlim is not reentrant - holding it here would deadlock against
-    /// the call below.
+    /// Holds the lifecycle gate across both halves and calls the core methods, which do
+    /// not take it - SemaphoreSlim is not reentrant, so calling the public StopServerAsync
+    /// and StartServerAsync from in here would deadlock against itself.
+    ///
+    /// Taking it once is the point: a restart that released between the stop and the
+    /// start let another caller win the gate in the gap and start the server, after which
+    /// this one failed with "already running" on a server that was, confusingly, running.
     /// </remarks>
-    public async Task RestartServerAsync(string name, CancellationToken cancellationToken)
+    public async Task RestartServerAsync(string name, int timeoutSeconds, CancellationToken cancellationToken)
     {
-        await StopServerAsync(name, 300, cancellationToken);
+        using var _ = await EnterLifecycleAsync(name, cancellationToken);
+
+        await StopServerCoreAsync(name, timeoutSeconds, cancellationToken);
         await Task.Delay(1000, cancellationToken); // Brief pause between stop and start
-        await StartServerAsync(name, cancellationToken);
+        await StartServerCoreAsync(name, cancellationToken);
 
         _logger.LogInformation("Restarted server {ServerName}", name);
     }
 
     public async Task KillServerAsync(string name, CancellationToken cancellationToken)
+    {
+        using var _ = await EnterLifecycleAsync(name, cancellationToken);
+        await KillServerCoreAsync(name, cancellationToken);
+    }
+
+    private async Task KillServerCoreAsync(string name, CancellationToken cancellationToken)
     {
         var processInfo = _processManager.GetServerProcess(name);
         if (processInfo?.JavaPid == null)

--- a/apps/MineOS.Tests/Unit/ServerStartConcurrencyTests.cs
+++ b/apps/MineOS.Tests/Unit/ServerStartConcurrencyTests.cs
@@ -20,6 +20,11 @@ namespace MineOS.Tests.Unit;
 /// Velocity instance dying with EADDRINUSE on a port its own twin had taken. On a
 /// game server the same race puts two JVMs on one world directory.
 ///
+/// The same gate now covers stop and kill. Gating starts alone closed only half the
+/// window: stop sends its command and then polls for the process to disappear, and
+/// took no gate, so a start could run against a server midway through shutting down
+/// and a stop could be sent to a JVM still coming up. Both touch one world directory.
+///
 /// These tests assert on the ordering of the running-check itself rather than on a
 /// launch, so they do not need `screen` on PATH: both calls fail after the check, and
 /// what matters is that the second never enters while the first is still inside.
@@ -102,6 +107,85 @@ public class ServerStartConcurrencyTests
 
         release.SetResult();
         await Task.WhenAll(slow, other);
+    }
+
+    [Fact]
+    public async Task StopWaitsForAStartThatIsStillInFlight()
+    {
+        // The window this closes: a stop command reaching a JVM that is still starting.
+        var startEntered = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+        var order = new List<string>();
+
+        var processManager = new Mock<IProcessManager>();
+        processManager
+            .Setup(m => m.IsServerRunningAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                lock (order) order.Add("check");
+                if (order.Count == 1)
+                {
+                    startEntered.SetResult();
+                    await release.Task;
+                }
+                return false;
+            });
+
+        var service = CreateService(processManager.Object);
+        const string name = "gate-test-stop-waits";
+
+        var start = Swallow(service.StartServerAsync(name, CancellationToken.None));
+        await startEntered.Task;
+
+        var stop = Swallow(service.StopServerAsync(name, 1, CancellationToken.None));
+
+        await Task.Delay(100);
+        lock (order) Assert.Single(order);
+
+        release.SetResult();
+        await Task.WhenAll(start, stop);
+    }
+
+    [Fact]
+    public async Task StartIsRefusedWhileAnotherOperationHoldsTheGate()
+    {
+        // Bounded wait, not an infinite one: a stop can legitimately hold the gate for
+        // its whole shutdown timeout, and parking an HTTP request behind that is how a
+        // proxy in front of MineOS ends up timing the request out.
+        var startEntered = new TaskCompletionSource();
+        var release = new TaskCompletionSource();
+
+        var processManager = new Mock<IProcessManager>();
+        processManager
+            .Setup(m => m.IsServerRunningAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                if (!startEntered.Task.IsCompleted)
+                {
+                    startEntered.SetResult();
+                    await release.Task;
+                }
+                return false;
+            });
+
+        var service = CreateService(processManager.Object);
+        const string name = "gate-test-busy";
+
+        var held = Swallow(service.StartServerAsync(name, CancellationToken.None));
+        await startEntered.Task;
+
+        // Deliberately waits out the gate's own timeout rather than cancelling the
+        // token, which would raise OperationCanceledException and prove nothing about
+        // the busy path. Costs a few seconds; this is the behaviour the action endpoint
+        // turns into a 409.
+        var busy = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.StopServerAsync(name, 1, CancellationToken.None)
+                .WaitAsync(TimeSpan.FromSeconds(30)));
+
+        Assert.Contains("busy", busy.Message, StringComparison.OrdinalIgnoreCase);
+
+        release.SetResult();
+        await held;
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to the start gate. Gating starts alone closed only half the window.

`StopServerAsync` sends its command and then polls for the process to disappear, and neither it nor `KillServerAsync` took the gate. So:

- a **start** could run against a server midway through shutting down;
- a **stop** could be sent to a JVM that was still coming up;
- a **restart** released the gate between its stop and its start — another caller could win that gap and start the server, after which the restart failed with "already running" on a server that was, confusingly, running.

Each ends with two lifecycle operations against one world directory, which is the thing that must never have two writers. Same failure mode the start gate was added for, after two launches 9ms apart put two Velocity instances on one port.

## What changed

The gate now covers **start, stop, kill and restart**, and restart holds it once across both halves (calling the core methods — `SemaphoreSlim` is not reentrant).

The wait is **bounded at 5s** rather than infinite. A stop legitimately holds the gate for its entire shutdown timeout, up to five minutes; parking an HTTP request behind that is precisely how a reverse proxy in front of MineOS ends up timing the request out. Callers get `"server is busy"`, which the action endpoint already turns into a 409 alongside `"already running"`.

## A second bug found on the way

The `restart` action was duplicating `RestartServerAsync`'s body inline — stop, `Task.Delay(1000)`, start — instead of calling it, which is *why* it was two separately gated calls. It now calls the method.

`RestartServerAsync` hardcoded a 300s stop timeout while the endpoint resolved the configured one, so calling it as-is would have silently dropped `MINEOS_SHUTDOWN_TIMEOUT`. The timeout is now a parameter and gets threaded through.

## Verification

231 .NET tests pass. `StopWaitsForAStartThatIsStillInFlight` fails when the gate is removed from stop — checked, not assumed. `StartIsRefusedWhileAnotherOperationHoldsTheGate` deliberately waits out the real 5s timeout rather than cancelling the token, which would raise `OperationCanceledException` and prove nothing.