### PR TITLE
fix(jobs): stop concurrent writes inserting a job row twice

### DIFF
--- a/apps/MineOS.Infrastructure/Services/BackgroundJobService.cs
+++ b/apps/MineOS.Infrastructure/Services/BackgroundJobService.cs
@@ -370,6 +370,13 @@ public sealed class BackgroundJobService : IBackgroundJobService, IHostedService
     private class JobState
     {
         private readonly object _lock = new();
+
+        /// <summary>
+        /// Serializes the fire-and-forget writes of this job's row. Held on the state
+        /// rather than in a side dictionary so it lives and dies with the job entry.
+        /// </summary>
+        public SemaphoreSlim PersistGate { get; } = new(1, 1);
+
         public required string JobId { get; init; }
         public required string Type { get; init; }
         public required string ServerName { get; init; }
@@ -468,6 +475,25 @@ public sealed class BackgroundJobService : IBackgroundJobService, IHostedService
     }
 
     private async Task UpsertJobAsync(JobState state, CancellationToken cancellationToken)
+    {
+        // Persists are fire-and-forget (see PersistJobFireAndForget), so a status
+        // change, each progress tick and the completion write all run at once for one
+        // job. Finding the row and inserting it when absent is a check-then-act: two
+        // writers both see nothing and both insert, and the second is rejected with
+        // "UNIQUE constraint failed: Jobs.JobId". The per-job gate keeps concurrent
+        // writers for one row in line while leaving different jobs parallel.
+        await state.PersistGate.WaitAsync(cancellationToken);
+        try
+        {
+            await UpsertJobCoreAsync(state, cancellationToken);
+        }
+        finally
+        {
+            state.PersistGate.Release();
+        }
+    }
+
+    private async Task UpsertJobCoreAsync(JobState state, CancellationToken cancellationToken)
     {
         var snap = state.Snapshot();
 

--- a/apps/MineOS.Tests/Unit/JobPersistenceConcurrencyTests.cs
+++ b/apps/MineOS.Tests/Unit/JobPersistenceConcurrencyTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using MineOS.Application.Dtos;
+using MineOS.Application.Interfaces;
+using MineOS.Domain.Entities;
+using MineOS.Infrastructure.Services;
+using Moq;
+
+namespace MineOS.Tests.Unit;
+
+/// <summary>
+/// Job rows are written fire-and-forget: a status change, every progress tick and
+/// the completion write each spawn their own unawaited persist. They therefore run
+/// concurrently for a single job, and the write is a check-then-act — find the row,
+/// insert it if it is missing. Two writers that both find nothing both insert, and
+/// SQLite rejects the second with "UNIQUE constraint failed: Jobs.JobId".
+/// </summary>
+public class JobPersistenceConcurrencyTests
+{
+    /// <summary>
+    /// Stands in for the Jobs table, with SQLite's primary key behaviour. The delay in
+    /// FindByIdAsync widens the check-then-act window so the race is deterministic
+    /// rather than a coin flip — without serialization every run must fail.
+    /// </summary>
+    private sealed class FakeJobRepo : IRepository<JobRecord>
+    {
+        private readonly ConcurrentDictionary<string, JobRecord> _rows = new();
+        public int DuplicateInsertAttempts;
+        public int Inserts;
+
+        public Task<JobRecord?> FindByIdAsync(CancellationToken ct, params object[] keyValues)
+        {
+            var id = (string)keyValues[0];
+            return Task.Run(async () =>
+            {
+                await Task.Delay(15, ct);
+                return _rows.TryGetValue(id, out var row) ? row : null;
+            }, ct);
+        }
+
+        public Task AddAsync(JobRecord entity, CancellationToken ct)
+        {
+            if (!_rows.TryAdd(entity.JobId, entity))
+            {
+                Interlocked.Increment(ref DuplicateInsertAttempts);
+                throw new InvalidOperationException(
+                    "SQLite Error 19: 'UNIQUE constraint failed: Jobs.JobId'.");
+            }
+            Interlocked.Increment(ref Inserts);
+            return Task.CompletedTask;
+        }
+
+        public Task UpdateAsync(JobRecord entity, CancellationToken ct) => Task.CompletedTask;
+
+        public JobRecord? FindById(params object[] keyValues) => throw new NotSupportedException();
+        public Task<JobRecord?> FirstOrDefaultAsync(
+            System.Linq.Expressions.Expression<Func<JobRecord, bool>> predicate, CancellationToken ct)
+            => throw new NotSupportedException();
+        public Task<List<JobRecord>> ToListAsync(
+            System.Linq.Expressions.Expression<Func<JobRecord, bool>> predicate, CancellationToken ct)
+            => throw new NotSupportedException();
+        public Task AddRangeAsync(IEnumerable<JobRecord> entities, CancellationToken ct)
+            => throw new NotSupportedException();
+        public Task RemoveAsync(JobRecord entity, CancellationToken ct) => throw new NotSupportedException();
+        public Task RemoveWhereAsync(
+            System.Linq.Expressions.Expression<Func<JobRecord, bool>> predicate, CancellationToken ct)
+            => throw new NotSupportedException();
+    }
+
+    private static BackgroundJobService CreateService(FakeJobRepo repo)
+    {
+        var services = new ServiceCollection().BuildServiceProvider();
+        return new BackgroundJobService(
+            NullLogger<BackgroundJobService>.Instance,
+            services.GetRequiredService<IServiceScopeFactory>(),
+            repo,
+            Mock.Of<IRepository<SystemNotification>>(),
+            Mock.Of<IDiscordWebhookService>());
+    }
+
+    [Fact]
+    public async Task Rapid_Progress_Reports_Insert_The_Job_Row_Exactly_Once()
+    {
+        var repo = new FakeJobRepo();
+        var service = CreateService(repo);
+        await service.StartAsync(CancellationToken.None);
+
+        try
+        {
+            // Each Report spawns another unawaited persist while the first is still
+            // inside FindByIdAsync — the exact overlap the live system produces.
+            string? queuedId = null;
+            var jobId = service.QueueJob("backup", "alpha", async (_, progress, _) =>
+            {
+                for (var i = 1; i <= 10; i++)
+                {
+                    progress.Report(new JobProgressDto(
+                        queuedId!, "backup", "alpha", "running", i * 10, $"step {i}",
+                        DateTimeOffset.UtcNow));
+                }
+                await Task.Delay(200);
+            });
+            queuedId = jobId;
+
+            var deadline = DateTime.UtcNow.AddSeconds(15);
+            while (DateTime.UtcNow < deadline
+                   && service.GetJobStatus(jobId)?.Status is not ("completed" or "failed"))
+            {
+                await Task.Delay(50);
+            }
+
+            // Give the trailing fire-and-forget persists time to land.
+            await Task.Delay(500);
+
+            Assert.Equal(0, repo.DuplicateInsertAttempts);
+            Assert.Equal(1, repo.Inserts);
+        }
+        finally
+        {
+            // StopAsync awaits the queue loops, which surface the cancellation that
+            // stopped them. Not what this test is about.
+            try { await service.StopAsync(CancellationToken.None); }
+            catch (OperationCanceledException) { }
+        }
+    }
+}


### PR DESCRIPTION
Found while testing beta.10 in the local lab.

## The bug

```
SQLite Error 19: 'UNIQUE constraint failed: Jobs.JobId'
INSERT INTO "Jobs" ("JobId", ...)
```

Job rows are persisted fire-and-forget — `PersistJobFireAndForget` spawns an unawaited `Task.Run` for the status change, for every progress tick, and for the completion write. Those overlap for a single job, and `UpsertJobAsync` was a check-then-act: `FindByIdAsync`, then `AddAsync` if nothing came back. Two writers both see nothing, both insert, and the second is rejected — so a job's final state can be lost.

It surfaced on a cron-triggered start that failed: the constraint violation was logged *while saving the failure*, on top of the error it was recording.

Pre-existing, not from the beta.10 batch — `git diff v1.2.0-beta.9 066e522` leaves this path untouched. Filing it against the rc.

## The fix

A per-job `SemaphoreSlim` serializes writers for one row; different jobs still persist in parallel. It hangs off `JobState` rather than a side dictionary so its lifetime is exactly the job entry's — `_jobs` is never pruned, and a parallel map would be a second unbounded one.

## Testing

The test drives the real queue with rapid progress reports against a repository that enforces SQLite's primary key and widens the check-then-act window so the race is deterministic rather than a coin flip.

- Without the gate: **3 duplicate inserts** — fails.
- With the gate: **0 duplicates, 1 insert** — passes.
- Full solution: **277 + 6 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Grn7EwMxvEp1Jvx2frL2JS