### PR TITLE
fix(web): mobile-friendly pass on server/proxy management pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ tools/mineos-cli/.idea/*
 tools/mineos-cli/mineos.exe.old
 mineos/*
 .worktrees/
+
+# Session handoff notes (local scratch, never for the public repo)
+*-HANDOFF.md

--- a/apps/web/src/lib/components/TopBar.svelte
+++ b/apps/web/src/lib/components/TopBar.svelte
@@ -29,6 +29,7 @@
 	let recentProfileIds = $state<string[]>([]);
 	let actionBusy = $state<string | null>(null);
 	let mineosVersion = $state<string | null>(null);
+	let searchPlaceholder = $state('Search servers, profiles...');
 
 	const minQueryLength = 2;
 	const maxResults = 8;
@@ -65,6 +66,14 @@
 			const res = await api.getMeta(fetch);
 			if (res.data?.version) mineosVersion = res.data.version;
 		})();
+
+		const narrowQuery = window.matchMedia('(max-width: 480px)');
+		const updatePlaceholder = () => {
+			searchPlaceholder = narrowQuery.matches ? 'Search...' : 'Search servers, profiles...';
+		};
+		updatePlaceholder();
+		narrowQuery.addEventListener('change', updatePlaceholder);
+		return () => narrowQuery.removeEventListener('change', updatePlaceholder);
 	});
 
 	function loadRecent(key: string): string[] {
@@ -351,7 +360,7 @@
 		<input
 			bind:this={searchInput}
 			type="text"
-			placeholder="Search servers, profiles..."
+			placeholder={searchPlaceholder}
 			bind:value={query}
 			onfocus={handleSearchFocus}
 			onblur={handleSearchBlur}
@@ -557,6 +566,7 @@
 		font-size: 14px;
 		font-family: inherit;
 		transition: all 0.2s;
+		text-overflow: ellipsis;
 	}
 
 	.topbar-search input:focus {

--- a/apps/web/src/lib/components/server/FilesPanel.svelte
+++ b/apps/web/src/lib/components/server/FilesPanel.svelte
@@ -203,6 +203,7 @@
 			{#if files.length === 0}
 				<p class="empty">No files or directories</p>
 			{:else}
+				<div class="table-scroll">
 				<table>
 					<thead>
 						<tr>
@@ -251,6 +252,7 @@
 						{/each}
 					</tbody>
 				</table>
+				</div>
 			{/if}
 		</div>
 
@@ -383,8 +385,13 @@
 		color: var(--mc-text, #eef0f8);
 	}
 
+	.table-scroll {
+		overflow-x: auto;
+	}
+
 	table {
 		width: 100%;
+		min-width: 480px;
 		border-collapse: collapse;
 	}
 
@@ -585,5 +592,17 @@
 	.upload-btn {
 		display: inline-flex;
 		align-items: center;
+	}
+
+	@media (max-width: 900px) {
+		.content {
+			grid-template-columns: 1fr;
+		}
+
+		.toolbar {
+			flex-direction: column;
+			align-items: stretch;
+			gap: 0.75rem;
+		}
 	}
 </style>

--- a/apps/web/src/lib/components/server/LogsPanel.svelte
+++ b/apps/web/src/lib/components/server/LogsPanel.svelte
@@ -376,8 +376,10 @@
 
 	.console-header {
 		display: flex;
+		flex-wrap: wrap;
 		justify-content: space-between;
 		align-items: center;
+		gap: 0.5rem;
 	}
 
 	.tab-bar {
@@ -386,6 +388,8 @@
 		background: #121725;
 		padding: 0.35rem;
 		border-radius: 10px;
+		overflow-x: auto;
+		max-width: 100%;
 	}
 
 	.tab-button {
@@ -397,6 +401,8 @@
 		font-size: 0.9rem;
 		cursor: pointer;
 		transition: background 0.2s, color 0.2s;
+		white-space: nowrap;
+		flex-shrink: 0;
 	}
 
 	.tab-button.active {

--- a/apps/web/src/lib/components/server/ServerShell.svelte
+++ b/apps/web/src/lib/components/server/ServerShell.svelte
@@ -497,7 +497,8 @@
 
 		.server-side {
 			width: 100%;
-			justify-content: space-between;
+			flex-direction: column;
+			align-items: stretch;
 			margin-left: 0;
 		}
 

--- a/apps/web/src/routes/(app)/proxies/[name]/proxy-config/+page.svelte
+++ b/apps/web/src/routes/(app)/proxies/[name]/proxy-config/+page.svelte
@@ -597,6 +597,9 @@
 	.field input[type='text'],
 	.field input[type='number'],
 	.field select {
+		width: 100%;
+		min-width: 0;
+		box-sizing: border-box;
 		padding: 0.4rem 0.6rem;
 		background: var(--input-bg);
 		border: 1px solid var(--border-color);
@@ -620,7 +623,8 @@
 	}
 
 	.field.checkbox .label {
-		flex: 1 1 auto;
+		flex: 1 1 0%;
+		min-width: 0;
 	}
 
 	.field.checkbox .help {
@@ -722,6 +726,9 @@
 	.server-row select,
 	.try-row select,
 	.forced-head input {
+		width: 100%;
+		min-width: 0;
+		box-sizing: border-box;
 		padding: 0.35rem 0.55rem;
 		background: var(--input-bg);
 		border: 1px solid var(--border-color);

--- a/apps/web/src/routes/(app)/proxies/[name]/proxy-config/BungeeConfigEditor.svelte
+++ b/apps/web/src/routes/(app)/proxies/[name]/proxy-config/BungeeConfigEditor.svelte
@@ -584,6 +584,9 @@
 	.field input[type='text'],
 	.field input[type='number'],
 	.field select {
+		width: 100%;
+		min-width: 0;
+		box-sizing: border-box;
 		padding: 0.4rem 0.6rem;
 		background: var(--input-bg, #1f2937);
 		border: 1px solid var(--border-color, #374151);
@@ -607,7 +610,8 @@
 	}
 
 	.field.checkbox .label {
-		flex: 1 1 auto;
+		flex: 1 1 0%;
+		min-width: 0;
 	}
 
 	.field.checkbox .help {
@@ -646,6 +650,9 @@
 
 	.server-row input,
 	.try-row input {
+		width: 100%;
+		min-width: 0;
+		box-sizing: border-box;
 		padding: 0.35rem 0.55rem;
 		background: var(--input-bg, #1f2937);
 		border: 1px solid var(--border-color, #374151);
@@ -653,6 +660,20 @@
 		color: inherit;
 		font-size: 0.85rem;
 		font-family: inherit;
+	}
+
+	@media (max-width: 720px) {
+		.server-row {
+			grid-template-columns: 1fr;
+		}
+
+		.server-row.two-col {
+			grid-template-columns: 1fr;
+		}
+
+		.try-row {
+			grid-template-columns: 1fr;
+		}
 	}
 
 	.restricted-toggle {


### PR DESCRIPTION
## Summary
- Fixed 6 real mobile-viewport bugs found by testing every page/tab at 390px against live data on the mclab lab stack (all server types: vanilla, Paper, Velocity proxy, BungeeCord proxy)
- Server detail header: Accept EULA/Start buttons were clipped off-screen on mobile
- File browser: content area lost half its width to a phantom second column; file table now scrolls horizontally within its card
- Topbar search: placeholder text was cut off mid-word ("Search servers, prof...") on narrow screens — shows "Search..." under 480px instead
- Console/log toolbar: Clear Logs button was clipped off-screen; toolbar now wraps
- Velocity proxy config: long `<select>` option text pushed the whole form ~25px past the viewport edge; checkbox labels wrapped onto an orphaned line below the checkbox instead of beside it
- BungeeCord proxy config: identical bugs (duplicated CSS), same fixes, plus added a stacking breakpoint for a 5-column grid that had no mobile handling at all
- Removed stale untracked `*-HANDOFF.md` session notes and gitignored the pattern so they don't end up in the repo again

Everything else — dashboard, servers list, full server-creation wizard, server config/properties/backups/worlds/players/performance, Modrinth plugin search, profiles, admin pages, global search — was already solid at mobile width; no changes needed.

## Test plan
- [x] `npm run check` — 0 errors (93 pre-existing warnings, none from this change)
- [x] Manually verified every fix live at 390px viewport against the mclab lab stack, using real data (created test servers of each type: vanilla, Paper/plugins, Velocity proxy, BungeeCord proxy)
- [x] Confirmed no page-level horizontal overflow remains via `scrollWidth` checks on each fixed page
- [ ] David: spot-check on an actual phone

🤖 Generated with [Claude Code](https://claude.com/claude-code)