### PR TITLE
fix(web): stop the Admin Shell from killing the web container (#156)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -34,6 +34,8 @@ COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/build ./build
 COPY --from=build /app/server.js ./server.js
+# server.js imports this at runtime; without it the container fails to boot.
+COPY --from=build /app/wsCloseCode.js ./wsCloseCode.js
 
 EXPOSE 3000
 

--- a/apps/web/server.js
+++ b/apps/web/server.js
@@ -4,6 +4,7 @@
 import { createServer } from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
 import { handler } from './build/handler.js';
+import { closeSafely } from './wsCloseCode.js';
 
 const PORT = parseInt(process.env.PORT || '3000', 10);
 const HOST = process.env.HOST || '0.0.0.0';
@@ -90,26 +91,29 @@ server.on('upgrade', (req, socket, head) => {
 					}
 				});
 
-				// Handle close
+				// Handle close. The reported code is not necessarily one that may be
+				// sent - 1006 in particular is raised locally whenever a connection
+				// drops without a close frame - and passing it on throws inside this
+				// handler, which ends the process. See wsCloseCode.js and #156.
 				clientWs.on('close', (code, reason) => {
 					console.log(`[WS Proxy] Client closed: ${code}`);
-					upstream.close(code, reason);
+					closeSafely(upstream, code, reason, console.error);
 				});
 
 				upstream.on('close', (code, reason) => {
 					console.log(`[WS Proxy] Upstream closed: ${code}`);
-					clientWs.close(code, reason);
+					closeSafely(clientWs, code, reason, console.error);
 				});
 
 				// Handle errors
 				clientWs.on('error', (err) => {
 					console.error(`[WS Proxy] Client error:`, err.message);
-					upstream.close();
+					closeSafely(upstream, undefined, undefined, console.error);
 				});
 
 				upstream.on('error', (err) => {
 					console.error(`[WS Proxy] Upstream error:`, err.message);
-					clientWs.close();
+					closeSafely(clientWs, undefined, undefined, console.error);
 				});
 			});
 		});

--- a/apps/web/src/lib/server/wsCloseCode.test.ts
+++ b/apps/web/src/lib/server/wsCloseCode.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest';
+// Lives beside server.js rather than under src/: the production image ships only
+// build/, package.json and server.js, and server.js imports it at runtime.
+import { closeSafely, sanitizeCloseCode, sanitizeCloseReason } from '../../../wsCloseCode.js';
+
+/**
+ * Stands in for a ws socket, with ws's own validation. Getting this wrong is what
+ * killed the process: the throw lands in a 'close' handler where nothing catches it.
+ */
+function fakeSocket() {
+	const calls: Array<{ code: unknown; reason: unknown }> = [];
+	return {
+		calls,
+		close(code?: number, reason?: unknown) {
+			if (code !== undefined) {
+				const valid =
+					Number.isInteger(code) &&
+					((code >= 1000 && code <= 1014 && code !== 1004 && code !== 1005 && code !== 1006) ||
+						(code >= 3000 && code <= 4999));
+				if (!valid) throw new TypeError('First argument must be a valid error code number');
+			}
+			if (reason !== undefined && Buffer.byteLength(reason as string) > 123) {
+				throw new RangeError('The message must not be greater than 123 bytes');
+			}
+			calls.push({ code, reason });
+		}
+	};
+}
+
+describe('sanitizeCloseCode', () => {
+	it.each([1006, 1005, 1004, 1015, 999, 5000, 0, -1])('drops the reserved code %i', (code) => {
+		// 1006 is the one that shipped: ws raises it locally whenever a connection
+		// drops without a close frame, which is what closing the Admin Shell does.
+		expect(sanitizeCloseCode(code)).toBeUndefined();
+	});
+
+	it.each([1000, 1001, 1011, 1014, 3000, 4999])('passes the sendable code %i through', (code) => {
+		expect(sanitizeCloseCode(code)).toBe(code);
+	});
+
+	it('drops a non-integer code', () => {
+		expect(sanitizeCloseCode(1000.5)).toBeUndefined();
+		expect(sanitizeCloseCode(undefined)).toBeUndefined();
+		expect(sanitizeCloseCode('1000')).toBeUndefined();
+	});
+});
+
+describe('sanitizeCloseReason', () => {
+	it('passes a short reason through', () => {
+		expect(sanitizeCloseReason('bye')?.toString()).toBe('bye');
+	});
+
+	it('truncates past the 123 byte protocol cap', () => {
+		// Over the cap ws throws a RangeError — the same uncaught-in-a-close-handler
+		// death as a bad code, just a rarer trigger.
+		const reason = sanitizeCloseReason('x'.repeat(500));
+
+		expect(reason?.length).toBeLessThanOrEqual(123);
+	});
+
+	it('does not cut a multi-byte character in half', () => {
+		const reason = sanitizeCloseReason('☃'.repeat(100));
+
+		expect(reason?.length).toBeLessThanOrEqual(123);
+		// A truncation mid-sequence would decode to a replacement character.
+		expect(reason?.toString('utf8')).not.toContain('�');
+	});
+
+	it('treats an empty reason as none', () => {
+		expect(sanitizeCloseReason('')).toBeUndefined();
+		expect(sanitizeCloseReason(undefined)).toBeUndefined();
+	});
+});
+
+describe('closeSafely', () => {
+	it('does not throw on the code that took the process down', () => {
+		const socket = fakeSocket();
+
+		expect(() => closeSafely(socket, 1006, 'connection lost')).not.toThrow();
+		expect(socket.calls).toEqual([{ code: undefined, reason: Buffer.from('connection lost') }]);
+	});
+
+	it('forwards a legitimate close code untouched', () => {
+		const socket = fakeSocket();
+
+		closeSafely(socket, 1000, 'done');
+
+		expect(socket.calls[0].code).toBe(1000);
+	});
+
+	it('swallows a throw from a socket already tearing down', () => {
+		// Belt and braces: this runs in a close handler, the one place a throw is
+		// unrecoverable. Nothing about ending one shell session is worth the process.
+		const log = vi.fn();
+		const exploding = {
+			close() {
+				throw new Error('already closed');
+			}
+		};
+
+		expect(() => closeSafely(exploding, 1000, undefined, log)).not.toThrow();
+		expect(log).toHaveBeenCalledOnce();
+	});
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,9 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig, loadEnv, type Plugin } from 'vite';
 import { WebSocketServer, WebSocket } from 'ws';
+// Plain JS helper shared with server.js, which runs as-is in the image and cannot
+// import TypeScript.
+import { closeSafely } from './wsCloseCode.js';
 
 const allowedHostsEnv = process.env.VITE_ALLOWED_HOSTS ?? '';
 const allowedHosts = allowedHostsEnv
@@ -72,10 +75,12 @@ function wsProxyPlugin(): Plugin {
 								clientWs.send(data, { binary: isBinary });
 							}
 						});
-						clientWs.on('close', (code, reason) => upstream.close(code, reason));
-						upstream.on('close', (code, reason) => clientWs.close(code, reason));
-						clientWs.on('error', () => upstream.close());
-						upstream.on('error', () => clientWs.close());
+						// Same reserved-close-code trap as the production proxy in
+						// server.js; see wsCloseCode.js.
+						clientWs.on('close', (code, reason) => closeSafely(upstream, code, reason));
+						upstream.on('close', (code, reason) => closeSafely(clientWs, code, reason));
+						clientWs.on('error', () => closeSafely(upstream));
+						upstream.on('error', () => closeSafely(clientWs));
 					});
 				});
 

--- a/apps/web/wsCloseCode.js
+++ b/apps/web/wsCloseCode.js
@@ -1,0 +1,79 @@
+// Plain JS, and deliberately not under src/: server.js imports this at runtime in
+// the production image, which ships only build/, package.json and server.js.
+
+/**
+ * Close codes that may be *sent* on the wire.
+ *
+ * A WebSocket 'close' event reports codes that a close frame may never carry.
+ * 1006 (abnormal closure) is the common one: `ws` raises it locally whenever a
+ * connection drops without a close frame, which is exactly what happens when
+ * someone closes the Admin Shell.
+ *
+ * Handing that straight back to close() is fatal. ws validates the argument and
+ * throws `TypeError: First argument must be a valid error code number`, the throw
+ * happens inside a 'close' event handler where nothing catches it, and an uncaught
+ * exception on the event loop ends the process — so closing the Admin Shell took
+ * the whole mineos-web container down with it, dropping every other session and
+ * every open page. See #156.
+ *
+ * Mirrors ws's own isValidStatusCode so the check cannot disagree with the code
+ * that does the throwing.
+ *
+ * @param {unknown} code
+ * @returns {number | undefined}
+ */
+export function sanitizeCloseCode(code) {
+	if (typeof code !== 'number' || !Number.isInteger(code)) return undefined;
+
+	// 1004, 1005 and 1006 are reserved: they describe how a connection ended and
+	// must never be put in a frame.
+	if (code >= 1000 && code <= 1014 && code !== 1004 && code !== 1005 && code !== 1006) {
+		return code;
+	}
+	if (code >= 3000 && code <= 4999) return code;
+
+	return undefined;
+}
+
+/**
+ * A close reason is capped at 123 bytes by the protocol, and ws throws a
+ * RangeError past that — the same uncaught-in-a-close-handler death as above,
+ * just a rarer trigger. Truncation is on bytes, not characters, and steps back off
+ * a partial UTF-8 sequence rather than emitting a broken one.
+ *
+ * @param {unknown} reason
+ * @returns {Buffer | undefined}
+ */
+export function sanitizeCloseReason(reason) {
+	if (reason === undefined || reason === null) return undefined;
+
+	const buffer = Buffer.isBuffer(reason) ? reason : Buffer.from(String(reason), 'utf8');
+	if (buffer.length === 0) return undefined;
+	if (buffer.length <= 123) return buffer;
+
+	let end = 123;
+	while (end > 0 && (buffer[end] & 0xc0) === 0x80) end--;
+	return buffer.subarray(0, end);
+}
+
+/**
+ * Close one end of the proxy without ever taking the process down with it.
+ *
+ * The try/catch is not redundant with the sanitizers: this runs in a close/error
+ * handler, the one place where a throw is unrecoverable, and the socket may
+ * already be closing underneath us. Nothing about tearing down one shell session
+ * is worth the process.
+ *
+ * @param {{ close: (code?: number, reason?: Buffer) => void }} socket
+ * @param {unknown} [code]
+ * @param {unknown} [reason]
+ * @param {(message: string) => void} [log]
+ */
+export function closeSafely(socket, code, reason, log) {
+	try {
+		socket.close(sanitizeCloseCode(code), sanitizeCloseReason(reason));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		log?.(`[WS Proxy] Ignoring close failure: ${message}`);
+	}
+}


### PR DESCRIPTION
Closes #156.

Closing the Admin Shell could take the whole `mineos-web` process down — and with it every other session and every open page.

## The bug

A WebSocket `close` **event** reports codes that a close **frame** may never carry. 1006 is the common one: `ws` raises it locally whenever a connection drops without a close frame, which is exactly what closing the shell does. The proxy forwarded whatever it was handed straight to the other end:

```js
upstream.on('close', (code, reason) => clientWs.close(code, reason));
```

`ws` validates that argument and throws — `sender.js:187`, `"First argument must be a valid error code number"`, the exact message in the issue. The throw happens inside a `'close'` handler, where nothing catches it, and an uncaught exception on the event loop ends the process.

## The fix

Close codes and reasons are sanitized before being forwarded. The rule mirrors ws's own `isValidStatusCode` (`validation.js:37`) so the two cannot disagree about what throws — I read it rather than inferring it.

Reasons are truncated to the protocol's 123-byte cap without cutting a multi-byte character in half; over that, ws throws a `RangeError` from `sender.js:194` — same uncaught-in-a-close-handler death, rarer trigger. The close call itself is wrapped too: it runs in the one place where a throw is unrecoverable, and nothing about ending one shell session is worth the process.

The dev proxy in `vite.config.ts` had the identical two lines, so this is a shared plain-JS helper rather than the same fix written twice — the pattern that just bit us with the restart action.

## Packaging

The helper sits beside `server.js` because the production image ships only `build/`, `package.json` and `server.js`, and `server.js` imports it at runtime. The Dockerfile copies it — without that the container would not boot at all, so I verified rather than assumed:

- image builds
- `/app/wsCloseCode.js` is present and imports cleanly inside the container
- container boots (`Listening on http://0.0.0.0:3000`) and serves `/login` → 200

22 tests; 126 web tests total; svelte-check clean.